### PR TITLE
tiny simplification to cmake

### DIFF
--- a/.github/workflows/core-linux.yaml
+++ b/.github/workflows/core-linux.yaml
@@ -86,7 +86,6 @@ jobs:
           mkdir RandLAPACK-build
           cd RandLAPACK-build
           cmake -DCMAKE_BUILD_TYPE=Debug \
-              -Dblaspp_DIR=`pwd`/../blaspp-install/lib/blaspp \
               -DRandBLAS_DIR=`pwd`/../RandBLAS-install/lib/cmake \
               -Dlapackpp_DIR=`pwd`/../lapackpp-install/lib/lapackpp \
               -DCMAKE_INSTALL_PREFIX=`pwd`/../RandLAPACK-install \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ include(build_options)
 include(version)
 
 # find dependencies
-include(lapackpp)
 include(RandLAPACK_RandBLAS)
+include(lapackpp)
 
 # compile sources
 add_subdirectory(src)  # loads src/CMakeLists.txt

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -183,36 +183,43 @@ Here's how Riley configured his BLAS++ and LAPACK++ installations:
 
 0. Install and configure MKL. You can get MKL [here](https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit-download.html?operatingsystem=linux&distributions=webdownload&options=online).
    Once you've installed it you need to edit your `.bashrc` file.
-   The minimal change is to set the environment variable `MKLROOT`  to something like
-   `~/intel/oneapi/mkl/latest`. The preferred change is to execute an MKL-provided script
-   that changes several environment variables automatically. That script is usually called
-   `setvars.sh`. Riley's bashrc file was updated to contain the line
+   Riley's bashrc file was updated to contain the line
    ```
-   source ~/intel/oneapi/setvars.sh
+   export MAIN_MKL_LIBS="/home/riley/intel/oneapi/mkl/latest/lib/intel64"
+   export LD_LIBRARY_PATH="${MAIN_MKL_LIBS}:${LD_LIBRARY_PATH}"
+   export LIBRARY_PATH="${MAIN_MKL_LIBS}:${LIBRARY_PATH}"
    ```
+
 1. Download BLAS++ source, create a new folder called ``build``
    at the top level of the BLAS++ project directory, and ``cd`` into that
    folder.
+
 2. Run ``export CXX=gcc`` so that ``gcc`` is the default compiler for
    the current bash session.
+
 3. Decide a common prefix for where you'll put BLAS++ and LAPACK++
    installation files. We recommend ``/opt/mklpp``.
+
 4. Run the following CMake command 
-    ```shell
+    ```
     cmake -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/opt/mklpp \
-        -DBLAS_LIBRARIES='-lmkl_intel_ilp64 -lmkl_intel_thread -lmkl_core -liomp5 -lpthread' \
+        -Dblas=mkl \
+        -Dblas_int=int64 \
         -Dbuild_tests=OFF ..
     ```
-    Note how the MKL BLAS and threading libraries are specified explicitly with the ``-DBLAS_LIBRARIES`` flag.
-    Using that flag is in contrast with simply setting ``-Dblas=mkl``,
-    in which case the BLAS++ CMake recipe tries to configure MKL for you.
+   Save the output of that command somewhere. It contains information
+   on the precise BLAS libraries linked to BLAS++.
+
 5. Run ``cmake --build .``
-6. Run ``sudo make -j2 install``
+
+6. Run ``sudo make install``
+
 7. Download LAPACK++ source, create a new folder called ``build`` at the top level
    of the LAPACK++ project directory, and ``cd`` into that folder.
+
 8. Run the following CMake command
-   ```shell
+   ```
     cmake -DCMAKE_BUILD_TYPE=Release \
        -Dblaspp_DIR=/opt/mklpp/lib/blaspp \
        -DCMAKE_INSTALL_PREFIX=/opt/mklpp \
@@ -222,7 +229,7 @@ Here's how Riley configured his BLAS++ and LAPACK++ installations:
     ```
 
 You can then link to BLAS++ and LAPACK++ in other CMake projects
-just by including ``find_package(blaspp)`` and ``find_package(lapackpp)``
+just by including ``find_package(blaspp REQUIRED)`` and ``find_package(lapackpp REQUIRED)``
 in your ``CMakeLists.txt`` file, and then passing build flags
 ```
 -Dblaspp_DIR=/opt/mklpp/lib/blaspp -Dlapackpp_DIR=/opt/mklpp/lib/lapackpp

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -106,7 +106,6 @@ git clone https://github.com/BallisticLA/RandLAPACK.git
 mkdir RandLAPACK-build
 cd RandLAPACK-build
 cmake -DCMAKE_BUILD_TYPE=Release \
-    -Dblaspp_DIR=`pwd`/../blaspp-install/lib/blaspp/ \
     -Dlapackpp_DIR=`pwd`/../lapackpp-install/lib/lapackpp/ \
     -DRandBLAS_DIR=`pwd`/../RandBLAS-install/lib/cmake/ \
     -DCMAKE_BINARY_DIR=`pwd` \
@@ -118,15 +117,9 @@ ctest  # run unit tests (only if GTest was found by CMake)
 
 Here are the conceptual meanings in the recipe's build flags:
 
-* `-Dblaspp_DIR=W` means `W` is the directory containing the file `blasppConfig.cmake`.
-   Similarly, `-Dlapackpp_DIR=X` means `X` is the directory containing `lapackppConfig.cmake`.
-   
+* `-Dlapackpp_DIR=X` means `X` is the directory containing `lapackppConfig.cmake`.
     If you follow BLAS++ installation instructions from Section 5 instead of
-    Section 1, then you'd set ``-Dblaspp_DIR=/opt/mklpp/lib/blaspp`` and
-    `-Dlapackpp_DIR=/opt/mklpp/lib/lapackpp`. (You'd also need to use this value
-    of `-Dblaspp_DIR` when building LAPACK++ in the first place.)
-    Recall that we do not recommend that you follow Section 5 the first time you
-    build RandLAPACK.
+    Section 1, then you'd set `-Dlapackpp_DIR=/opt/mklpp/lib/lapackpp`.
 
 * `-DRandBLAS_DIR=Y` means `Y` is the directory containing `RandBLASConfig.cmake`.
 
@@ -135,6 +128,8 @@ Here are the conceptual meanings in the recipe's build flags:
    for using RandLAPACK in other projects. You should make note of the directory
    that ends up containing the file ``RandLAPACKConfig.cmake``.
 
+Note that you do not need to specify locations for BLAS++ or Random123.
+The locations of those libraries are inferred automatically from RandBLAS.
 
 ## 4. Using RandLAPACK in other projects
 


### PR DESCRIPTION
This changes to the order of LAPACK++ and RandBLAS include statements at the project's top-level CMakeLists.txt file. The effect is for the location of BLAS++ to automatically be inferred from RandBLAS.