### PR TITLE
Adding updates to CQRRPT

### DIFF
--- a/RandLAPACK/comps/rl_qb.hh
+++ b/RandLAPACK/comps/rl_qb.hh
@@ -244,10 +244,10 @@ int QB<T>::call(
 
         // Updating B norm estimation
         T norm_B_i = lapack::lange(Norm::Fro, block_sz, n, B_i_dat, block_sz);
-        norm_B = hypot(norm_B, norm_B_i);
+        norm_B = std::hypot(norm_B, norm_B_i);
         // Updating approximation error
         prev_err = approx_err;
-        approx_err = sqrt(abs(norm_A - norm_B)) * (sqrt(norm_A + norm_B) / norm_A);
+        approx_err = std::sqrt(std::abs(norm_A - norm_B)) * (std::sqrt(norm_A + norm_B) / norm_A);
 
         // Early termination - handling round-off error accumulation
         if ((curr_sz > 0) && (approx_err > prev_err)) {

--- a/RandLAPACK/comps/rl_rs.hh
+++ b/RandLAPACK/comps/rl_rs.hh
@@ -141,8 +141,6 @@ int RS<T>::call(
     T* Omega_1_dat = util::upsize(m * k, this->Omega_1);
     auto state = this->st;
 
-    RandBLAS::base::RNGState<r123::Philox4x32> st;
-
     if (p % 2 == 0) {
         // Fill n by k Omega
         RandBLAS::dense::DenseDist  D{.n_rows = n, .n_cols = k};

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -55,12 +55,12 @@ class CQRRPT : public CQRRPTalg<T> {
         /// values of the R-factor via an appropriate LAPACK function.
         CQRRPT(
             bool verb,
-            bool t,
+            bool time_subroutines,
             RandBLAS::base::RNGState<r123::Philox4x32> st,
             T ep
         ) {
             verbosity = verb;
-            timing = t;
+            timing = time_subroutines;
             state = st;
             eps = ep;
             no_hqrrp = 1;
@@ -153,7 +153,6 @@ class CQRRPT : public CQRRPTalg<T> {
         // Preconditioning-related
         T cond_num_A_pre;
         T cond_num_A_norm_pre;
-        std::string path;
 };
 
 // -----------------------------------------------------------------------------
@@ -258,6 +257,8 @@ int CQRRPT<T>::call(
     int64_t k = n;
     int i;
     if(this->naive_rank_estimate) {
+        /// Using R[i,i] to approximate the i-th singular value of A_hat. 
+        /// Truncate at the largest i where R[i,i] / R[0,0] >= eps.
         for(i = 0; i < n; ++i) {
             if(std::abs(A_hat_dat[i * d + i]) / std::abs(A_hat_dat[0]) < this->eps) {
                 k = i;

--- a/RandLAPACK/drivers/rl_rsvd.hh
+++ b/RandLAPACK/drivers/rl_rsvd.hh
@@ -132,7 +132,7 @@ int RSVD<T>::call(
     // Making sure all vectors are large enough
     util::upsize(m * k, U);
     util::upsize(k * k, this->U_buf);
-    util::upsize(k * 1, S);
+    util::upsize(k, S);
     util::upsize(k * n, VT);
 
     // SVD of B

--- a/benchmark/CQRRPT_accuracy.cc
+++ b/benchmark/CQRRPT_accuracy.cc
@@ -175,7 +175,7 @@ int main() {
     //test_CQRRPT_approx_qual<double>(131072, 2000, 2000, 2000, 1, std::numeric_limits<double>::epsilon(), std::make_tuple(8, 1e10, false), state, 1, "../testing/RandLAPACK-benchmarking/QR/accuracy/raw_data/");
     //test_CQRRPT_approx_qual<double>(131072, 2000, 2000, 2000, 1, std::numeric_limits<double>::epsilon(), std::make_tuple(8, 1e10, false), state, 2, "../testing/RandLAPACK-benchmarking/QR/accuracy/raw_data/");
     // Spiked spectrum *V good params
-    //test_CQRRPT_approx_qual<double>(131072, 2000, 2000, 6000, 4, std::numeric_limits<double>::epsilon(), std::make_tuple(8, 1e10, false), state, 1, "../testing/RandLAPACK-benchmarking/QR/accuracy/raw_data/");
-    //test_CQRRPT_approx_qual<double>(131072, 2000, 2000, 6000, 4, std::numeric_limits<double>::epsilon(), std::make_tuple(8, 1e10, false), state, 2, "../testing/RandLAPACK-benchmarking/QR/accuracy/raw_data/");
+    test_CQRRPT_approx_qual<double>(131072, 2000, 2000, 6000, 4, std::numeric_limits<double>::epsilon(), std::make_tuple(8, 1e10, false), state, 1, "../testing/RandLAPACK-benchmarking/QR/accuracy/raw_data/");
+    test_CQRRPT_approx_qual<double>(131072, 2000, 2000, 6000, 4, std::numeric_limits<double>::epsilon(), std::make_tuple(8, 1e10, false), state, 2, "../testing/RandLAPACK-benchmarking/QR/accuracy/raw_data/");
     return 0;
 }

--- a/benchmark/QR_accuracy_stability_analysis.cc
+++ b/benchmark/QR_accuracy_stability_analysis.cc
@@ -15,148 +15,317 @@
 
 template <typename T>
 static void
-test_cond_helper_0(int64_t m, 
+error_check(int64_t m,
+            int64_t n,
+            int64_t k,
+            T norm_A,
+            T* A_dat,
+            T* A_1_dat,
+            T* Q_dat,
+            T* R_dat,
+            T* I_ref_dat
+            ) {
+
+    // Check orthogonality of Q
+    // Q' * Q  - I = 0
+    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, m, 1.0, Q_dat, m, Q_dat, m, -1.0, I_ref_dat, k);
+    T norm_0 = lapack::lange(lapack::Norm::Fro, k, k, I_ref_dat, k);
+
+    // AP - QR
+    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, k, 1.0, Q_dat, m, R_dat, k, -1.0, A_dat, m);
+    
+    // Implementing max col norm metric
+    T max_col_norm = 0.0;
+    T col_norm = 0.0;
+    int max_idx = 0;
+    for(int i = 0; i < n; ++i) {
+        col_norm = blas::nrm2(m, A_dat + (m * i), 1);
+        if(max_col_norm < col_norm) {
+            max_col_norm = col_norm;
+            max_idx = i;
+        }
+    }
+    T col_norm_A = blas::nrm2(n, A_1_dat + (m * max_idx), 1);
+    T norm_AQR = lapack::lange(Norm::Fro, m, n, A_dat, m);
+    
+    printf("REL NORM OF AP - QR: %15e\n", norm_AQR / norm_A);
+    printf("MAX COL NORM METRIC: %15e\n", max_col_norm / col_norm_A);
+    printf("FRO NORM OF Q' * Q - I: %2e\n\n", norm_0);
+}
+
+
+template <typename T>
+static void
+cholqr_helper(int64_t m, 
                   int64_t n, 
                   const std::tuple<int, T, bool>& mat_type, 
                   RandBLAS::base::RNGState<r123::Philox4x32> state) {
 
     std::vector<T> A(m * n, 0.0);
+    std::vector<T> A_hat(m * n, 0.0);
     std::vector<T> I_ref(n * n, 0.0);
+    std::vector<T> R_sp(n * n, 0.0);
 
     // Generate random matrix
     RandLAPACK::util::gen_mat_type(m, n, A, n, state, mat_type);
     RandLAPACK::util::eye(n, n, I_ref);
 
-    // CHOL QR
-    RandLAPACK::CholQRQ<T> Orth_CholQR(false, false);
-    // Orthonormalize A
-    Orth_CholQR.call(m, n, A);
+    std::copy(A.data(), A.data() + (m * n), A_hat.data());
 
     T* A_dat = A.data();
+    T* A_hat_dat = A_hat.data();
     T* I_ref_dat = I_ref.data();
+    T* R_sp_dat  = R_sp.data();
+
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, n, m, 1.0, A_dat, m, 0.0, R_sp_dat, n);
+    lapack::potrf(Uplo::Upper, n, R_sp_dat, n);
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, n, 1.0, R_sp_dat, n, A_dat, m);
 
     // Check orthogonality of Q
     // Q' * Q  - I = 0
     blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, n, m, 1.0, A_dat, m, A_dat, m, -1.0, I_ref_dat, n);
     T norm_Q = lapack::lange(lapack::Norm::Fro, n, n, I_ref_dat, n);
+    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, n, 1.0, A_dat, m, R_sp_dat, n, -1.0, A_hat_dat, m);
+    T norm_A = lapack::lange(Norm::Fro, m, n, A_hat_dat, m);
+
     printf("COND(A^{pre}): %21e\n", std::get<1>(mat_type));
-    printf("FRO NORM OF Q' * Q - I: %e\n\n", norm_Q);
+    printf("FRO NORM OF Q' * Q - I: %e\n", norm_Q);
+    printf("FRO NORM OF AP - QR: %15e\n\n", norm_A);
 }
 
 template <typename T>
-static int
-test_cond_helper_1(int64_t m, 
-                  int64_t n, 
-                  int64_t true_k,
-                  int64_t d,
-                  int64_t nnz,
-                  const std::tuple<int, T, bool>& mat_type, 
-                  RandBLAS::base::RNGState<r123::Philox4x32> state,
-                  int naive_rank_estimate,
-                  int cond_check) {
+static void
+cqrrpt_helper(int64_t m, 
+                int64_t n, 
+                const std::tuple<int, T, bool>& mat_type, 
+                RandBLAS::base::RNGState<r123::Philox4x32> state,
+                const std::vector<T>& additional_params) {
+
+    int64_t true_k = additional_params[0];
+    int64_t d = additional_params[1];
 
     std::vector<T> A(m * n, 0.0);
-    std::vector<T> A_hat(m * n, 0.0);
+    std::vector<T> A_1(m * n, 0.0);
+    std::vector<T> A_2(m * n, 0.0);
     std::vector<T> R(n * n, 0.0);
     std::vector<int64_t> J;
 
     // Generate random matrix
     RandLAPACK::util::gen_mat_type(m, n, A, true_k, state, mat_type);
 
-    std::copy(A.data(), A.data() + (m * n), A_hat.data());
+    std::copy(A.data(), A.data() + (m * n), A_1.data());
+    std::copy(A.data(), A.data() + (m * n), A_2.data());
 
     // CQRRPT constructor
     RandLAPACK::CQRRPT<T> CQRRPT(false, true, state, std::numeric_limits<double>::epsilon());
-    CQRRPT.nnz                 = nnz;
-    CQRRPT.num_threads         = 4;
-    CQRRPT.cond_check          = cond_check;
-    CQRRPT.naive_rank_estimate = naive_rank_estimate;
+    CQRRPT.nnz                 = additional_params[2];
+    CQRRPT.num_threads         = additional_params[3];
+    CQRRPT.cond_check          = additional_params[4];
+    CQRRPT.naive_rank_estimate = additional_params[5];
+    CQRRPT.path = "../../../"; 
+    CQRRPT.use_fro_norm = additional_params[6];
 
     // CQRRPT
     CQRRPT.call(m, n, A, d, R, J);
 
     printf("COND(A): %27e\n", std::get<1>(mat_type));
     printf("COND(A^{pre}): %21e\n", CQRRPT.cond_num_A_pre);
-    printf("TRUE RANK(A): %14ld\n", n);
+    printf("COND(normc(A^{pre})): %14e\n", CQRRPT.cond_num_A_norm_pre);
+    printf("TRUE RANK(A): %14ld\n", true_k);
     printf("RANK(A) ESTIMATE: %10ld\n", CQRRPT.rank);
     int k = CQRRPT.rank;
 
-    T* A_dat = A.data();
-    T* A_hat_dat = A_hat.data();
-    T* R_dat = R.data();
     std::vector<T> I_ref(k * k, 0.0);
     RandLAPACK::util::eye(k, k, I_ref);
-    T* I_ref_dat = I_ref.data();
-
-    // Check orthogonality of Q
-    // Q' * Q  - I = 0
-    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, m, 1.0, A_dat, m, A_dat, m, -1.0, I_ref_dat, k);
-    T norm_Q = lapack::lange(lapack::Norm::Fro, k, k, I_ref_dat, k);
 
     // Check approximation quality
-    RandLAPACK::util::col_swap(m, n, n, A_hat, J);
-    // AP - QR
-    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, k, 1.0, A_dat, m, R_dat, k, -1.0, A_hat_dat, m);
-    T norm_A = lapack::lange(Norm::Fro, m, n, A_hat_dat, m);
+    RandLAPACK::util::col_swap(m, n, n, A_1, J);
+    RandLAPACK::util::col_swap(m, n, n, A_2, J);
 
-    printf("FRO NORM OF AP - QR: %15e\n", norm_A);
-    printf("FRO NORM OF Q' * Q - I: %2e\n\n", norm_Q);
+    error_check(m, n, k, lapack::lange(Norm::Fro, m, n, A.data(), m), A_1.data(), A_2.data(), A.data(), R.data(), I_ref.data()); 
+}
 
-    if(k != true_k)
-        return 1;
+template <typename T>
+static void
+scholqr_helper(int64_t m, 
+                  int64_t n, 
+                  const std::tuple<int, T, bool>& mat_type, 
+                  RandBLAS::base::RNGState<r123::Philox4x32> state,
+                  const std::vector<T>& additional_params) {
 
-    return 0;
+    int64_t k = additional_params[0];
+    T shift_c = additional_params[1];
+
+    std::vector<T> A(m * n, 0.0);
+    std::vector<T> A_1(m * n, 0.0);
+    std::vector<T> A_2(m * n, 0.0);
+
+    std::vector<T> ATA(n * n, 0.0);
+    std::vector<T> ATA1(n * n, 0.0);
+    std::vector<T> ATA2(n * n, 0.0);
+    std::vector<T> ATA_buf(n * n, 0.0);
+
+    // Generate random matrix
+    RandLAPACK::util::gen_mat_type(m, n, A, k, state, mat_type);
+
+    std::copy(A.data(), A.data() + (m * n), A_1.data());
+    std::copy(A.data(), A.data() + (m * n), A_2.data());
+
+    T norm_A;    
+    // Decide which norm we're using
+    if(additional_params[2]) {
+        norm_A = lapack::lange(Norm::Fro, m, n, A.data(), m);
+    } else {
+        norm_A = RandLAPACK::util::estimate_spectral_norm(m, n, A.data(), 10, state);
+    }
+
+    T shift = std::numeric_limits<double>::epsilon() * shift_c * std::pow(norm_A, 2);
+    // A = A' * A
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, n, m, 1.0, A.data(), m, 0.0, ATA.data(), n);
+
+    // A = A + shift * I
+    for (int i = 0; i < n; ++i) {
+        ATA[i * (n + 1)] += shift;
+    }
+    
+    // R_0 = chol(A)
+    if(lapack::potrf(Uplo::Upper, n, ATA.data(), n)){
+        printf("CHOLESKY FAILED\n");
+        return;
+    }
+    // Q = A_orig * R_0^-1
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, n, 1.0, ATA.data(), n, A.data(), m);
+    // Define R1
+    std::copy(ATA.data(), ATA.data() + (n * n), ATA1.data());
+
+    // CholeskyQR2
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, n, m, 1.0, A.data(), m, 0.0, ATA.data(), n);
+    if(lapack::potrf(Uplo::Upper, n, ATA.data(), n)){
+        printf("CHOLESKY FAILED\n");
+        return;
+    }
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, n, 1.0, ATA.data(), n, A.data(), m);
+    // Define R2
+    std::copy(ATA.data(), ATA.data() + (n * n), ATA2.data());
+
+    // CholeskyQR3
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, n, m, 1.0, A.data(), m, 0.0, ATA.data(), n);
+    if(lapack::potrf(Uplo::Upper, n, ATA.data(), n)){
+        printf("CHOLESKY FAILED\n");
+        return;
+    }
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, n, 1.0, ATA.data(), n, A.data(), m);
+
+    // Re-combine R's
+    blas::trmm(Layout::ColMajor, Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, n, n, 1.0, ATA.data(), n, ATA2.data(), n);
+    blas::trmm(Layout::ColMajor, Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, n, n, 1.0, ATA2.data(), n, ATA1.data(), n);
+
+    std::vector<T> I_ref(n * n, 0.0);
+    RandLAPACK::util::eye(n, n, I_ref);
+
+    error_check(m, n, n, norm_A, A_1.data(), A_2.data(), A.data(), ATA1.data(), I_ref.data());
 }
 
 template <typename T>
 static void 
-test_speed(int r_pow, 
+test_cond_orth(int row, 
            int col, 
-           int64_t k,
-           int64_t d,
-           int64_t nnz,
            T cond_start,
            T cond_end,
            T cond_step,
            RandBLAS::base::RNGState<r123::Philox4x32> state,
-           int naive_rank_estimate,
-           int cond_check,
-           int alg_type) {
-    printf("\n/-----------------------------------------CQRRPT CONDITION NUMBER BENCHMARK START-----------------------------------------/\n");
-    if(naive_rank_estimate && alg_type) {
-        printf("USING NAIVE RANK DETECTION\n\n");
-    } else if(alg_type){
-        printf("USING PRINCIPLED RANK DETECTION\n\n");
-    }
-    int detect_rank_underestimate = 1;
-    T rank_underestimate_cond = 0;
+           int alg_type,
+           int mat_type_num,
+           std::vector<T> additional_params) {
 
     for (; cond_start <= cond_end; cond_start *= cond_step) {
-        auto mat_type = std::make_tuple(0, cond_start, false);
-        if(alg_type) {
-            if(test_cond_helper_1<T>(std::pow(2, r_pow), col, k, d, nnz, mat_type, state, naive_rank_estimate, cond_check) && detect_rank_underestimate)
-            {
-                detect_rank_underestimate = 0;
-                rank_underestimate_cond = cond_start;
-            }
-        } else {
-            test_cond_helper_0<T>(std::pow(2, r_pow), col, mat_type, state);
+
+        auto mat_type = std::make_tuple(mat_type_num, cond_start, true);
+        switch(alg_type) {
+            case 0:
+                    // CholQR
+                    cholqr_helper<T>(row, col, mat_type, state);
+                    break;
+            case 1:
+                    // CQRRPT
+                    cqrrpt_helper<T>(row, col, mat_type, state, additional_params);
+                    break;
+            case 2:
+                    // sCholQR
+                    scholqr_helper(row, col, mat_type, state, additional_params);
+                    break;
+            default:
+            throw std::runtime_error(std::string("Unrecognized case."));
+            break;
         }
     }
-    if(!detect_rank_underestimate)
-    {
-        printf("FAILED TO ACCURATELY ESTIMATE RANK FOR COND(A): %e\n", rank_underestimate_cond);
-    }
-    printf("/-----------------------------------------CQRRPT CONDITION NUMBER EFFECT BENCHMARK STOP-----------------------------------------/\n\n");
 }
 
 int main(){
     // Run with env OMP_NUM_THREADS=36 numactl --interleave all ./filename  
     auto state = RandBLAS::base::RNGState(0, 0);
-    // CholQR check
-    test_speed<double>(17, 1024, 1024, 1024, 1, 1, 10e16, 10, state, 0, 1, 0);
+    // Old tests
+    //test_cond_orth<double>(10000, 1024, 1024, 1024, 1, 10, 10e16, 10, state, 0, 1, 0);
+    //test_cond_orth<double>(1024, 5, 5, 5, 1, 10, 10, 10, state, 0, 1, 1);
     // CQRRPT check
-    test_speed<double>(17, 1024, 1024, 1024, 1, 1, 10e16, 10, state, 0, 1, 1);
-    test_speed<double>(17, 1024, 1024, 1024, 1, 1, 10e16, 10, state, 1, 1, 1);
+    //test_cond_orth<double>(10000, 1024, 1024, 1024, 1, 1, 1, 10, state, 0, 1, 1);
+    //test_cond_orth<double>(10000, 1024, 1024, 1024, 1, 1, 10e16, 10, state, 1, 1, 1);
+
+    // Things presented on 04/17/2023
+
+    // Spiked data Max test
+    // Condition number parameter here is unused
+    /*
+    test_cond_orth<double>(10000, 2000, 10e16, 10e16, 10, state, 1, 8, {2000, 2000, 1, 4, 1, 1});
+    test_cond_orth<double>(10000, 2000, 10e16, 10e16, 10, state, 1, 8, {2000, 3000, 4, 4, 1, 1});
+    test_cond_orth<double>(10000, 2000, 10e16, 10e16, 10, state, 1, 8, {2000, 4000, 4, 4, 1, 1});
+    test_cond_orth<double>(10000, 2000, 10e16, 10e16, 10, state, 1, 8, {2000, 6000, 4, 4, 1, 1});
+    test_cond_orth<double>(10000, 2000, 10e16, 10e16, 10, state, 1, 8, {2000, 8000, 4, 4, 1, 1});
+    */
+
+    // Scaled data Max test
+    // Condition number here acts as scaling "sigma"
+    
+    test_cond_orth<double>(10000, 2000, 10e15, 10e15, 10, state, 1, 9, {2000, 2000, 1, 4, 1, 1});
+    test_cond_orth<double>(10000, 2000, 10e15, 10e15, 10, state, 1, 9, {2000, 3000, 4, 4, 1, 1});
+    test_cond_orth<double>(10000, 2000, 10e15, 10e15, 10, state, 1, 9, {2000, 4000, 4, 4, 1, 1});
+    test_cond_orth<double>(10000, 2000, 10e15, 10e15, 10, state, 1, 9, {2000, 6000, 4, 4, 1, 1});
+    test_cond_orth<double>(10000, 2000, 10e15, 10e15, 10, state, 1, 9, {2000, 8000, 4, 4, 1, 1});
+    
+    // Oleg test
+    // Condition number here acts as scaling "sigma"
+    //test_cond_orth<double>(10e6, 300, 10e7, 10e15, 100, state, 1, 9, {295, 2 * 300, 4, 4, 0, 1});
+
+    // Things to present on 04/14/2023
+
+    // Checking sCholQR3
+    //test_cond_orth<double>(10000, 2000, 10e16, 10e16, 10, state, 2, 9, {2000, 11 * 1, 1});
+    //test_cond_orth<double>(10000, 2000, 10e16, 10e16, 10, state, 2, 9, {2000, 11 * 5, 1});
+    //test_cond_orth<double>(10000, 2000, 10e16, 10e16, 10, state, 2, 9, {2000, 11 * 2000, 1});
+    //test_cond_orth<double>(10000, 2000, 10e16, 10e16, 10, state, 2, 9, {2000, 11 * 10000, 1});
+    //test_cond_orth<double>(10000, 2000, 10e16, 10e16, 10, state, 2, 9, {2000, 11 * (10000 * 2000 + 2000 * (2000 + 1)), 1});
+
+    // Oleg test - An attempt to get an even higher condition number of A^{pre}
+    // Condition number here acts as scaling "sigma"
+    /*
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 1, 9, {300, 2 * 300, 4, 4, 1, 0, 1});
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 1, 9, {300, 2 * 300, 4, 4, 1, 0, 0});
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 1, 9, {300, 2 * 300, 4, 4, 1, 1});
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 2, 9, {300, 11 * 1, 1});
+    printf("\nBREAK\n");
+    */
+    /*
+    // Fro
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 1, 9, {300, 1.5 * 300, 4, 4, 1, 0, 1});
+    // L2
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 1, 9, {300, 1.5 * 300, 4, 4, 1, 0, 0});
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 1, 9, {300, 1.5 * 300, 4, 4, 1, 1});
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 2, 9, {300, 11 * 1, 1});
+    printf("\nBREAK\n");
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 1, 9, {300, 2 * 300, 4, 4, 1, 0, 1});
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 1, 9, {300, 2 * 300, 4, 4, 1, 0, 0});
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 1, 9, {300, 2 * 300, 4, 4, 1, 1});
+    test_cond_orth<double>(10e6, 300, 10e7, 10e7, 100, state, 2, 9, {300, 11 * 1, 1});
+    */
     return 0;
 }

--- a/benchmark/QR_accuracy_stability_analysis.cc
+++ b/benchmark/QR_accuracy_stability_analysis.cc
@@ -39,13 +39,13 @@ error_check(int64_t m,
     T col_norm = 0.0;
     int max_idx = 0;
     for(int i = 0; i < n; ++i) {
-        col_norm = blas::nrm2(m, A_dat + (m * i), 1);
+        col_norm = blas::nrm2(m, &A_dat[m * i], 1);
         if(max_col_norm < col_norm) {
             max_col_norm = col_norm;
             max_idx = i;
         }
     }
-    T col_norm_A = blas::nrm2(n, A_1_dat + (m * max_idx), 1);
+    T col_norm_A = blas::nrm2(n, &A_1_dat[m * max_idx], 1);
     T norm_AQR = lapack::lange(Norm::Fro, m, n, A_dat, m);
     
     printf("REL NORM OF AP - QR: %15e\n", norm_AQR / norm_A);

--- a/test/comps/test_orth.cc
+++ b/test/comps/test_orth.cc
@@ -60,9 +60,10 @@ class TestOrth : public ::testing::Test
         // Call the scheme twice for better orthogonality
         CholQRQ.call(m, k, Y);
         // Q' * Q  - I = 0
-        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, m, 1.0, Y_dat, m, Y_dat, m, -1.0, I_ref_dat, k);
+        blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, Y_dat, m, -1.0, I_ref_dat, k);
+        T norm_fro = lapack::lansy(lapack::Norm::Fro, Uplo::Upper, k, I_ref_dat, k);
 
-        T norm_fro = lapack::lange(lapack::Norm::Fro, k, k, I_ref_dat, k);
+
         printf("FRO NORM OF Q' * Q - I: %f\n", norm_fro);
         ASSERT_NEAR(norm_fro, 0.0, std::pow(std::numeric_limits<T>::epsilon(), 0.625));
     }

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -141,7 +141,7 @@ class TestQB : public ::testing::Test
         // TEST 2: B - Q'A = 0
         blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, n, m, -1.0, Q_dat, m, A_cpy_2_dat, m, 1.0, B_cpy_dat, k);
         // TEST 3: Q'Q = I = 0
-        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, m, -1.0, Q_dat, m, Q_dat, m, 1.0, Ident_dat, k);
+        blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, Q_dat, m, -1.0, Ident_dat, k);
 
         // Get low-rank SVD
         lapack::gesdd(Job::SomeVec, m, n, A_cpy_dat, m, s_dat, U_dat, m, VT_dat, n);
@@ -167,7 +167,7 @@ class TestQB : public ::testing::Test
         printf("FRO NORM OF B - Q'A:   %e\n", norm_test_2);
         ASSERT_NEAR(norm_test_2, 0, test_tol);
         // Test 3 Output
-        T norm_test_3 = lapack::lange(lapack::Norm::Fro, k, k, Ident_dat, k);
+        T norm_test_3 = lapack::lansy(lapack::Norm::Fro, Uplo::Upper, k, Ident_dat, k);
         printf("FRO NORM OF Q'Q - I:   %e\n", norm_test_3);
         ASSERT_NEAR(norm_test_3, 0, test_tol);
         // Test 4 Output

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -140,7 +140,7 @@ class TestQB : public ::testing::Test
         blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, k, -1.0, Q_dat, m, B_dat, k, 1.0, A_dat, m);
         // TEST 2: B - Q'A = 0
         blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, n, m, -1.0, Q_dat, m, A_cpy_2_dat, m, 1.0, B_cpy_dat, k);
-        // TEST 3: Q'Q = I = 0
+        // TEST 3: Q'Q = I
         blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, Q_dat, m, -1.0, Ident_dat, k);
 
         // Get low-rank SVD


### PR DESCRIPTION
Updating CQRRPT:
- Adding an option to perform principled rank estimation with spectral or Frobenius norm
- Adding a check for cholesky factorzation failure
- Adding an optional check for a condition number of normc(A^{pre})
Updating QR_accuracy_stability_analysis benchmark
- Adding a routine to check accuracy and stability of sCholQR3
- Other changes
