### PR TITLE
Test expand

### DIFF
--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -23,6 +23,8 @@ class REVD2alg {
             blas::Uplo uplo,
             std::vector<T>& A,
             int64_t& k,
+            T tol,
+            int p,
             std::vector<T>& V,
             std::vector<T>& eigvals
         ) = 0;
@@ -35,13 +37,9 @@ class REVD2 : public REVD2alg<T> {
         // Constructor
         REVD2(
             RandLAPACK::RangeFinder<T>& rf_obj,
-            T tolerance,
-            int power_iters,
             RandBLAS::base::RNGState<RNG> s,
             bool verb
         ) : RF_Obj(rf_obj) {
-            tol = tolerance;
-            p = power_iters;
             state = s;
             verbosity = verb;
         }
@@ -92,6 +90,8 @@ class REVD2 : public REVD2alg<T> {
             blas::Uplo uplo,
             std::vector<T>& A,
             int64_t& k,
+            T tol,
+            int p,
             std::vector<T>& V,
             std::vector<T>& eigvals
         ) override;
@@ -99,8 +99,6 @@ class REVD2 : public REVD2alg<T> {
     public:
         RandLAPACK::RangeFinder<T>& RF_Obj;
         RandBLAS::base::RNGState<RNG> state;
-        T tol;
-        int p;
         bool verbosity;
 
         std::vector<T> Y;
@@ -173,10 +171,12 @@ T power_error_est(
 
 template <typename T, typename RNG>
 int REVD2<T, RNG>::call(
-        int64_t m, // m = n
+        int64_t m,
         blas::Uplo uplo,
         std::vector<T>& A,
         int64_t& k,
+        T tol,
+        int p,
         std::vector<T>& V,
         std::vector<T>& eigvals
 ){
@@ -257,7 +257,7 @@ int REVD2<T, RNG>::call(
 
         err = power_error_est(m, k, p, Omega_dat, V_dat, uplo, A_dat, Y_dat, eigvals.data()); 
 
-        if(err <= 5 * std::max(this->tol, nu) || k == m) {
+        if(err <= 5 * std::max(tol, nu) || k == m) {
             break;
         } else if (2 * k > m) {
             k = m;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,6 +11,7 @@ if (GTest_FOUND)
         comps/test_orth.cc
         comps/test_qb.cc
         comps/test_preconditioners.cc
+        comps/test_rf.cc
         drivers/test_rsvd.cc
         drivers/test_cqrrpt.cc
         drivers/test_revd2.cc

--- a/test/comps/test_orth.cc
+++ b/test/comps/test_orth.cc
@@ -40,7 +40,7 @@ class TestOrth : public ::testing::Test
     };
 
     template <typename T, typename RNG>
-    static void computational_helper(int64_t m, int64_t n, int64_t k, RandBLAS::base::RNGState<RNG> state, OrthTestData<T>& all_data) {
+    static void sketch_and_copy_computational_helper(int64_t m, int64_t n, int64_t k, RandBLAS::base::RNGState<RNG> state, OrthTestData<T>& all_data) {
         // Fill the gaussian random matrix
         RandBLAS::dense::DenseDist D{.n_rows = n, .n_cols = k};
         state = RandBLAS::dense::fill_buff(all_data.Omega.data(), D, state);
@@ -89,6 +89,6 @@ TEST_F(TestOrth, Test_CholQRQ)
     OrthTestData<double> all_data(m, n, k);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
-    computational_helper<double, r123::Philox4x32>(m, n, k, state, all_data);
+    sketch_and_copy_computational_helper<double, r123::Philox4x32>(m, n, k, state, all_data);
     test_orth_sketch<double, r123::Philox4x32>(m, k, all_data);
 }

--- a/test/comps/test_orth.cc
+++ b/test/comps/test_orth.cc
@@ -32,11 +32,11 @@ class TestOrth : public ::testing::Test
         std::vector<T> I_ref;
 
         OrthTestData(int64_t m, int64_t n, int64_t k) :
-        A(m * n, 0.0),
-        Y(m * k, 0.0),
-        Omega(n * k, 0.0),
-        I_ref(k * k, 0.0)
-        {}
+            A(m * n, 0.0),
+            Y(m * k, 0.0),
+            Omega(n * k, 0.0),
+            I_ref(k * k, 0.0)
+            {}
     };
 
     template <typename T, typename RNG>

--- a/test/comps/test_orth.cc
+++ b/test/comps/test_orth.cc
@@ -55,7 +55,7 @@ class TestOrth : public ::testing::Test
     /// Tests orthogonality of a matrix Q, obtained by orthogonalizing a Gaussian sketch.
     /// Checks I - \transpose{Q}Q.
     template <typename T, typename RNG>
-    static void test_orth_sketch(int64_t m, int64_t n, int64_t k, RandBLAS::base::RNGState<RNG> state, OrthTestData<T>& all_data) {
+    static void test_orth_sketch(int64_t m, int64_t k, OrthTestData<T>& all_data) {
 
         T* Y_dat = all_data.Y.data();
         T* I_ref_dat = all_data.I_ref.data();
@@ -90,5 +90,5 @@ TEST_F(TestOrth, Test_CholQRQ)
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
     computational_helper<double, r123::Philox4x32>(m, n, k, state, all_data);
-    test_orth_sketch<double, r123::Philox4x32>(m, n, k, state, all_data);
+    test_orth_sketch<double, r123::Philox4x32>(m, k, all_data);
 }

--- a/test/comps/test_orth.cc
+++ b/test/comps/test_orth.cc
@@ -24,41 +24,52 @@ class TestOrth : public ::testing::Test
 
     virtual void TearDown() {};
 
+    template <typename T>
+    struct OrthTestData {
+        std::vector<T> A;
+        std::vector<T> Y;
+        std::vector<T> Omega;
+        std::vector<T> I_ref;
+
+        OrthTestData(int64_t m, int64_t n, int64_t k) :
+        A(m * n, 0.0),
+        Y(m * k, 0.0),
+        Omega(n * k, 0.0),
+        I_ref(k * k, 0.0)
+        {}
+    };
+
+    template <typename T, typename RNG>
+    static void computational_helper(int64_t m, int64_t n, int64_t k, RandBLAS::base::RNGState<RNG> state, OrthTestData<T>& all_data) {
+        // Fill the gaussian random matrix
+        RandBLAS::dense::DenseDist D{.n_rows = n, .n_cols = k};
+        state = RandBLAS::dense::fill_buff(all_data.Omega.data(), D, state);
+        
+        // Generate a reference identity
+        RandLAPACK::util::eye(k, k, all_data.I_ref);
+
+        // Y = A * Omega
+        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, n, 1.0, all_data.A.data(), m, all_data.Omega.data(), n, 0.0, all_data.Y.data(), m);
+    }
+
     /// Tests orthogonality of a matrix Q, obtained by orthogonalizing a Gaussian sketch.
     /// Checks I - \transpose{Q}Q.
     template <typename T, typename RNG>
-    static void test_orth_sketch(int64_t m, int64_t n, int64_t k, std::tuple<int, T, bool> mat_type, RandBLAS::base::RNGState<RNG> state) {
+    static void test_orth_sketch(int64_t m, int64_t n, int64_t k, RandBLAS::base::RNGState<RNG> state, OrthTestData<T>& all_data) {
 
-        int64_t size = m * n;
-        std::vector<T> A(size, 0.0);
-        std::vector<T> Y(m * k, 0.0);
-        std::vector<T> Omega(n * k, 0.0);
-        std::vector<T> I_ref(k * k, 0.0);
+        T* Y_dat = all_data.Y.data();
+        T* I_ref_dat = all_data.I_ref.data();
 
-        T* A_dat = A.data();
-        T* Y_dat = Y.data();
-        T* Omega_dat = Omega.data();
-        T* I_ref_dat = I_ref.data();
-
-        RandLAPACK::util::gen_mat_type(m, n, A, k, state, mat_type);
-
-        // Fill the gaussian random matrix
-        RandBLAS::dense::DenseDist D{.n_rows = n, .n_cols = k};
-        state = RandBLAS::dense::fill_buff(Omega_dat, D, state);
-        // Generate a reference identity
-        RandLAPACK::util::eye(k, k, I_ref);
-        // Y = A * Omega
-        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, n, 1.0, A_dat, m, Omega_dat, n, 0.0, Y_dat, m);
         // Orthogonalization Constructor
         RandLAPACK::CholQRQ<T> CholQRQ(false, false);
 
         // Orthonormalize sketch Y
-        if(CholQRQ.call(m, k, Y) != 0) {
+        if(CholQRQ.call(m, k, all_data.Y) != 0) {
             EXPECT_TRUE(false) << "\nPOTRF FAILED DURE TO ILL-CONDITIONED DATA\n";
             return;
         }
         // Call the scheme twice for better orthogonality
-        CholQRQ.call(m, k, Y);
+        CholQRQ.call(m, k, all_data.Y);
         // Q' * Q  - I = 0
         blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, Y_dat, m, -1.0, I_ref_dat, k);
         T norm_fro = lapack::lansy(lapack::Norm::Fro, Uplo::Upper, k, I_ref_dat, k);
@@ -69,6 +80,15 @@ class TestOrth : public ::testing::Test
     }
 };
 
-TEST_F(TestOrth, SimpleTest)
+TEST_F(TestOrth, Test_CholQRQ)
 {
+    int64_t m = 1000;
+    int64_t n = 200;
+    int64_t k = 200;
+    auto state = RandBLAS::base::RNGState();
+    OrthTestData<double> all_data(m, n, k);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
+    computational_helper<double, r123::Philox4x32>(m, n, k, state, all_data);
+    test_orth_sketch<double, r123::Philox4x32>(m, n, k, state, all_data);
 }

--- a/test/comps/test_orth.cc
+++ b/test/comps/test_orth.cc
@@ -55,13 +55,14 @@ class TestOrth : public ::testing::Test
     /// Tests orthogonality of a matrix Q, obtained by orthogonalizing a Gaussian sketch.
     /// Checks I - \transpose{Q}Q.
     template <typename T, typename RNG>
-    static void test_orth_sketch(int64_t m, int64_t k, OrthTestData<T>& all_data) {
+    static void test_orth_sketch(
+        int64_t m, 
+        int64_t k, 
+        OrthTestData<T>& all_data, 
+        RandLAPACK::CholQRQ<T>& CholQRQ) {
 
         T* Y_dat = all_data.Y.data();
         T* I_ref_dat = all_data.I_ref.data();
-
-        // Orthogonalization Constructor
-        RandLAPACK::CholQRQ<T> CholQRQ(false, false);
 
         // Orthonormalize sketch Y
         if(CholQRQ.call(m, k, all_data.Y) != 0) {
@@ -86,9 +87,12 @@ TEST_F(TestOrth, Test_CholQRQ)
     int64_t n = 200;
     int64_t k = 200;
     auto state = RandBLAS::base::RNGState();
+    
     OrthTestData<double> all_data(m, n, k);
+    // Orthogonalization Constructor
+    RandLAPACK::CholQRQ<double> CholQRQ(false, false);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
     sketch_and_copy_computational_helper<double, r123::Philox4x32>(m, n, k, state, all_data);
-    test_orth_sketch<double, r123::Philox4x32>(m, k, all_data);
+    test_orth_sketch<double, r123::Philox4x32>(m, k, all_data, CholQRQ);
 }

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -15,61 +15,58 @@ class TestQB : public ::testing::Test
 
     virtual void TearDown() {};
 
+    template <typename T>
+    struct data {
+        std::vector<T>& A;
+        std::vector<T>& Q;
+        std::vector<T>& B;
+        std::vector<T>& B_cpy;
+        std::vector<T>& A_hat;
+        std::vector<T>& A_k;
+        std::vector<T>& A_cpy;
+        std::vector<T>& A_cpy_2;
+        std::vector<T>& A_cpy_3;
+        std::vector<T>& s;
+        std::vector<T>& S;
+        std::vector<T>& U;
+        std::vector<T>& VT;
+    };
+
+    template <typename T, typename RNG>
+    static void computational_helper(int64_t m, int64_t n, T& norm_A, data<T>* all_data) {
+        
+        // Create a copy of the original matrix
+        blas::copy(m * n, all_data -> A.data(), 1, all_data -> A_cpy.data(), 1);
+        blas::copy(m * n, all_data -> A.data(), 1, all_data -> A_cpy_2.data(), 1);
+        blas::copy(m * n, all_data -> A.data(), 1, all_data -> A_cpy_3.data(), 1);
+
+        // Get low-rank SVD
+        lapack::gesdd(Job::SomeVec, m, n, all_data -> A_cpy.data(), m, all_data -> s.data(), all_data -> U.data(), m, all_data -> VT.data(), n);
+
+        // pre-compute norm
+        norm_A = lapack::lange(Norm::Fro, m, n, all_data -> A.data(), m);
+    }
+
     /// General test for QB:
     /// Computes QB factorzation, and checks:
     /// 1. A - QB
     /// 2. B - \transpose{Q}A
     /// 3. I - \transpose{Q}Q
     /// 4. A_k - QB = U_k\Sigma_k\transpose{V_k} - QB
-
     template <typename T, typename RNG>
-    static void computational_helper(int64_t m, int64_t n,
-    T& norm_A,
-    std::vector<T>& A, 
-    std::vector<T>& A_cpy, 
-    std::vector<T>& A_cpy_2, 
-    std::vector<T>& A_cpy_3,
-    std::vector<T>& s, 
-    std::vector<T>& U, 
-    std::vector<T>& VT) {
-        
-        // Create a copy of the original matrix
-        blas::copy(m * n, A.data(), 1, A_cpy.data(), 1);
-        blas::copy(m * n, A.data(), 1, A_cpy_2.data(), 1);
-        blas::copy(m * n, A.data(), 1, A_cpy_3.data(), 1);
-
-        // Get low-rank SVD
-        lapack::gesdd(Job::SomeVec, m, n, A_cpy.data(), m, s.data(), U.data(), m, VT.data(), n);
-
-        // pre-compute norm
-        norm_A = lapack::lange(Norm::Fro, m, n, A.data(), m);
-    }
-
-    template <typename T, typename RNG>
-    static void test_QB2_low_exact_rank(int64_t m, int64_t n, int64_t k, int64_t p, int64_t block_sz, T tol, RandBLAS::base::RNGState<RNG> state,
-    std::vector<T>& A,
-    std::vector<T>& Q,
-    std::vector<T>& B, 
-    std::vector<T>& B_cpy, 
-    std::vector<T>& A_hat, 
-    std::vector<T>& A_k, 
-    std::vector<T>& A_cpy_2, 
-    std::vector<T>& s, 
-    std::vector<T>& S, 
-    std::vector<T>& U, 
-    std::vector<T>& VT) {
+    static void test_QB2_low_exact_rank(int64_t m, int64_t n, int64_t k, int64_t p, int64_t block_sz, T tol, RandBLAS::base::RNGState<RNG> state, data<T>* all_data) {
 
         printf("|==================================TEST QB2 GENERAL BEGIN==================================|\n");
 
-        T* A_dat = A.data();
-        T* A_hat_dat = A_hat.data();
-        T* A_k_dat = A_k.data();
-        T* A_cpy_2_dat = A_cpy_2.data();
+        T* A_dat = all_data -> A.data();
+        T* A_hat_dat = all_data -> A_hat.data();
+        T* A_k_dat = all_data -> A_k.data();
+        T* A_cpy_2_dat = all_data -> A_cpy_2.data();
 
-        T* U_dat = U.data();
-        T* s_dat = s.data();
-        T* S_dat = S.data();
-        T* VT_dat = VT.data();
+        T* U_dat = all_data -> U.data();
+        T* s_dat = all_data -> s.data();
+        T* S_dat = all_data -> S.data();
+        T* VT_dat = all_data -> VT.data();
 
         //Subroutine parameters
         bool verbosity = false;
@@ -91,12 +88,12 @@ class TestQB : public ::testing::Test
         // QB constructor - Choose defaut (QB2)
         RandLAPACK::QB<T> QB(RF, Orth_QB, verbosity, orth_check);
         // Regular QB2 call
-        QB.call(m, n, A, k, block_sz, tol, Q, B);
+        QB.call(m, n, all_data -> A, k, block_sz, tol, all_data -> Q, all_data -> B);
 
         // Reassing pointers because Q, B have been resized
-        T* Q_dat = Q.data();
-        T* B_dat = B.data();
-        T* B_cpy_dat = B_cpy.data();
+        T* Q_dat = all_data -> Q.data();
+        T* B_dat = all_data -> B.data();
+        T* B_cpy_dat = all_data -> B_cpy.data();
 
         printf("Inner dimension of QB: %-25ld\n", k);
 
@@ -121,7 +118,7 @@ class TestQB : public ::testing::Test
         std::vector<T> z_buf(n, 0.0);
         // zero out the trailing singular values
         blas::copy(n - k, z_buf.data(), 1, s_dat + k, 1);
-        RandLAPACK::util::diag(n, n, s, n, S);
+        RandLAPACK::util::diag(n, n, all_data -> s, n, all_data -> S);
 
         // TEST 4: Below is A_k - A_hat = A_k - QB
         blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, n, 1.0, U_dat, m, S_dat, n, 1.0, A_k_dat, m);
@@ -160,19 +157,16 @@ class TestQB : public ::testing::Test
         T tol, 
         RandBLAS::base::RNGState<RNG> state,
         T& norm_A, 
-        std::vector<T>& A,
-        std::vector<T>& Q,
-        std::vector<T>& B,
-        std::vector<T>& A_hat) {
+        data<T>* all_data) {
 
         printf("|===============================TEST QB2 K = min(M, N) BEGIN===============================|\n");
 
         int64_t k_est = std::min(m, n);
 
-        T* A_dat = A.data();
-        T* Q_dat = Q.data();
-        T* B_dat = B.data();
-        T* A_hat_dat = A_hat.data();
+        T* A_dat = all_data -> A.data();
+        T* Q_dat = all_data -> Q.data();
+        T* B_dat = all_data -> B.data();
+        T* A_hat_dat = all_data -> A_hat.data();
 
         //Subroutine parameters
         bool verbosity = false;
@@ -194,11 +188,11 @@ class TestQB : public ::testing::Test
         // QB constructor - Choose defaut (QB2)
         RandLAPACK::QB<T> QB(RF, Orth_QB, verbosity, orth_check);
         // Regular QB2 call
-        QB.call(m, n, A, k_est, block_sz, tol, Q, B);
+        QB.call(m, n, all_data -> A, k_est, block_sz, tol, all_data -> Q, all_data -> B);
 
         // Reassing pointers because Q, B have been resized
-        Q_dat = Q.data();
-        B_dat = B.data();
+        Q_dat = all_data -> Q.data();
+        B_dat = all_data -> B.data();
 
         printf("Inner dimension of QB: %ld\n", k_est);
 
@@ -273,8 +267,9 @@ TEST_F(TestQB, Polynomial_Decay)
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
 
+
     // For running QB
-    std::vector<double> A(m * n, 0.0);
+    std::vector<double> A    (m * n, 0.0);
     std::vector<double> Q    (m * k, 0.0);
     std::vector<double> B    (k * n, 0.0);
     std::vector<double> B_cpy(k * n, 0.0);
@@ -290,15 +285,16 @@ TEST_F(TestQB, Polynomial_Decay)
     std::vector<double> U (m * n, 0.0);
     std::vector<double> VT(n * n, 0.0);
 
+    data<double> all_data = {A, Q, B, B_cpy, A_hat, A_k, A_cpy, A_cpy_2, A_cpy_3, s, S, U, VT};
+
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, A, k, state, std::make_tuple(0, 2025, false));
-    computational_helper<double, r123::Philox4x32>(m, n, norm_A, A, A_cpy, A_cpy_2, A_cpy_3, s, U, VT);
-    test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, p, block_sz, tol, state, A, Q, B, B_cpy, A_hat, A_k, A_cpy_2, s, S, U, VT);
-    
+    computational_helper<double, r123::Philox4x32>(m, n, norm_A, &all_data);
+    test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, p, block_sz, tol, state, &all_data);
+
     // Reset data - mandatory
-    Q.clear();
-    B.clear();
-    std::fill(A_hat.begin(), A_hat.end(), 0.0);
+    all_data.Q.clear();
+    all_data.B.clear();
+    std::fill(all_data.A_hat.begin(), all_data.A_hat.end(), 0.0);
 
-    test_QB2_k_eq_min<double, r123::Philox4x32>(m, n, p, block_sz, tol, state, norm_A, A_cpy_3, Q, B, A_hat);
-
+    test_QB2_k_eq_min<double, r123::Philox4x32>(m, n, p, block_sz, tol, state, norm_A, & all_data);
 }

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -17,19 +17,19 @@ class TestQB : public ::testing::Test
 
     template <typename T>
     struct QBTestData {
-        std::vector<T>& A;
-        std::vector<T>& Q;
-        std::vector<T>& B;
-        std::vector<T>& B_cpy;
-        std::vector<T>& A_hat;
-        std::vector<T>& A_k;
-        std::vector<T>& A_cpy;
-        std::vector<T>& A_cpy_2;
-        std::vector<T>& A_cpy_3;
-        std::vector<T>& s;
-        std::vector<T>& S;
-        std::vector<T>& U;
-        std::vector<T>& VT;
+        std::vector<T> A;
+        std::vector<T> Q;
+        std::vector<T> B;
+        std::vector<T> B_cpy;
+        std::vector<T> A_hat;
+        std::vector<T> A_k;
+        std::vector<T> A_cpy;
+        std::vector<T> A_cpy_2;
+        std::vector<T> A_cpy_3;
+        std::vector<T> s;
+        std::vector<T> S;
+        std::vector<T> U;
+        std::vector<T> VT;
 
         QBTestData(int64_t m, int64_t n, int64_t k) :
         A(m * n, 0.0), 
@@ -284,9 +284,8 @@ TEST_F(TestQB, Polynomial_Decay)
     auto state = RandBLAS::base::RNGState();
 
     QBTestData<double> all_data(m, n, k);
-
+    
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    /*
     computational_helper<double, r123::Philox4x32>(m, n, norm_A, &all_data);
     test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, p, block_sz, tol, state, &all_data);
 
@@ -296,5 +295,4 @@ TEST_F(TestQB, Polynomial_Decay)
     std::fill(all_data.A_hat.begin(), all_data.A_hat.end(), 0.0);
 
     test_QB2_k_eq_min<double, r123::Philox4x32>(m, n, p, block_sz, tol, state, norm_A, & all_data);
-    */
 }

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -32,24 +32,48 @@ class TestQB : public ::testing::Test
         std::vector<T> VT;
 
         QBTestData(int64_t m, int64_t n, int64_t k) :
-        A(m * n, 0.0), 
-        Q(m * k, 0.0), 
-        B(k * n, 0.0), 
-        B_cpy(k * n, 0.0), 
-        A_hat(m * n, 0.0),
-        A_k(m * n, 0.0),  
-        A_cpy(m * n, 0.0),  
-        A_cpy_2(m * n, 0.0),
-        A_cpy_3(m * n, 0.0),
-        s(n, 0.0),
-        S(n * n, 0.0),
-        U(m * n, 0.0),
-        VT(n * n, 0.0)
-        {}
+                    A(m * n, 0.0), 
+                    Q(m * k, 0.0), 
+                    B(k * n, 0.0), 
+                    B_cpy(k * n, 0.0), 
+                    A_hat(m * n, 0.0),
+                    A_k(m * n, 0.0),  
+                    A_cpy(m * n, 0.0),  
+                    A_cpy_2(m * n, 0.0),
+                    A_cpy_3(m * n, 0.0),
+                    s(n, 0.0),
+                    S(n * n, 0.0),
+                    U(m * n, 0.0),
+                    VT(n * n, 0.0)
+                    {}
     };
 
     template <typename T, typename RNG>
-    static void computational_helper(int64_t m, int64_t n, QBTestData<T>& all_data) {
+    struct algorithm_objects {
+        RandLAPACK::PLUL<T> Stab;
+        RandLAPACK::RS<T, RNG> RS;
+        RandLAPACK::CholQRQ<T> Orth_RF;
+        RandLAPACK::RF<T> RF;
+        RandLAPACK::CholQRQ<T> Orth_QB;
+        RandLAPACK::QB<T> QB;
+
+        algorithm_objects(bool verbosity, 
+                            bool cond_check, 
+                            bool orth_check, 
+                            int64_t p, 
+                            int64_t passes_per_iteration, 
+                            RandBLAS::base::RNGState<RNG> state) :
+                            Stab(cond_check, verbosity),
+                            RS(Stab, state, p, passes_per_iteration, verbosity, cond_check),
+                            Orth_RF(cond_check, verbosity),
+                            RF(RS, Orth_RF, verbosity, cond_check),
+                            Orth_QB(cond_check, verbosity),
+                            QB(RF, Orth_QB, verbosity, orth_check)
+                            {}
+    };
+
+    template <typename T>
+    static void svd_and_copy_computational_helper(int64_t m, int64_t n, QBTestData<T>& all_data) {
         
         // Create a copy of the original matrix
         blas::copy(m * n, all_data.A.data(), 1, all_data.A_cpy.data(), 1);
@@ -60,13 +84,6 @@ class TestQB : public ::testing::Test
         lapack::gesdd(Job::SomeVec, m, n, all_data.A_cpy.data(), m, all_data.s.data(), all_data.U.data(), m, all_data.VT.data(), n);
     }
 
-    template <typename T, typename RNG>
-    static void computational_helper(int64_t m, int64_t n, T& norm_A, QBTestData<T>& all_data) {
-
-        // pre-compute norm
-        norm_A = lapack::lange(Norm::Fro, m, n, all_data.A.data(), m);
-    }
-
     /// General test for QB:
     /// Computes QB factorzation, and checks:
     /// 1. A - QB
@@ -74,9 +91,14 @@ class TestQB : public ::testing::Test
     /// 3. I - \transpose{Q}Q
     /// 4. A_k - QB = U_k\Sigma_k\transpose{V_k} - QB
     template <typename T, typename RNG>
-    static void test_QB2_low_exact_rank(int64_t m, int64_t n, int64_t k, int64_t p, int64_t block_sz, T tol, RandBLAS::base::RNGState<RNG> state, QBTestData<T>& all_data) {
-
-        printf("|==================================TEST QB2 GENERAL BEGIN==================================|\n");
+    static void test_QB2_low_exact_rank(
+        int64_t m, 
+        int64_t n, 
+        int64_t k,  
+        int64_t block_sz, 
+        T tol,  
+        QBTestData<T>& all_data,
+        algorithm_objects<T, RNG>& all_algs) {
 
         T* A_dat = all_data.A.data();
         T* A_hat_dat = all_data.A_hat.data();
@@ -88,27 +110,8 @@ class TestQB : public ::testing::Test
         T* S_dat = all_data.S.data();
         T* VT_dat = all_data.VT.data();
 
-        //Subroutine parameters
-        bool verbosity = false;
-        bool cond_check = true;
-        bool orth_check = true;
-        int64_t passes_per_iteration = 1;
-
-        // Make subroutine objects
-        // Stabilization Constructor - Choose PLU
-        RandLAPACK::PLUL<T> Stab(cond_check, verbosity);
-        // RowSketcher constructor - Choose default (rs1)
-        RandLAPACK::RS<T, RNG> RS(Stab, state, p, passes_per_iteration, verbosity, cond_check);
-        // Orthogonalization Constructor - Choose CholQR
-        RandLAPACK::CholQRQ<T> Orth_RF(cond_check, verbosity);
-        // RangeFinder constructor - Choose default (rf1)
-        RandLAPACK::RF<T> RF(RS, Orth_RF, verbosity, cond_check);
-        // Orthogonalization Constructor - Choose CholQR
-        RandLAPACK::CholQRQ<T> Orth_QB(cond_check, verbosity);
-        // QB constructor - Choose defaut (QB2)
-        RandLAPACK::QB<T> QB(RF, Orth_QB, verbosity, orth_check);
         // Regular QB2 call
-        QB.call(m, n, all_data.A, k, block_sz, tol, all_data.Q, all_data.B);
+        all_algs.QB.call(m, n, all_data.A, k, block_sz, tol, all_data.Q, all_data.B);
 
         // Reassing pointers because Q, B have been resized
         T* Q_dat = all_data.Q.data();
@@ -133,11 +136,8 @@ class TestQB : public ::testing::Test
         // TEST 3: Q'Q = I
         blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, Q_dat, m, -1.0, Ident_dat, k);
 
-        // buffer zero vector
-        // buffer zero vector
-        std::vector<T> z_buf(n, 0.0);
         // zero out the trailing singular values
-        blas::copy(n - k, z_buf.data(), 1, s_dat + k, 1);
+        std::fill(s_dat + k, s_dat + n, 0.0);
         RandLAPACK::util::diag(n, n, all_data.s, n, all_data.S);
 
         // TEST 4: Below is A_k - A_hat = A_k - QB
@@ -162,7 +162,6 @@ class TestQB : public ::testing::Test
         T norm_test_4 = lapack::lange(Norm::Fro, m, n, A_hat_dat, m);
         printf("FRO NORM OF A_k - QB:  %e\n", norm_test_4);
         ASSERT_NEAR(norm_test_4, 0, test_tol);
-        printf("|===================================TEST QB2 GENERAL END===================================|\n");
     }
 
     /// k = min(m, n) test for CholQRCP:
@@ -171,15 +170,12 @@ class TestQB : public ::testing::Test
     template <typename T, typename RNG>
     static void test_QB2_k_eq_min(
         int64_t m, 
-        int64_t n, 
-        int64_t p, 
+        int64_t n,  
         int64_t block_sz, 
         T tol, 
-        RandBLAS::base::RNGState<RNG> state,
         T& norm_A, 
-        QBTestData<T>& all_data) {
-
-        printf("|===============================TEST QB2 K = min(M, N) BEGIN===============================|\n");
+        QBTestData<T>& all_data,
+        algorithm_objects<T, RNG>& all_algs) {
 
         int64_t k_est = std::min(m, n);
 
@@ -188,27 +184,8 @@ class TestQB : public ::testing::Test
         T* B_dat = all_data.B.data();
         T* A_hat_dat = all_data.A_hat.data();
 
-        //Subroutine parameters
-        bool verbosity = false;
-        bool cond_check = true;
-        bool orth_check = true;
-        int64_t passes_per_iteration = 1;
-
-        // Make subroutine objects
-        // Stabilization Constructor - Choose CholQR
-        RandLAPACK::PLUL<T> Stab(cond_check, verbosity);
-        // RowSketcher constructor - Choose default (rs1)
-        RandLAPACK::RS<T, RNG> RS(Stab, state, p, passes_per_iteration, verbosity, cond_check);
-        // Orthogonalization Constructor - Choose CholQR
-        RandLAPACK::CholQRQ<T> Orth_RF(cond_check, verbosity);
-        // RangeFinder constructor - Choose default (rf1)
-        RandLAPACK::RF<T> RF(RS, Orth_RF, verbosity, cond_check);
-        // Orthogonalization Constructor - Choose CholQR
-        RandLAPACK::CholQRQ<T> Orth_QB(cond_check, verbosity);
-        // QB constructor - Choose defaut (QB2)
-        RandLAPACK::QB<T> QB(RF, Orth_QB, verbosity, orth_check);
         // Regular QB2 call
-        QB.call(m, n, all_data.A, k_est, block_sz, tol, all_data.Q, all_data.B);
+        all_algs.QB.call(m, n, all_data.A, k_est, block_sz, tol, all_data.Q, all_data.B);
 
         // Reassing pointers because Q, B have been resized
         Q_dat = all_data.Q.data();
@@ -234,7 +211,6 @@ class TestQB : public ::testing::Test
             printf("FRO NORM OF A:         %e\n", norm_A);
             EXPECT_TRUE(norm_test_1 <= (tol * norm_A));
         }
-        printf("|================================TEST QB2 K = min(M, N) END================================|\n");
     }
 };
 
@@ -244,15 +220,22 @@ TEST_F(TestQB, Polynomial_Decay_general1)
     int64_t n = 100;
     int64_t k = 50;
     int64_t p = 5;
+    int64_t passes_per_iteration = 1;
     int64_t block_sz = 10;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
+    
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+    bool orth_check = true;
 
     QBTestData<double> all_data(m, n, k);
-    
+    algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, orth_check, p, passes_per_iteration, state);
+
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    computational_helper<double, r123::Philox4x32>(m, n, all_data);
-    test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, p, block_sz, tol, state, all_data);
+    svd_and_copy_computational_helper<double>(m, n, all_data);
+    test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, block_sz, tol, all_data, all_algs);
 }
 
 TEST_F(TestQB, Polynomial_Decay_general2)
@@ -261,15 +244,22 @@ TEST_F(TestQB, Polynomial_Decay_general2)
     int64_t n = 100;
     int64_t k = 50;
     int64_t p = 5;
+    int64_t passes_per_iteration = 1;
     int64_t block_sz = 2;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
+    
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+    bool orth_check = true;
 
     QBTestData<double> all_data(m, n, k);
+    algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, orth_check, p, passes_per_iteration, state);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 6.7, false));
-    computational_helper<double, r123::Philox4x32>(m, n, all_data);
-    test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, p, block_sz, tol, state, all_data);
+    svd_and_copy_computational_helper<double>(m, n, all_data);
+    test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, block_sz, tol, all_data, all_algs);
 }
 
 TEST_F(TestQB, Rand_diag_general)
@@ -278,15 +268,22 @@ TEST_F(TestQB, Rand_diag_general)
     int64_t n = 100;
     int64_t k = 50;
     int64_t p = 5;
+    int64_t passes_per_iteration = 1;
     int64_t block_sz = 2;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
 
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+    bool orth_check = true;
+
     QBTestData<double> all_data(m, n, k);
+    algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, orth_check, p, passes_per_iteration, state);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(4, 0, false));
-    computational_helper<double, r123::Philox4x32>(m, n, all_data);
-    test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, p, block_sz, tol, state, all_data);
+    svd_and_copy_computational_helper<double>(m, n, all_data);
+    test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, block_sz, tol, all_data, all_algs);
 }
 
 TEST_F(TestQB, Polynomial_Decay_zero_tol1)
@@ -295,16 +292,22 @@ TEST_F(TestQB, Polynomial_Decay_zero_tol1)
     int64_t n = 100;
     int64_t k = 50;
     int64_t p = 5;
+    int64_t passes_per_iteration = 1;
     int64_t block_sz = 10;
-    double norm_A = 0;
     double tol = (double) 0.1;
     auto state = RandBLAS::base::RNGState();
 
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+    bool orth_check = true;
+
     QBTestData<double> all_data(m, n, k);
+    algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, orth_check, p, passes_per_iteration, state);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    computational_helper<double, r123::Philox4x32>(m, n, norm_A, all_data);
-    test_QB2_k_eq_min<double, r123::Philox4x32>(m, n, p, block_sz, tol, state, norm_A, all_data);
+    double norm_A = lapack::lange(Norm::Fro, m, n, all_data.A.data(), m);
+    test_QB2_k_eq_min<double, r123::Philox4x32>(m, n, block_sz, tol, norm_A, all_data, all_algs);
 }
 
 TEST_F(TestQB, Polynomial_Decay_zero_tol2)
@@ -313,14 +316,20 @@ TEST_F(TestQB, Polynomial_Decay_zero_tol2)
     int64_t n = 100;
     int64_t k = 50;
     int64_t p = 5;
+    int64_t passes_per_iteration = 1;
     int64_t block_sz = 10;
-    double norm_A = 0;
     double tol = 0.0;
     auto state = RandBLAS::base::RNGState();
 
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+    bool orth_check = true;
+
     QBTestData<double> all_data(m, n, k);
+    algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, orth_check, p, passes_per_iteration, state);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    computational_helper<double, r123::Philox4x32>(m, n, norm_A, all_data);
-    test_QB2_k_eq_min<double, r123::Philox4x32>(m, n, p, block_sz, tol, state, norm_A, all_data);
+    double norm_A = lapack::lange(Norm::Fro, m, n, all_data.A.data(), m);
+    test_QB2_k_eq_min<double, r123::Philox4x32>(m, n, block_sz, tol, norm_A, all_data, all_algs);
 }

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -30,31 +30,23 @@ class TestQB : public ::testing::Test
         std::vector<T>& S;
         std::vector<T>& U;
         std::vector<T>& VT;
+
+        QBTestData(int64_t m, int64_t n, int64_t k) :
+        A(m * n, 0.0), 
+        Q(m * k, 0.0), 
+        B(k * n, 0.0), 
+        B_cpy(k * n, 0.0), 
+        A_hat(m * n, 0.0),
+        A_k(m * n, 0.0),  
+        A_cpy(m * n, 0.0),  
+        A_cpy_2(m * n, 0.0),
+        A_cpy_3(m * n, 0.0),
+        s(n, 0.0),
+        S(n * n, 0.0),
+        U(m * n, 0.0),
+        VT(n * n, 0.0)
+        {}
     };
-
-    template <typename T>
-    static QBTestData<T> allocation_helper(int64_t m, int64_t n,  int64_t k) {
-
-        // For running QB
-        std::vector<double> A    (m * n, 0.0);
-        std::vector<double> Q    (m * k, 0.0);
-        std::vector<double> B    (k * n, 0.0);
-        std::vector<double> B_cpy(k * n, 0.0);
-        // For results comparison
-        std::vector<double> A_hat   (m * n, 0.0);
-        std::vector<double> A_k     (m * n, 0.0);
-        std::vector<double> A_cpy   (m * n, 0.0);
-        std::vector<double> A_cpy_2 (m * n, 0.0);
-        std::vector<double> A_cpy_3 (m * n, 0.0);
-        // For low-rank SVD
-        std::vector<double> s (n, 0.0);
-        std::vector<double> S (n * n, 0.0);
-        std::vector<double> U (m * n, 0.0);
-        std::vector<double> VT(n * n, 0.0);
-
-        QBTestData<double> all_data =  {A, Q, B, B_cpy, A_hat, A_k, A_cpy, A_cpy_2, A_cpy_3, s, S, U, VT};
-        return all_data;
-    }
 
     template <typename T, typename RNG>
     static void computational_helper(int64_t m, int64_t n, T& norm_A, QBTestData<T>* all_data) {
@@ -291,7 +283,7 @@ TEST_F(TestQB, Polynomial_Decay)
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
 
-    QBTestData<double> all_data = allocation_helper<double>(m, n, k);
+    QBTestData<double> all_data(m, n, k);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
     /*

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -32,20 +32,20 @@ class TestQB : public ::testing::Test
         std::vector<T> VT;
 
         QBTestData(int64_t m, int64_t n, int64_t k) :
-                    A(m * n, 0.0), 
-                    Q(m * k, 0.0), 
-                    B(k * n, 0.0), 
-                    B_cpy(k * n, 0.0), 
-                    A_hat(m * n, 0.0),
-                    A_k(m * n, 0.0),  
-                    A_cpy(m * n, 0.0),  
-                    A_cpy_2(m * n, 0.0),
-                    A_cpy_3(m * n, 0.0),
-                    s(n, 0.0),
-                    S(n * n, 0.0),
-                    U(m * n, 0.0),
-                    VT(n * n, 0.0)
-                    {}
+            A(m * n, 0.0), 
+            Q(m * k, 0.0), 
+            B(k * n, 0.0), 
+            B_cpy(k * n, 0.0), 
+            A_hat(m * n, 0.0),
+            A_k(m * n, 0.0),  
+            A_cpy(m * n, 0.0),  
+            A_cpy_2(m * n, 0.0),
+            A_cpy_3(m * n, 0.0),
+            s(n, 0.0),
+            S(n * n, 0.0),
+            U(m * n, 0.0),
+            VT(n * n, 0.0)
+            {}
     };
 
     template <typename T, typename RNG>

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -272,23 +272,6 @@ TEST_F(TestQB, Polynomial_Decay_general2)
     test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, p, block_sz, tol, state, all_data);
 }
 
-TEST_F(TestQB, Zero_Mat_general)
-{
-    int64_t m = 100;
-    int64_t n = 100;
-    int64_t k = 50;
-    int64_t p = 5;
-    int64_t block_sz = 2;
-    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
-    auto state = RandBLAS::base::RNGState();
-
-    QBTestData<double> all_data(m, n, k);
-    
-    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(3, 0, false));
-    computational_helper<double, r123::Philox4x32>(m, n, all_data);
-    test_QB2_low_exact_rank<double, r123::Philox4x32>(m, n, k, p, block_sz, tol, state, all_data);
-}
-
 TEST_F(TestQB, Rand_diag_general)
 {
     int64_t m = 100;

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -16,11 +16,11 @@ class TestRF : public ::testing::Test
     virtual void TearDown() {};
 
     template <typename T>
-    struct QBTestData {
+    struct RFTestData {
         std::vector<T> A;
         std::vector<T> Q;
 
-        QBTestData(int64_t m, int64_t n, int64_t k) :
+        RFTestData(int64_t m, int64_t n, int64_t k) :
         A(m * n, 0.0), 
         Q(m * k, 0.0) 
         {}
@@ -33,7 +33,7 @@ class TestRF : public ::testing::Test
     /// 3. I - \transpose{Q}Q
     /// 4. A_k - QB = U_k\Sigma_k\transpose{V_k} - QB
     template <typename T, typename RNG>
-    static void test_RF_general(int64_t m, int64_t n, int64_t k, int64_t p, RandBLAS::base::RNGState<RNG> state, QBTestData<T>& all_data) {
+    static void test_RF_general(int64_t m, int64_t n, int64_t k, int64_t p, RandBLAS::base::RNGState<RNG> state, RFTestData<T>& all_data) {
 
         printf("|==================================TEST QB2 GENERAL BEGIN==================================|\n");
 
@@ -81,7 +81,7 @@ TEST_F(TestRF, Polynomial_Decay_general1)
     int64_t p = 5;
     auto state = RandBLAS::base::RNGState();
 
-    QBTestData<double> all_data(m, n, k);
+    RFTestData<double> all_data(m, n, k);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
     test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
@@ -95,7 +95,7 @@ TEST_F(TestRF, Polynomial_Decay_general2)
     int64_t p = 5;
     auto state = RandBLAS::base::RNGState();
 
-    QBTestData<double> all_data(m, n, k);
+    RFTestData<double> all_data(m, n, k);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 6.7, false));
     test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
@@ -109,7 +109,7 @@ TEST_F(TestRF, Rand_diag_general)
     int64_t p = 5;
     auto state = RandBLAS::base::RNGState();
 
-    QBTestData<double> all_data(m, n, k);
+    RFTestData<double> all_data(m, n, k);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(4, 0, false));
     test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -1,0 +1,116 @@
+#include "RandLAPACK.hh"
+#include "rl_blaspp.hh"
+#include "rl_lapackpp.hh"
+
+#include <RandBLAS.hh>
+
+#include <fstream>
+#include <gtest/gtest.h>
+
+class TestRF : public ::testing::Test
+{
+    protected:
+
+    virtual void SetUp() {};
+
+    virtual void TearDown() {};
+
+    template <typename T>
+    struct QBTestData {
+        std::vector<T> A;
+        std::vector<T> Q;
+
+        QBTestData(int64_t m, int64_t n, int64_t k) :
+        A(m * n, 0.0), 
+        Q(m * k, 0.0) 
+        {}
+    };
+
+    /// General test for QB:
+    /// Computes QB factorzation, and checks:
+    /// 1. A - QB
+    /// 2. B - \transpose{Q}A
+    /// 3. I - \transpose{Q}Q
+    /// 4. A_k - QB = U_k\Sigma_k\transpose{V_k} - QB
+    template <typename T, typename RNG>
+    static void test_RF_general(int64_t m, int64_t n, int64_t k, int64_t p, RandBLAS::base::RNGState<RNG> state, QBTestData<T>& all_data) {
+
+        printf("|==================================TEST QB2 GENERAL BEGIN==================================|\n");
+
+        //Subroutine parameters
+        bool verbosity = false;
+        bool cond_check = true;
+        int64_t passes_per_iteration = 1;
+
+        // Make subroutine objects
+        // Stabilization Constructor - Choose PLU
+        RandLAPACK::PLUL<T> Stab(cond_check, verbosity);
+        // RowSketcher constructor - Choose default (rs1)
+        RandLAPACK::RS<T, RNG> RS(Stab, state, p, passes_per_iteration, verbosity, cond_check);
+        // Orthogonalization Constructor - Choose CholQR
+        RandLAPACK::HQRQ<T> Orth_RF(cond_check, verbosity);
+        // RangeFinder constructor - Choose default (rf1)
+        RandLAPACK::RF<T> RF(RS, Orth_RF, verbosity, cond_check);
+
+        RF.call(m, n, all_data.A, k, all_data.Q);
+
+        // Reassing pointers because Q, B have been resized
+        T* Q_dat = all_data.Q.data();
+
+        std::vector<T> Ident(k * k, 0.0);
+        T* Ident_dat = Ident.data();
+        // Generate a reference identity
+        RandLAPACK::util::eye(k, k, Ident);
+
+        // TEST 1: Q'Q = I
+        blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, Q_dat, m, -1.0, Ident_dat, k);
+
+        T test_tol = std::pow(std::numeric_limits<T>::epsilon(), 0.625);
+        // Test 1 Output
+        T norm_test_1 = lapack::lansy(lapack::Norm::Fro, Uplo::Upper, k, Ident_dat, k);
+        printf("FRO NORM OF Q'Q - I:   %e\n", norm_test_1);
+        ASSERT_NEAR(norm_test_1, 0, test_tol);
+    }
+};
+
+TEST_F(TestRF, Polynomial_Decay_general1)
+{
+    int64_t m = 100;
+    int64_t n = 100;
+    int64_t k = 50;
+    int64_t p = 5;
+    auto state = RandBLAS::base::RNGState();
+
+    QBTestData<double> all_data(m, n, k);
+    
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
+    test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
+}
+
+TEST_F(TestRF, Polynomial_Decay_general2)
+{
+    int64_t m = 100;
+    int64_t n = 100;
+    int64_t k = 50;
+    int64_t p = 5;
+    auto state = RandBLAS::base::RNGState();
+
+    QBTestData<double> all_data(m, n, k);
+    
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 6.7, false));
+    test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
+}
+
+TEST_F(TestRF, Rand_diag_general)
+{
+    int64_t m = 100;
+    int64_t n = 100;
+    int64_t k = 50;
+    int64_t p = 5;
+    auto state = RandBLAS::base::RNGState();
+
+    QBTestData<double> all_data(m, n, k);
+    
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(4, 0, false));
+    test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
+}

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -112,6 +112,10 @@ class TestRF : public ::testing::Test
         T norm2_test_2 = lapack::lange(Norm::Fro, m, k, Q_cpy_dat, m);
         printf("FRO NORM OF QQ' * Q_hat - Q_hat:   %e\n", norm1_test_2);
         printf("FRO NORM OF Q_hat Q_hat' * Q = Q:   %e\n", norm2_test_2);
+        if(k == n) {
+            ASSERT_NEAR(norm1_test_2, 0, test_tol);
+            ASSERT_NEAR(norm1_test_2, 0, test_tol);
+        }
     }
 };
 
@@ -119,7 +123,7 @@ TEST_F(TestRF, Polynomial_Decay_general1)
 {
     int64_t m = 100;
     int64_t n = 100;
-    int64_t k = 50;
+    int64_t k = 100;
     int64_t p = 5;
     auto state = RandBLAS::base::RNGState();
 
@@ -129,7 +133,7 @@ TEST_F(TestRF, Polynomial_Decay_general1)
     computational_helper<double, r123::Philox4x32>(m, n, all_data);
     test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
 }
-/*
+
 TEST_F(TestRF, Polynomial_Decay_general2)
 {
     int64_t m = 100;
@@ -157,4 +161,3 @@ TEST_F(TestRF, Rand_diag_general)
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(4, 0, false));
     test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
 }
-*/

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -37,6 +37,25 @@ class TestRF : public ::testing::Test
     };
 
     template <typename T, typename RNG>
+    struct algorithm_objects {
+        RandLAPACK::PLUL<T> Stab;
+        RandLAPACK::RS<T, RNG> RS;
+        RandLAPACK::HQRQ<T> Orth_RF;
+        RandLAPACK::RF<T> RF;
+
+        algorithm_objects(bool verbosity, 
+                            bool cond_check, 
+                            int64_t p, 
+                            int64_t passes_per_iteration, 
+                            RandBLAS::base::RNGState<RNG> state) :
+                            Stab(cond_check, verbosity),
+                            RS(Stab, state, p, passes_per_iteration, verbosity, cond_check),
+                            Orth_RF(cond_check, verbosity),
+                            RF(RS, Orth_RF, verbosity, cond_check)
+                            {}
+    };
+
+    template <typename T, typename RNG>
     static void orth_and_copy_computational_helper(int64_t m, int64_t n, RFTestData<T>& all_data) {
         
         lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
@@ -54,24 +73,14 @@ class TestRF : public ::testing::Test
     /// 3. I - \transpose{Q}Q
     /// 4. A_k - QB = U_k\Sigma_k\transpose{V_k} - QB
     template <typename T, typename RNG>
-    static void test_RF_general(int64_t m, int64_t n, int64_t k, int64_t p, RandBLAS::base::RNGState<RNG> state, RFTestData<T>& all_data) {
+    static void test_RF_general(
+        int64_t m, 
+        int64_t n, 
+        int64_t k, 
+        RFTestData<T>& all_data, 
+        algorithm_objects<T, RNG>& all_algs) {
 
-        //Subroutine parameters
-        bool verbosity = false;
-        bool cond_check = true;
-        int64_t passes_per_iteration = 1;
-
-        // Make subroutine objects
-        // Stabilization Constructor - Choose PLU
-        RandLAPACK::PLUL<T> Stab(cond_check, verbosity);
-        // RowSketcher constructor - Choose default (rs1)
-        RandLAPACK::RS<T, RNG> RS(Stab, state, p, passes_per_iteration, verbosity, cond_check);
-        // Orthogonalization Constructor - Choose CholQR
-        RandLAPACK::HQRQ<T> Orth_RF(cond_check, verbosity);
-        // RangeFinder constructor - Choose default (rf1)
-        RandLAPACK::RF<T> RF(RS, Orth_RF, verbosity, cond_check);
-
-        RF.call(m, n, all_data.A, k, all_data.Q);
+        all_algs.RF.call(m, n, all_data.A, k, all_data.Q);
 
         // Reassing pointers because Q, B have been resized
         T* Q_dat = all_data.Q.data();
@@ -123,13 +132,20 @@ TEST_F(TestRF, Polynomial_Decay_general1)
     int64_t n = 100;
     int64_t k = 100;
     int64_t p = 5;
+    int64_t passes_per_iteration = 1;
     auto state = RandBLAS::base::RNGState();
 
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+
     RFTestData<double> all_data(m, n, k);
+    algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
     orth_and_copy_computational_helper<double, r123::Philox4x32>(m, n, all_data);
-    test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
+    
+    test_RF_general<double, r123::Philox4x32>(m, n, k, all_data, all_algs);
 }
 
 TEST_F(TestRF, Polynomial_Decay_general2)
@@ -138,13 +154,20 @@ TEST_F(TestRF, Polynomial_Decay_general2)
     int64_t n = 100;
     int64_t k = 50;
     int64_t p = 5;
+    int64_t passes_per_iteration = 1;
     auto state = RandBLAS::base::RNGState();
 
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+
     RFTestData<double> all_data(m, n, k);
+    algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
-    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 6.7, false));
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
     orth_and_copy_computational_helper<double, r123::Philox4x32>(m, n, all_data);
-    test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
+    
+    test_RF_general<double, r123::Philox4x32>(m, n, k, all_data, all_algs);
 }
 
 TEST_F(TestRF, Rand_diag_general)
@@ -153,11 +176,18 @@ TEST_F(TestRF, Rand_diag_general)
     int64_t n = 100;
     int64_t k = 50;
     int64_t p = 5;
+    int64_t passes_per_iteration = 1;
     auto state = RandBLAS::base::RNGState();
 
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+
     RFTestData<double> all_data(m, n, k);
+    algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
-    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(4, 0, false));
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
     orth_and_copy_computational_helper<double, r123::Philox4x32>(m, n, all_data);
-    test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
+    
+    test_RF_general<double, r123::Philox4x32>(m, n, k, all_data, all_algs);
 }

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -37,7 +37,7 @@ class TestRF : public ::testing::Test
     };
 
     template <typename T, typename RNG>
-    static void computational_helper(int64_t m, int64_t n, RFTestData<T>& all_data) {
+    static void orth_and_copy_computational_helper(int64_t m, int64_t n, RFTestData<T>& all_data) {
         
         lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
         
@@ -55,8 +55,6 @@ class TestRF : public ::testing::Test
     /// 4. A_k - QB = U_k\Sigma_k\transpose{V_k} - QB
     template <typename T, typename RNG>
     static void test_RF_general(int64_t m, int64_t n, int64_t k, int64_t p, RandBLAS::base::RNGState<RNG> state, RFTestData<T>& all_data) {
-
-        printf("|==================================TEST QB2 GENERAL BEGIN==================================|\n");
 
         //Subroutine parameters
         bool verbosity = false;
@@ -130,7 +128,7 @@ TEST_F(TestRF, Polynomial_Decay_general1)
     RFTestData<double> all_data(m, n, k);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    orth_and_copy_computational_helper<double, r123::Philox4x32>(m, n, all_data);
     test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
 }
 
@@ -145,6 +143,7 @@ TEST_F(TestRF, Polynomial_Decay_general2)
     RFTestData<double> all_data(m, n, k);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 6.7, false));
+    orth_and_copy_computational_helper<double, r123::Philox4x32>(m, n, all_data);
     test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
 }
 
@@ -159,5 +158,6 @@ TEST_F(TestRF, Rand_diag_general)
     RFTestData<double> all_data(m, n, k);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(4, 0, false));
+    orth_and_copy_computational_helper<double, r123::Philox4x32>(m, n, all_data);
     test_RF_general<double, r123::Philox4x32>(m, n, k, p, state, all_data);
 }

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -17,6 +17,9 @@ class TestRF : public ::testing::Test
 
     template <typename T>
     struct RFTestData {
+        int64_t row;
+        int64_t col;
+        int64_t rank;
         std::vector<T> A;
         std::vector<T> A_cpy;
         std::vector<T> Q;
@@ -33,7 +36,11 @@ class TestRF : public ::testing::Test
         Buf2(m * m, 0.0), 
         Q_cpy(m * k, 0.0), 
         Q_hat_cpy(m * n, 0.0) 
-        {}
+        {
+            row = m;
+            col = n;
+            rank = k;
+        }
     };
 
     template <typename T, typename RNG>
@@ -58,8 +65,11 @@ class TestRF : public ::testing::Test
     };
 
     template <typename T, typename RNG>
-    static void orth_and_copy_computational_helper(int64_t m, int64_t n, RFTestData<T>& all_data) {
+    static void orth_and_copy_computational_helper(RFTestData<T>& all_data) {
         
+        auto m = all_data.row;
+        auto n = all_data.col;
+
         lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
         
         RandLAPACK::CholQRQ<T> CholQRQ(false, false);
@@ -76,11 +86,12 @@ class TestRF : public ::testing::Test
     /// 4. A_k - QB = U_k\Sigma_k\transpose{V_k} - QB
     template <typename T, typename RNG>
     static void test_RF_general(
-        int64_t m, 
-        int64_t n, 
-        int64_t k, 
         RFTestData<T>& all_data, 
         algorithm_objects<T, RNG>& all_algs) {
+
+        auto m = all_data.row;
+        auto n = all_data.col;
+        auto k = all_data.rank;
 
         all_algs.RF.call(m, n, all_data.A, k, all_data.Q);
 
@@ -145,9 +156,9 @@ TEST_F(TestRF, Polynomial_Decay_general1)
     algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    orth_and_copy_computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
     
-    test_RF_general<double, r123::Philox4x32>(m, n, k, all_data, all_algs);
+    test_RF_general<double, r123::Philox4x32>(all_data, all_algs);
 }
 
 TEST_F(TestRF, Polynomial_Decay_general2)
@@ -167,9 +178,9 @@ TEST_F(TestRF, Polynomial_Decay_general2)
     algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    orth_and_copy_computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
     
-    test_RF_general<double, r123::Philox4x32>(m, n, k, all_data, all_algs);
+    test_RF_general<double, r123::Philox4x32>(all_data, all_algs);
 }
 
 TEST_F(TestRF, Rand_diag_general)
@@ -189,7 +200,7 @@ TEST_F(TestRF, Rand_diag_general)
     algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    orth_and_copy_computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
     
-    test_RF_general<double, r123::Philox4x32>(m, n, k, all_data, all_algs);
+    test_RF_general<double, r123::Philox4x32>(all_data, all_algs);
 }

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -43,16 +43,18 @@ class TestRF : public ::testing::Test
         RandLAPACK::HQRQ<T> Orth_RF;
         RandLAPACK::RF<T> RF;
 
-        algorithm_objects(bool verbosity, 
-                            bool cond_check, 
-                            int64_t p, 
-                            int64_t passes_per_iteration, 
-                            RandBLAS::base::RNGState<RNG> state) :
-                            Stab(cond_check, verbosity),
-                            RS(Stab, state, p, passes_per_iteration, verbosity, cond_check),
-                            Orth_RF(cond_check, verbosity),
-                            RF(RS, Orth_RF, verbosity, cond_check)
-                            {}
+        algorithm_objects(
+            bool verbosity, 
+            bool cond_check, 
+            int64_t p, 
+            int64_t passes_per_iteration, 
+            RandBLAS::base::RNGState<RNG> state
+        ) :
+            Stab(cond_check, verbosity),
+            RS(Stab, state, p, passes_per_iteration, verbosity, cond_check),
+            Orth_RF(cond_check, verbosity),
+            RF(RS, Orth_RF, verbosity, cond_check)
+            {}
     };
 
     template <typename T, typename RNG>

--- a/test/comps/test_util.cc
+++ b/test/comps/test_util.cc
@@ -27,28 +27,32 @@ class TestUtil : public ::testing::Test
     virtual void TearDown() {};
 
     template <typename T>
-    struct UtilTestData {
+    struct SpectralTestData {
         std::vector<T> A;
         std::vector<T> A_cpy;
         std::vector<T> s;
+
+        SpectralTestData(int64_t m, int64_t n) :
+        A(m * n, 0.0),
+        A_cpy(m * n, 0.0), 
+        s(n, 0.0)
+        {}
+    };
+
+    template <typename T>
+    struct NormcTestData {
+        std::vector<T> A;
         std::vector<T> A_norm;
 
-        UtilTestData(int64_t m, int64_t n) :
+        NormcTestData(int64_t m, int64_t n) :
         A(m * n, 0.0), 
-        A_cpy(m * n, 0.0), 
-        s(n, 0.0),
         A_norm(m * n, 0.0) 
         {}
     };
 
     template <typename T, typename RNG>
-    static void computational_helper(int64_t m, int64_t n, UtilTestData<T>& all_data) {
-        lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
-    }
-
-    template <typename T, typename RNG>
     static void 
-    test_spectral_norm(int64_t m, int64_t n, RandBLAS::base::RNGState<RNG> state, UtilTestData<T>& all_data) {
+    test_spectral_norm(int64_t m, int64_t n, RandBLAS::base::RNGState<RNG> state, SpectralTestData<T>& all_data) {
 
         T norm = RandLAPACK::util::estimate_spectral_norm(m, n, all_data.A.data(), 10000, state);
         // Get an SVD -> first singular value == 2_norm
@@ -60,7 +64,7 @@ class TestUtil : public ::testing::Test
 
     template <typename T>
     static void 
-    test_normc(int64_t m, UtilTestData<T>& all_data) {
+    test_normc(int64_t m, NormcTestData<T>& all_data) {
         
         int cnt = 0;
         // we have a vector with entries 10:m, first 10 entries = 0
@@ -77,9 +81,9 @@ class TestUtil : public ::testing::Test
 
     template <typename T>
     static void 
-    test_binary_rank_search_zero_mat(int64_t m, int64_t n, UtilTestData<T>& all_data) {
+    test_binary_rank_search_zero_mat(int64_t m, int64_t n, std::vector<T>& A) {
         
-        int64_t k = RandLAPACK::util::rank_search_binary(0, m, 0, n, 0.0, std::pow(std::numeric_limits<T>::epsilon(), 0.75), all_data.A.data());
+        int64_t k = RandLAPACK::util::rank_search_binary(0, m, 0, n, 0.0, std::pow(std::numeric_limits<T>::epsilon(), 0.75), A.data());
 
         printf("K IS %ld\n", k);
         ASSERT_EQ(k, 0);
@@ -91,10 +95,10 @@ TEST_F(TestUtil, test_spectral_norm_polynomial_decay_double_precision) {
     int64_t m = 1000;
     int64_t n = 100;
     auto state = RandBLAS::base::RNGState();
-    UtilTestData<double> all_data(m, n);
+    SpectralTestData<double> all_data(m, n);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(0, 2025, false));
-    computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
     test_spectral_norm<double, r123::Philox4x32>(m, n, state, all_data);
 }
 
@@ -103,10 +107,10 @@ TEST_F(TestUtil, test_spectral_norm_rank_def_mat_double_precision) {
     int64_t m = 1000;
     int64_t n = 100;
     auto state = RandBLAS::base::RNGState();
-    UtilTestData<double> all_data(m, n);
+    SpectralTestData<double> all_data(m, n);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(9, std::pow(10, 15), false));
-    computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
     test_spectral_norm<double, r123::Philox4x32>(m, n, state, all_data);
 }
 
@@ -115,10 +119,10 @@ TEST_F(TestUtil, test_spectral_norm_polynomial_decay_single_precision) {
     int64_t m = 1000;
     int64_t n = 100;
     auto state = RandBLAS::base::RNGState();
-    UtilTestData<float> all_data(m, n);
+    SpectralTestData<float> all_data(m, n);
 
     RandLAPACK::util::gen_mat_type<float, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(0, 2, false));
-    computational_helper<float, r123::Philox4x32>(m, n, all_data);
+    lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
     test_spectral_norm<float, r123::Philox4x32>(m, n, state, all_data);
 }
 
@@ -127,17 +131,17 @@ TEST_F(TestUtil, test_spectral_norm_rank_def_mat_single_precision) {
     int64_t m = 1000;
     int64_t n = 100;
     auto state = RandBLAS::base::RNGState();
-    UtilTestData<float> all_data(m, n);
+    SpectralTestData<float> all_data(m, n);
 
     RandLAPACK::util::gen_mat_type<float, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(9, std::pow(10, 7), false));
-    computational_helper<float, r123::Philox4x32>(m, n, all_data);
+    lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
     test_spectral_norm<float, r123::Philox4x32>(m, n, state, all_data);
 }
 
 TEST_F(TestUtil, test_normc) {
     int64_t m = 1000;
     int64_t n = 1;
-    UtilTestData<double> all_data(m, n);
+    NormcTestData<double> all_data(m, n);
 
     test_normc<double>(m, all_data);
 }
@@ -145,7 +149,7 @@ TEST_F(TestUtil, test_normc) {
 TEST_F(TestUtil, test_binary_rank_search_zero_mat) {
     int64_t m = 1000;
     int64_t n = 100;
-    UtilTestData<double> all_data(m, n);
+    std::vector<double> A(m * n, 0.0); 
 
-    test_binary_rank_search_zero_mat<double>(m, n, all_data);
+    test_binary_rank_search_zero_mat<double>(m, n, A);
 }

--- a/test/comps/test_util.cc
+++ b/test/comps/test_util.cc
@@ -107,7 +107,7 @@ TEST_F(TestUtil, test_spectral_norm_rank_def_mat_double_precision) {
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(9, std::pow(10, 15), false));
     computational_helper<double, r123::Philox4x32>(m, n, all_data);
-    test_spectral_norm<double, r123::Philox4x32>(1000, 100, state, all_data);
+    test_spectral_norm<double, r123::Philox4x32>(m, n, state, all_data);
 }
 
 TEST_F(TestUtil, test_spectral_norm_polynomial_decay_single_precision) {
@@ -131,7 +131,7 @@ TEST_F(TestUtil, test_spectral_norm_rank_def_mat_single_precision) {
 
     RandLAPACK::util::gen_mat_type<float, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(9, std::pow(10, 7), false));
     computational_helper<float, r123::Philox4x32>(m, n, all_data);
-    test_spectral_norm<float, r123::Philox4x32>(1000, 100, state, all_data);
+    test_spectral_norm<float, r123::Philox4x32>(m, n, state, all_data);
 }
 
 TEST_F(TestUtil, test_normc) {
@@ -147,5 +147,5 @@ TEST_F(TestUtil, test_binary_rank_search_zero_mat) {
     int64_t n = 100;
     UtilTestData<double> all_data(m, n);
 
-    test_binary_rank_search_zero_mat<double>(1000, 100, all_data);
+    test_binary_rank_search_zero_mat<double>(m, n, all_data);
 }

--- a/test/comps/test_util.cc
+++ b/test/comps/test_util.cc
@@ -26,68 +26,126 @@ class TestUtil : public ::testing::Test
 
     virtual void TearDown() {};
 
+    template <typename T>
+    struct UtilTestData {
+        std::vector<T> A;
+        std::vector<T> A_cpy;
+        std::vector<T> s;
+        std::vector<T> A_norm;
+
+        UtilTestData(int64_t m, int64_t n) :
+        A(m * n, 0.0), 
+        A_cpy(m * n, 0.0), 
+        s(n, 0.0),
+        A_norm(m * n, 0.0) 
+        {}
+    };
+
+    template <typename T, typename RNG>
+    static void computational_helper(int64_t m, int64_t n, UtilTestData<T>& all_data) {
+        lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
+    }
+
     template <typename T, typename RNG>
     static void 
-    test_spectral_norm(int64_t m, int64_t n, std::tuple<int, T, bool> mat_type, RandBLAS::base::RNGState<RNG> state) {
-        
-        std::vector<T> A(m * n, 0.0);
-        std::vector<T> A_cpy(m * n, 0.0);
-        std::vector<T> s(n, 0.0);
-        RandLAPACK::util::gen_mat_type(m, n, A, n, state, mat_type);
+    test_spectral_norm(int64_t m, int64_t n, RandBLAS::base::RNGState<RNG> state, UtilTestData<T>& all_data) {
 
-        T norm = RandLAPACK::util::estimate_spectral_norm(m, n, A.data(), 10000, state);
-
+        T norm = RandLAPACK::util::estimate_spectral_norm(m, n, all_data.A.data(), 10000, state);
         // Get an SVD -> first singular value == 2_norm
-        lapack::lacpy(MatrixType::General, m, n, A.data(), m, A_cpy.data(), m);
-        lapack::gesdd(Job::NoVec, m, n, A_cpy.data(), m, s.data(), NULL, m, NULL, n);
+        lapack::gesdd(Job::NoVec, m, n, all_data.A_cpy.data(), m, all_data.s.data(), NULL, m, NULL, n);
 
-        printf("Computed norm:  %e\nComputed s_max: %e\n", norm, s[0]);
-        ASSERT_NEAR(norm, s[0], std::pow(std::numeric_limits<T>::epsilon(), 0.75));
+        printf("Computed norm:  %e\nComputed s_max: %e\n", norm, all_data.s[0]);
+        ASSERT_NEAR(norm, all_data.s[0], std::pow(std::numeric_limits<T>::epsilon(), 0.75));
     }
 
     template <typename T>
     static void 
-    test_normc(int64_t m) {
+    test_normc(int64_t m, UtilTestData<T>& all_data) {
         
-        std::vector<T> A(m, 0.0);
-        std::vector<T> A_norm(m, 0.0);
         int cnt = 0;
         // we have a vector with entries 10:m, first 10 entries = 0
-        std::for_each(A.begin() + 10, A.end(), [&cnt](T &entry) { entry = ++cnt;});
+        std::for_each(all_data.A.begin() + 10, all_data.A.end(), [&cnt](T &entry) { entry = ++cnt;});
 
         // We expect A_norm to have all 1's
-        RandLAPACK::util::normc(1, m, A, A_norm);
+        RandLAPACK::util::normc(1, m, all_data.A, all_data.A_norm);
 
         // We expect this to be 1;
-        T norm = blas::nrm2(m, A_norm.data(), 1);
+        T norm = blas::nrm2(m, all_data.A_norm.data(), 1);
         printf("norm is%f\n", norm);
         ASSERT_NEAR(norm, std::sqrt(m - 10), std::pow(std::numeric_limits<T>::epsilon(), 0.75));
     }
 
     template <typename T>
     static void 
-    test_binary_rank_search_zero_mat(int64_t m, int64_t n) {
-        std::vector<T> A(m * n, 0.0);
+    test_binary_rank_search_zero_mat(int64_t m, int64_t n, UtilTestData<T>& all_data) {
         
-        int64_t k = RandLAPACK::util::rank_search_binary(0, m, 0, n, 0.0, std::pow(std::numeric_limits<T>::epsilon(), 0.75), A.data());
+        int64_t k = RandLAPACK::util::rank_search_binary(0, m, 0, n, 0.0, std::pow(std::numeric_limits<T>::epsilon(), 0.75), all_data.A.data());
 
         printf("K IS %ld\n", k);
         ASSERT_EQ(k, 0);
     }
 };
 
-TEST_F(TestUtil, test_spectral_norm) {
+TEST_F(TestUtil, test_spectral_norm_polynomial_decay_double_precision) {
+    
+    int64_t m = 1000;
+    int64_t n = 100;
     auto state = RandBLAS::base::RNGState();
-    test_spectral_norm<double, r123::Philox4x32>(1000, 100, std::make_tuple(0, 2, false), state);
-    test_spectral_norm<double, r123::Philox4x32>(1000, 100, std::make_tuple(9, std::pow(10, 15), false), state);
-    test_spectral_norm<float, r123::Philox4x32>(1000, 100, std::make_tuple(0, 2, false), state);
-    test_spectral_norm<float, r123::Philox4x32>(1000, 100, std::make_tuple(9, std::pow(10, 7), false), state);
+    UtilTestData<double> all_data(m, n);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(0, 2025, false));
+    computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    test_spectral_norm<double, r123::Philox4x32>(m, n, state, all_data);
+}
+
+TEST_F(TestUtil, test_spectral_norm_rank_def_mat_double_precision) {
+    
+    int64_t m = 1000;
+    int64_t n = 100;
+    auto state = RandBLAS::base::RNGState();
+    UtilTestData<double> all_data(m, n);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(9, std::pow(10, 15), false));
+    computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    test_spectral_norm<double, r123::Philox4x32>(1000, 100, state, all_data);
+}
+
+TEST_F(TestUtil, test_spectral_norm_polynomial_decay_single_precision) {
+    
+    int64_t m = 1000;
+    int64_t n = 100;
+    auto state = RandBLAS::base::RNGState();
+    UtilTestData<float> all_data(m, n);
+
+    RandLAPACK::util::gen_mat_type<float, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(0, 2, false));
+    computational_helper<float, r123::Philox4x32>(m, n, all_data);
+    test_spectral_norm<float, r123::Philox4x32>(m, n, state, all_data);
+}
+
+TEST_F(TestUtil, test_spectral_norm_rank_def_mat_single_precision) {
+    
+    int64_t m = 1000;
+    int64_t n = 100;
+    auto state = RandBLAS::base::RNGState();
+    UtilTestData<float> all_data(m, n);
+
+    RandLAPACK::util::gen_mat_type<float, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(9, std::pow(10, 7), false));
+    computational_helper<float, r123::Philox4x32>(m, n, all_data);
+    test_spectral_norm<float, r123::Philox4x32>(1000, 100, state, all_data);
 }
 
 TEST_F(TestUtil, test_normc) {
-    test_normc<double>(1000);
+    int64_t m = 1000;
+    int64_t n = 1;
+    UtilTestData<double> all_data(m, n);
+
+    test_normc<double>(m, all_data);
 }
 
 TEST_F(TestUtil, test_binary_rank_search_zero_mat) {
-    test_binary_rank_search_zero_mat<double>(1000, 100);
+    int64_t m = 1000;
+    int64_t n = 100;
+    UtilTestData<double> all_data(m, n);
+
+    test_binary_rank_search_zero_mat<double>(1000, 100, all_data);
 }

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -31,11 +31,6 @@ class TestCQRRPT : public ::testing::Test
         {}
     };
 
-    template <typename T, typename RNG>
-    static void computational_helper(int64_t m, int64_t n, CQRRPTTestData<T>& all_data) {
-        lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
-    }
-
     /// General test for CQRRPT:
     /// Computes QR factorzation, and computes A[:, J] - QR.
     template <typename T, typename RNG>
@@ -77,7 +72,7 @@ TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp)
     CQRRPTTestData<double> all_data(m, n);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
-    computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
     test_CQRRPT_general<double, r123::Philox4x32>(m, n, k, d, nnz, tol, state, no_hqrrp, all_data);
 }
 
@@ -94,6 +89,6 @@ TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp)
     CQRRPTTestData<double> all_data(m, n);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
-    computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
     test_CQRRPT_general<double, r123::Philox4x32>(m, n, k, d, nnz, tol, state, no_hqrrp, all_data);
 }

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -17,55 +17,83 @@ class TestCQRRPT : public ::testing::Test
 
     virtual void TearDown() {};
 
+    template <typename T>
+    struct CQRRPTTestData {
+        std::vector<T> A;
+        std::vector<T> R;
+        std::vector<int64_t> J;
+        std::vector<T> A_cpy;
+
+        CQRRPTTestData(int64_t m, int64_t n) :
+        A(m * n, 0.0), 
+        J(n, 0.0),  
+        A_cpy(m * n, 0.0) 
+        {}
+    };
+
+    template <typename T, typename RNG>
+    static void computational_helper(int64_t m, int64_t n, CQRRPTTestData<T>& all_data) {
+        lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
+    }
+
     /// General test for CQRRPT:
     /// Computes QR factorzation, and computes A[:, J] - QR.
     template <typename T, typename RNG>
-    static void test_CQRRPT_general(int64_t m, int64_t n, int64_t k, int64_t d, int64_t nnz, T tol, std::tuple<int, T, bool> mat_type, RandBLAS::base::RNGState<RNG> state, uint64_t no_hqrrp) {
-
-        printf("|================================TEST CQRRPT GENERAL BEGIN===============================|\n");
-
-        int64_t size = m * n;
-        std::vector<T> A(size, 0.0);
-
-        std::vector<T> R;
-        std::vector<int64_t> J(n, 0);
-
-        RandLAPACK::util::gen_mat_type(m, n, A, k, state, mat_type);
-
-        std::vector<T> A_hat(size, 0.0);
-        std::copy(A.data(), A.data() + size, A_hat.data());
-
-        T* A_dat = A.data();
-        T* A_hat_dat = A_hat.data();
+    static void test_CQRRPT_general(int64_t m, int64_t n, int64_t k, int64_t d, int64_t nnz, T tol, RandBLAS::base::RNGState<RNG> state, uint64_t no_hqrrp, CQRRPTTestData<T>& all_data) {
 
         RandLAPACK::CQRRPT<T, RNG> CQRRPT(false, false, state, tol);
         CQRRPT.nnz = nnz;
         CQRRPT.num_threads = 4;
         CQRRPT.no_hqrrp = no_hqrrp;
 
-        CQRRPT.call(m, n, A, d, R, J);
+        CQRRPT.call(m, n, all_data.A, d, all_data.R, all_data.J);
 
-        A_dat = A.data();
-        T* R_dat = R.data();
+        T* A_dat = all_data.A.data();
+        T* A_cpy_dat = all_data.A_cpy.data();
+        T* R_dat = all_data.R.data();
         k = CQRRPT.rank;
 
-        RandLAPACK::util::col_swap(m, n, n, A_hat, J);
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy, all_data.J);
 
         // AP - QR
-        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, k, 1.0, A_dat, m, R_dat, k, -1.0, A_hat_dat, m);
+        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, k, 1.0, A_dat, m, R_dat, k, -1.0, A_cpy_dat, m);
 
-        T norm_test = lapack::lange(Norm::Fro, m, n, A_hat_dat, m);
+        T norm_test = lapack::lange(Norm::Fro, m, n, A_cpy_dat, m);
         printf("FRO NORM OF AP - QR:  %e\n", norm_test);
-
-        printf("|=================================TEST CQRRPT GENERAL END================================|\n");
     }
 };
 
 // Note: If Subprocess killed exception -> reload vscode
-TEST_F(TestCQRRPT, SimpleTest)
+TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp)
 {
+    int64_t m = 10000;
+    int64_t n = 200;
+    int64_t k = 200;
+    int64_t d = 400;
+    int64_t nnz = 2;
+    uint64_t no_hqrrp = 1; 
+    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
-    test_CQRRPT_general<double, r123::Philox4x32>(10000, 200, 200, 400, 2, std::pow(std::numeric_limits<double>::epsilon(), 0.75), std::make_tuple(0, 2, false), state, 1);
-    test_CQRRPT_general<double, r123::Philox4x32>(10000, 200, 100, 400, 2, std::pow(std::numeric_limits<double>::epsilon(), 0.75), std::make_tuple(0, 2, false), state, 0);
-    //test_CQRRPT_general<double>(7, 5, 3, 5, 2, std::pow(std::numeric_limits<double>::epsilon(), 0.75), std::make_tuple(0, 2, false), state, 0);
+    CQRRPTTestData<double> all_data(m, n);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
+    computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    test_CQRRPT_general<double, r123::Philox4x32>(m, n, k, d, nnz, tol, state, no_hqrrp, all_data);
+}
+
+TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp)
+{
+    int64_t m = 10000;
+    int64_t n = 200;
+    int64_t k = 100;
+    int64_t d = 400;
+    int64_t nnz = 2;
+    uint64_t no_hqrrp = 0; 
+    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
+    auto state = RandBLAS::base::RNGState();
+    CQRRPTTestData<double> all_data(m, n);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
+    computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    test_CQRRPT_general<double, r123::Philox4x32>(m, n, k, d, nnz, tol, state, no_hqrrp, all_data);
 }

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -34,12 +34,13 @@ class TestCQRRPT : public ::testing::Test
     /// General test for CQRRPT:
     /// Computes QR factorzation, and computes A[:, J] - QR.
     template <typename T, typename RNG>
-    static void test_CQRRPT_general(int64_t m, int64_t n, int64_t k, int64_t d, int64_t nnz, T tol, RandBLAS::base::RNGState<RNG> state, uint64_t no_hqrrp, CQRRPTTestData<T>& all_data) {
-
-        RandLAPACK::CQRRPT<T, RNG> CQRRPT(false, false, state, tol);
-        CQRRPT.nnz = nnz;
-        CQRRPT.num_threads = 4;
-        CQRRPT.no_hqrrp = no_hqrrp;
+    static void test_CQRRPT_general(
+        int64_t m, 
+        int64_t n, 
+        int64_t k, 
+        int64_t d, 
+        CQRRPTTestData<T>& all_data,
+        RandLAPACK::CQRRPT<T, RNG>& CQRRPT) {
 
         CQRRPT.call(m, n, all_data.A, d, all_data.R, all_data.J);
 
@@ -65,15 +66,18 @@ TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp)
     int64_t n = 200;
     int64_t k = 200;
     int64_t d = 400;
-    int64_t nnz = 2;
-    uint64_t no_hqrrp = 1; 
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
+
     CQRRPTTestData<double> all_data(m, n);
+    RandLAPACK::CQRRPT<double, r123::Philox4x32> CQRRPT(false, false, state, tol);
+    CQRRPT.nnz = 2;
+    CQRRPT.num_threads = 4;
+    CQRRPT.no_hqrrp = 1;
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
     lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
-    test_CQRRPT_general<double, r123::Philox4x32>(m, n, k, d, nnz, tol, state, no_hqrrp, all_data);
+    test_CQRRPT_general<double, r123::Philox4x32>(m, n, k, d, all_data, CQRRPT);
 }
 
 TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp)
@@ -82,13 +86,16 @@ TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp)
     int64_t n = 200;
     int64_t k = 100;
     int64_t d = 400;
-    int64_t nnz = 2;
-    uint64_t no_hqrrp = 0; 
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
+
     CQRRPTTestData<double> all_data(m, n);
+    RandLAPACK::CQRRPT<double, r123::Philox4x32> CQRRPT(false, false, state, tol);
+    CQRRPT.nnz = 2;
+    CQRRPT.num_threads = 4;
+    CQRRPT.no_hqrrp = 0;
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
     lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
-    test_CQRRPT_general<double, r123::Philox4x32>(m, n, k, d, nnz, tol, state, no_hqrrp, all_data);
+    test_CQRRPT_general<double, r123::Philox4x32>(m, n, k, d, all_data, CQRRPT);
 }

--- a/test/drivers/test_revd2.cc
+++ b/test/drivers/test_revd2.cc
@@ -14,41 +14,51 @@ class TestREVD2 : public ::testing::Test
 
     virtual void TearDown() {};
 
-    /// General test for RSVD:
-    /// Computes the decomposition factors, then checks A-U\Sigma\transpose{V}.
+    template <typename T>
+    struct REVD2TestData {
+        std::vector<T> A_buf;
+        std::vector<T> A;
+        std::vector<T> A_cpy;
+        std::vector<T> V;
+        std::vector<T> eigvals;
+        std::vector<T> E;
+        std::vector<T> Buf;
+
+        REVD2TestData(int64_t m, int64_t k) :
+        A_buf(m * m, 0.0), 
+        A(m * m, 0.0), 
+        A_cpy(m * m, 0.0),  
+        V(m * k, 0.0), 
+        eigvals(k, 0.0), 
+        E(k * k, 0.0), 
+        Buf(m * k, 0.0)
+        {}
+    };
+
     template <typename T, typename RNG>
-    static void test_REVD2_general(int64_t m, int64_t k, int64_t k_start, std::tuple<int, T, bool> mat_type, RandBLAS::base::RNGState<RNG> state, int rank_expectation, T err_expectation) {
-
-        printf("|==================================TEST REVD2 GENERAL BEGIN==================================|\n");
-
-        // For running QB
-        std::vector<T> A_buf(m * m, 0.0);
-        RandLAPACK::util::gen_mat_type(m, m, A_buf, k, state, mat_type);
-
-        std::vector<T> A(m * m, 0.0);
-        T* A_dat = A.data();
+    static void computational_helper(int64_t m, T& norm_A, REVD2TestData<T>& all_data) {
 
         // We're using Nystrom, the original must be positive semidefinite
-        blas::syrk(Layout::ColMajor, Uplo::Lower, Op::Trans, m, m, 1.0, A_buf.data(), m, 0.0, A.data(), m);
+        blas::syrk(Layout::ColMajor, Uplo::Lower, Op::Trans, m, m, 1.0, all_data.A_buf.data(), m, 0.0, all_data.A.data(), m);
+        
+        T* A_dat = all_data.A.data();
+
         for(int i = 1; i < m; ++i)
             blas::copy(m - i, &A_dat[i + ((i-1) * m)], 1, &A_dat[(i - 1) + (i * m)], m);
 
-        // For results comparison
-        std::vector<T> A_cpy (m * m, 0.0);
-        std::vector<T> V(m * k, 0.0);
-        std::vector<T> eigvals(k, 0.0);
+                    // Create a copy of the original matrix
+        blas::copy(m * m, all_data.A.data(), 1, all_data.A_cpy.data(), 1);
+        norm_A = lapack::lange(Norm::Fro, m, m, all_data.A_cpy.data(), m);
+    }
 
-        T* A_cpy_dat = A_cpy.data();
-
-        // Create a copy of the original matrix
-        blas::copy(m * m, A_dat, 1, A_cpy_dat, 1);
-        T norm_A = lapack::lange(Norm::Fro, m, m, A_cpy_dat, m);
+    /// General test for REVD:
+    /// Computes the decomposition factors, then checks A-U\Sigma\transpose{V}.
+    template <typename T, typename RNG>
+    static void test_REVD2_general(int64_t m, int64_t k, int64_t k_start, int64_t p, int64_t passes_per_iteration, RandBLAS::base::RNGState<RNG> state, int rank_expectation, T err_expectation, T& norm_A, REVD2TestData<T>& all_data) {
 
         //Subroutine parameters 
         bool verbosity = false;
         bool cond_check = false;
-        int64_t p = 10;
-        int64_t passes_per_iteration = 10;
 
         // Make subroutine objects
         // Stabilization Constructor - Choose PLU
@@ -64,19 +74,20 @@ class TestREVD2 : public ::testing::Test
 
         k = k_start;
         REVD2.tol = std::pow(10, -14);
-        REVD2.call(m, blas::Uplo::Upper, A, k, V, eigvals);
+        REVD2.call(m, blas::Uplo::Upper, all_data.A, k, all_data.V, all_data.eigvals);
 
-        std::vector<T> E(k * k, 0.0);
-        std::vector<T> Buf (m * k, 0.0);
+        RandLAPACK::util::upsize(k * k, all_data.E);
+        RandLAPACK::util::upsize(m * k, all_data.Buf);
 
-        T* V_dat = V.data();
-        T* E_dat = E.data();
-        T* Buf_dat = Buf.data();
+        T* A_cpy_dat = all_data.A_cpy.data();
+        T* V_dat = all_data.V.data();
+        T* E_dat = all_data.E.data();
+        T* Buf_dat = all_data.Buf.data();
 
         // Construnct A_hat = U1 * S1 * VT1
 
         // Turn vector into diagonal matrix
-        RandLAPACK::util::diag(k, k, eigvals, k, E);
+        RandLAPACK::util::diag(k, k, all_data.eigvals, k, all_data.E);
         // V * E = Buf
         blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, k, 1.0, V_dat, m, E_dat, k, 0.0, Buf_dat, m);
         // A - Buf * V' - should be close to 0
@@ -86,33 +97,90 @@ class TestREVD2 : public ::testing::Test
         printf("||A - VEV'||_F / ||A||_F:  %e\n", norm_0 / norm_A);
         ASSERT_NEAR(norm_0 / norm_A, err_expectation, 10 * err_expectation);
         ASSERT_NEAR(k, rank_expectation, std::numeric_limits<double>::epsilon());
-
-        printf("|===================================TEST REVD2 GENERAL END===================================|\n");
     }
 };
 
 TEST_F(TestREVD2, Underestimation1) { 
+    int64_t m = 1000;
+    int64_t k = 100;
+    int64_t k_start = 1;
+    int64_t rank_expectation = 64;
+    double norm_A = 0;
+    int64_t p = 10;
+    int64_t passes_per_iteration = 10;
+    double err_expectation =std::pow(10, -13);
     auto state = RandBLAS::base::RNGState();
-    // Rank estimation must be 80 - underestimation - starting with very small rank
-    test_REVD2_general<double, r123::Philox4x32>(1000, 100, 1, std::make_tuple(0, std::pow(10, 8), false), state, 64, std::pow(10, -13));
+    REVD2TestData<double> all_data(m, k);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, all_data.A_buf, k, state, std::make_tuple(0, std::pow(10, 8), false));
+    computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
+    test_REVD2_general<double, r123::Philox4x32>(m, k, k_start, p, passes_per_iteration, state, rank_expectation, err_expectation, norm_A, all_data);
 }
+
 TEST_F(TestREVD2, Underestimation2) { 
+    int64_t m = 1000;
+    int64_t k = 100;
+    int64_t k_start = 10;
+    int64_t rank_expectation = 80;
+    double norm_A = 0;
+    int64_t p = 10;
+    int64_t passes_per_iteration = 10;
+    double err_expectation =std::pow(10, -13);
     auto state = RandBLAS::base::RNGState();
-    // Rank estimation must be 80 - underestimation
-    test_REVD2_general<double, r123::Philox4x32>(1000, 100, 10, std::make_tuple(0, std::pow(10, 8), false), state, 80, std::pow(10, -13));
+    REVD2TestData<double> all_data(m, k);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, all_data.A_buf, k, state, std::make_tuple(0, std::pow(10, 8), false));
+    computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
+    test_REVD2_general<double, r123::Philox4x32>(m, k, k_start, p, passes_per_iteration, state, rank_expectation, err_expectation, norm_A, all_data);
 }
+
 TEST_F(TestREVD2, Overestimation1) { 
+    int64_t m = 1000;
+    int64_t k = 100;
+    int64_t k_start = 10;
+    int64_t rank_expectation = 160;
+    double norm_A = 0;
+    int64_t p = 10;
+    int64_t passes_per_iteration = 10;
+    double err_expectation =std::pow(10, -13);
     auto state = RandBLAS::base::RNGState();
-    // Rank estimation must be 60 - overestimation
-    test_REVD2_general<double, r123::Philox4x32>(1000, 100, 10, std::make_tuple(0, std::pow(10, 2), false), state, 160, std::pow(10, -13));
+    REVD2TestData<double> all_data(m, k);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, all_data.A_buf, k, state, std::make_tuple(0, std::pow(10, 2), false));
+    computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
+    test_REVD2_general<double, r123::Philox4x32>(m, k, k_start, p, passes_per_iteration, state, rank_expectation, err_expectation, norm_A, all_data);
 }
+
 TEST_F(TestREVD2, Oversetimation2) { 
+    int64_t m = 1000;
+    int64_t k = 159;
+    int64_t k_start = 10;
+    int64_t rank_expectation = 160;
+    double norm_A = 0;
+    int64_t p = 10;
+    int64_t passes_per_iteration = 10;
+    double err_expectation =std::pow(10, -13);
     auto state = RandBLAS::base::RNGState();
-    // Rank estimation must be 160 - slight overestimation
-    test_REVD2_general<double, r123::Philox4x32>(1000, 159, 10, std::make_tuple(0, std::pow(10, 2), false), state, 160, std::pow(10, -13));
+    REVD2TestData<double> all_data(m, k);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, all_data.A_buf, k, state, std::make_tuple(0, std::pow(10, 2), false));
+    computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
+    test_REVD2_general<double, r123::Philox4x32>(m, k, k_start, p, passes_per_iteration, state, rank_expectation, err_expectation, norm_A, all_data);
 }
+
 TEST_F(TestREVD2, Exactness) { 
+    int64_t m = 100;
+    int64_t k = 100;
+    int64_t k_start = 10;
+    int64_t rank_expectation = 100;
+    double norm_A = 0;
+    int64_t p = 10;
+    int64_t passes_per_iteration = 10;
+    double err_expectation =std::pow(10, -13);
     auto state = RandBLAS::base::RNGState();
-    // Numerically rank deficient matrix - expecting rank estimate = m
-    test_REVD2_general<double, r123::Philox4x32>(100, 100, 10, std::make_tuple(0, std::pow(10, 2), false), state, 100, std::pow(10, -13));
+    REVD2TestData<double> all_data(m, k);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, all_data.A_buf, k, state, std::make_tuple(0, std::pow(10, 2), false));
+    computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
+    test_REVD2_general<double, r123::Philox4x32>(m, k, k_start, p, passes_per_iteration, state, rank_expectation, err_expectation, norm_A, all_data);
 }

--- a/test/drivers/test_revd2.cc
+++ b/test/drivers/test_revd2.cc
@@ -36,7 +36,7 @@ class TestREVD2 : public ::testing::Test
     };
 
     template <typename T, typename RNG>
-    static void computational_helper(int64_t m, T& norm_A, REVD2TestData<T>& all_data) {
+    static void symm_mat_and_copy_computational_helper(int64_t m, T& norm_A, REVD2TestData<T>& all_data) {
 
         // We're using Nystrom, the original must be positive semidefinite
         blas::syrk(Layout::ColMajor, Uplo::Lower, Op::Trans, m, m, 1.0, all_data.A_buf.data(), m, 0.0, all_data.A.data(), m);
@@ -113,7 +113,7 @@ TEST_F(TestREVD2, Underestimation1) {
     REVD2TestData<double> all_data(m, k);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, all_data.A_buf, k, state, std::make_tuple(0, std::pow(10, 8), false));
-    computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
+    symm_mat_and_copy_computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
     test_REVD2_general<double, r123::Philox4x32>(m, k, k_start, p, passes_per_iteration, state, rank_expectation, err_expectation, norm_A, all_data);
 }
 
@@ -130,7 +130,7 @@ TEST_F(TestREVD2, Underestimation2) {
     REVD2TestData<double> all_data(m, k);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, all_data.A_buf, k, state, std::make_tuple(0, std::pow(10, 8), false));
-    computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
+    symm_mat_and_copy_computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
     test_REVD2_general<double, r123::Philox4x32>(m, k, k_start, p, passes_per_iteration, state, rank_expectation, err_expectation, norm_A, all_data);
 }
 
@@ -147,7 +147,7 @@ TEST_F(TestREVD2, Overestimation1) {
     REVD2TestData<double> all_data(m, k);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, all_data.A_buf, k, state, std::make_tuple(0, std::pow(10, 2), false));
-    computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
+    symm_mat_and_copy_computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
     test_REVD2_general<double, r123::Philox4x32>(m, k, k_start, p, passes_per_iteration, state, rank_expectation, err_expectation, norm_A, all_data);
 }
 
@@ -164,7 +164,7 @@ TEST_F(TestREVD2, Oversetimation2) {
     REVD2TestData<double> all_data(m, k);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, all_data.A_buf, k, state, std::make_tuple(0, std::pow(10, 2), false));
-    computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
+    symm_mat_and_copy_computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
     test_REVD2_general<double, r123::Philox4x32>(m, k, k_start, p, passes_per_iteration, state, rank_expectation, err_expectation, norm_A, all_data);
 }
 
@@ -181,6 +181,6 @@ TEST_F(TestREVD2, Exactness) {
     REVD2TestData<double> all_data(m, k);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, all_data.A_buf, k, state, std::make_tuple(0, std::pow(10, 2), false));
-    computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
+    symm_mat_and_copy_computational_helper<double, r123::Philox4x32>(m, norm_A, all_data);
     test_REVD2_general<double, r123::Philox4x32>(m, k, k_start, p, passes_per_iteration, state, rank_expectation, err_expectation, norm_A, all_data);
 }

--- a/test/drivers/test_rsvd.cc
+++ b/test/drivers/test_rsvd.cc
@@ -132,10 +132,8 @@ class TestRSVD : public ::testing::Test
         //T norm_test_4 = lapack::lange(Norm::Fro, m, n, A_cpy_dat, m);
         //printf("FRO NORM OF A_k - QB:  %e\n", norm_test_4);
 
-        // buffer zero vector
-        std::vector<T> z_buf(n, 0.0);
         // zero out the trailing singular values
-        blas::copy(n - k, z_buf.data(), 1, s_dat + k, 1);
+        std::fill(s_dat + k, s_dat + n, 0.0);
         RandLAPACK::util::diag(n, n, all_data.s, n, all_data.S);
 
         // TEST 4: Below is A_k - A_hat = A_k - QB
@@ -146,7 +144,6 @@ class TestRSVD : public ::testing::Test
         T norm_test_4 = lapack::lange(Norm::Fro, m, n, A_hat_dat, m);
         printf("FRO NORM OF A_k - QB:  %e\n", norm_test_4);
         //ASSERT_NEAR(norm_test_4, 0, std::pow(std::numeric_limits<T>::epsilon(), 0.625));
-        printf("|===================================TEST QB2 GENERAL END===================================|\n");
     }
 };
 

--- a/test/drivers/test_rsvd.cc
+++ b/test/drivers/test_rsvd.cc
@@ -17,55 +17,77 @@ class TestRSVD : public ::testing::Test
 
     virtual void TearDown() {};
 
+    template <typename T>
+    struct RSVDTestData {
+
+        std::vector<T> A;
+        // For results comparison
+        std::vector<T> A_hat;
+        std::vector<T> A_hat_buf;
+        std::vector<T> A_k;
+        std::vector<T> A_cpy;
+
+        // For RSVD
+        std::vector<T> s1;
+        std::vector<T> S1;
+        std::vector<T> U1;
+        std::vector<T> VT1;
+
+        // For low-rank SVD
+        std::vector<T> s;
+        std::vector<T> S;
+        std::vector<T> U;
+        std::vector<T> VT;
+
+        RSVDTestData(int64_t m, int64_t n, int64_t k) :
+        A(m * n, 0.0),
+        // For results comparison
+        A_hat(m * n, 0.0),
+        A_hat_buf (m * k, 0.0),
+        A_k(m * n, 0.0),
+        A_cpy (m * n, 0.0),
+
+        // For RSVD
+        s1(n, 0.0),
+        S1(n * n, 0.0),
+        U1(m * n, 0.0),
+        VT1(n * n, 0.0),
+
+        // For low-rank SVD
+        s(n, 0.0),
+        S(n * n, 0.0),
+        U(m * n, 0.0),
+        VT(n * n, 0.0)
+        {}
+    };
+
+    template <typename T, typename RNG>
+    static void computational_helper(int64_t m, int64_t n, RSVDTestData<T>& all_data) {
+        
+        // Create a copy of the original matrix
+        blas::copy(m * n, all_data.A.data(), 1, all_data.A_cpy.data(), 1);
+
+        // Get low-rank SVD
+        lapack::gesdd(Job::SomeVec, m, n, all_data.A_cpy.data(), m, all_data.s.data(), all_data.U.data(), m, all_data.VT.data(), n);
+    }
+
     /// General test for RSVD:
     /// Computes the decomposition factors, then checks A-U\Sigma\transpose{V}.
     template <typename T, typename RNG>
-    static void test_RSVD1_general(int64_t m, int64_t n, int64_t k, int64_t p, int64_t block_sz, T tol, std::tuple<int, T, bool> mat_type, RandBLAS::base::RNGState<RNG> state) {
-        
-        printf("|==================================TEST QB2 GENERAL BEGIN==================================|\n");
+    static void test_RSVD1_general(int64_t m, int64_t n, int64_t k, int64_t p, int64_t block_sz, T tol, RandBLAS::base::RNGState<RNG> state, RSVDTestData<T>& all_data) {
 
-        // For running QB
-        std::vector<T> A(m * n, 0.0);
-        RandLAPACK::util::gen_mat_type(m, n, A, k, state, mat_type);
+        T* A_hat_dat = all_data.A_hat.data();
+        T* A_hat_buf_dat = all_data.A_hat_buf.data();
+        T* A_k_dat = all_data.A_k.data();
 
-        int64_t size = m * n;
+        T* U1_dat = all_data.U1.data();
+        T* S1_dat = all_data.S1.data();
+        T* VT1_dat = all_data.VT1.data();
 
-        // For results comparison
-        std::vector<T> A_hat(size, 0.0);
-        std::vector<T> A_hat_buf (m * k, 0.0);
-        std::vector<T> A_k(size, 0.0);
-        std::vector<T> A_cpy (m * n, 0.0);
-
-        // For RSVD
-        std::vector<T> s1(n, 0.0);
-        std::vector<T> S1(n * n, 0.0);
-        std::vector<T> U1(m * n, 0.0);
-        std::vector<T> VT1(n * n, 0.0);
-
-        // For low-rank SVD
-        std::vector<T> s(n, 0.0);
-        std::vector<T> S(n * n, 0.0);
-        std::vector<T> U(m * n, 0.0);
-        std::vector<T> VT(n * n, 0.0);
-
-        T* A_dat = A.data();
-
-        T* A_hat_dat = A_hat.data();
-        T* A_hat_buf_dat = A_hat_buf.data();
-        T* A_k_dat = A_k.data();
-        T* A_cpy_dat = A_cpy.data();
-
-        T* U1_dat = U1.data();
-        T* S1_dat = S1.data();
-        T* VT1_dat = VT1.data();
-
-        T* U_dat = U.data();
-        T* s_dat = s.data();
-        T* S_dat = S.data();
-        T* VT_dat = VT.data();
-
-        // Create a copy of the original matrix
-        blas::copy(size, A_dat, 1, A_cpy_dat, 1);
+        T* U_dat = all_data.U.data();
+        T* s_dat = all_data.s.data();
+        T* S_dat = all_data.S.data();
+        T* VT_dat = all_data.VT.data();
 
         //Subroutine parameters 
         bool verbosity = false;
@@ -96,12 +118,12 @@ class TestRSVD : public ::testing::Test
         RandLAPACK::RSVD<T> RSVD(QB, verbosity, block_sz);
 
         // Regular QB2 call
-        RSVD.call(m, n, A, k, tol, U1, s1, VT1);
+        RSVD.call(m, n, all_data.A, k, tol, all_data.U1, all_data.s1, all_data.VT1);
         
         // Construnct A_hat = U1 * S1 * VT1
 
         // Turn vector into diagonal matrix
-        RandLAPACK::util::diag(k, k, s1, k, S1);
+        RandLAPACK::util::diag(k, k, all_data.s1, k, all_data.S1);
         // U1 * S1 = A_hat_buf
         blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, k, 1.0, U1_dat, m, S1_dat, k, 1.0, A_hat_buf_dat, m);
         // A_hat_buf * VT1 =  A_hat
@@ -110,15 +132,11 @@ class TestRSVD : public ::testing::Test
         //T norm_test_4 = lapack::lange(Norm::Fro, m, n, A_cpy_dat, m);
         //printf("FRO NORM OF A_k - QB:  %e\n", norm_test_4);
 
-
-        // Reconstruct  a standard low-rank SVD
-        lapack::gesdd(Job::SomeVec, m, n, A_cpy_dat, m, s_dat, U_dat, m, VT_dat, n);
         // buffer zero vector
         std::vector<T> z_buf(n, 0.0);
-        T* z_buf_dat = z_buf.data();
         // zero out the trailing singular values
-        blas::copy(n - k, z_buf_dat, 1, s_dat + k, 1);
-        RandLAPACK::util::diag(n, n, s, n, S);
+        blas::copy(n - k, z_buf.data(), 1, s_dat + k, 1);
+        RandLAPACK::util::diag(n, n, all_data.s, n, all_data.S);
 
         // TEST 4: Below is A_k - A_hat = A_k - QB
         blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, n, 1.0, U_dat, m, S_dat, n, 1.0, A_k_dat, m);
@@ -134,7 +152,16 @@ class TestRSVD : public ::testing::Test
 
 TEST_F(TestRSVD, SimpleTest)
 { 
-    // Generate a random state
+    int64_t m = 100;
+    int64_t n = 100;
+    int64_t k = 5;
+    int64_t p = 10;
+    int64_t block_sz = 2;
+    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.5625);
     auto state = RandBLAS::base::RNGState();
-    test_RSVD1_general<double, r123::Philox4x32>(100, 100, 50, 5, 10, std::pow(std::numeric_limits<double>::epsilon(), 0.5625), std::make_tuple(0, 2, false), state);
+    RSVDTestData<double> all_data(m, n, k);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
+    computational_helper<double, r123::Philox4x32>(m, n, all_data);
+    test_RSVD1_general<double, r123::Philox4x32>(m, n, k, p, block_sz, tol, state, all_data);
 }


### PR DESCRIPTION
Adding basic tests for RangeFinder and refactoring the existing tests layout to perform space allocation, auxillary computations and the actual test run separately. The changes did not touch [test_determiter.cc](https://github.com/BallisticLA/RandLAPACK/blob/main/test/comps/test_determiter.cc), [test_pcgls.cc](https://github.com/BallisticLA/RandLAPACK/blob/main/test/comps/test_pcgls.cc) and [test_preconditioners.cc](https://github.com/BallisticLA/RandLAPACK/blob/main/test/comps/test_preconditioners.cc).