### PR TITLE
Modifications to SVD-based preconditioning

### DIFF
--- a/RandLAPACK/comps/rl_util.hh
+++ b/RandLAPACK/comps/rl_util.hh
@@ -3,7 +3,6 @@
 
 #include "rl_blaspp.hh"
 #include "rl_lapackpp.hh"
-#include "rl_util.hh"
 
 #include <RandBLAS.hh>
 #include <iostream>
@@ -847,6 +846,45 @@ void normc(
         }
     }
 }
+
+
+/**
+ * In-place transpose of square matrix of order n, with leading dimension n.
+ * Turns out that "layout" doesn't matter here.
+*/
+template <typename T>
+void transpose_square(T* H, int64_t n) {
+    for (int i = 0; i < n; ++i) {
+        for (int j = i + 1; j < n; ++j) {
+            T val_ij = H[i + j*n];
+            T val_ji = H[j + i*n];
+            H[i + j*n] = val_ji;
+            H[j + i*n] = val_ij;
+        }
+    }
+    return;
+}
+
+/**
+ * 
+*/
+template <typename T>
+void eat_lda_slack(
+    T* buff,
+    int64_t vec_len,
+    int64_t num_vecs,
+    int64_t inter_vec_stride
+) {
+    if (vec_len == inter_vec_stride)
+        return;
+    T* work = new T[vec_len]{};
+    for (int i = 0; i < num_vecs; ++i) {
+        blas::copy(vec_len, &buff[i*inter_vec_stride], 1, work, 1);
+        blas::copy(vec_len, work, 1, &buff[i*vec_len], 1);
+    }
+    delete [] work;
+}
+
 
 } // end namespace util
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,10 +23,9 @@ if (GTest_FOUND)
 
     gtest_discover_tests(RandLAPACK_tests)
 
+    add_executable(test_pcgls comps/test_pcgls.cc)
+    target_link_libraries(test_pcgls RandLAPACK GTest::GTest)
+    add_test(NAME test_pcgls COMMAND test_pcgls 15 100)
 endif()
 message(STATUS "Checking for regression tests ... ${tmp}")
-
-add_executable(test_pcgls comps/test_pcgls.cc)
-target_link_libraries(test_pcgls RandLAPACK)
-add_test(NAME test_pcgls COMMAND test_pcgls 100 15)
 

--- a/test/comps/test_preconditioners.cc
+++ b/test/comps/test_preconditioners.cc
@@ -6,69 +6,52 @@
 #include <lapack.hh>
 
 
-#define RELTOL_POWER 0.6
-#define ABSTOL_POWER 0.75
-
-
 template <typename T>
 void check_condnum_after_precond(
+    blas::Layout layout,
     std::vector<T> &A,
     std::vector<T> &M_wk,
     int64_t rank,
     int64_t m,
-    int64_t n,
-    blas::Layout layout    
+    int64_t n
 ) {
-    T *M = M_wk.data();
-    std::vector<T> A_pc(m*n, 0.0);
-    if (layout == blas::Layout::RowMajor) {
-        // interpret as transpose in column-major
-        // multiply by transpose(M) on the left.
-        T *at = A.data();
-        blas::gemm(
-            blas::Layout::ColMajor,
-            blas::Op::Trans,
-            blas::Op::NoTrans,
-            m, rank, n,
-            1.0, at, n, M, n,
-            0.0, A_pc.data(), m );
-    } else {
-        // A_pc = A @ M
-        T *a = A.data();
-        blas::gemm(
-            blas::Layout::ColMajor,
-            blas::Op::NoTrans,
-            blas::Op::NoTrans,
-            m, rank, n,
-            1.0, a, m, M, n,
-            0.0, A_pc.data(), m);
-    }
-    
-    // check the result
-    //T reltol = std::pow(std::numeric_limits<T>::epsilon(), RELTOL_POWER);
-    // EXPECT_EQ(rank, n);
-    T *ignore = nullptr;
-    std::vector<T> s(rank, 0.0);
-    lapack::gesvd(
-        lapack::Job::NoVec,
-        lapack::Job::NoVec,
-        m, rank, A_pc.data(), m,
-        s.data(), ignore, 1, ignore, 1
+    std::vector<T> A_pc(m * rank, 0.0);
+    bool is_colmajor = layout == blas::Layout::ColMajor;
+    int64_t lda = (is_colmajor) ? m : n;
+    int64_t ldm = (is_colmajor) ? n : rank;
+    int64_t ldapc = (is_colmajor) ? m : rank;
+    blas::gemm(
+        layout,
+        blas::Op::NoTrans,
+        blas::Op::NoTrans,
+        m, rank, n,
+        1.0, A.data(), lda, M_wk.data(), ldm,
+        0.0, A_pc.data(), ldapc
     );
+    
+    std::vector<T> s(rank, 0.0);
+    if (is_colmajor) {
+        lapack::gesvd(lapack::Job::NoVec, lapack::Job::NoVec,
+            m, rank, A_pc.data(), ldapc, s.data(), nullptr, 1, nullptr, 1
+        );
+    } else {
+        lapack::gesvd(lapack::Job::NoVec, lapack::Job::NoVec,
+            rank, m, A_pc.data(), ldapc, s.data(), nullptr, 1, nullptr, 1
+        );
+    }
     T cond = s[0] / s[rank-1];
     EXPECT_LE(cond, 10.0);
 }
 
 
-class Test_rpc_svd_saso : public ::testing::Test
+class Test_rpc_svd : public ::testing::Test
 {
 
     protected:
-        static inline int64_t m = 5000;
-        static inline int64_t n = 100;
-        static inline int64_t d = 300;
+        static inline int64_t m = 500;
+        static inline int64_t n = 10;
+        static inline int64_t d = 30;
         static inline std::vector<uint64_t> keys = {42, 1};
-        static inline std::vector<uint64_t> vec_nnzs = {8, 10};
         static inline double sqrt_cond = 1e5;
         static inline double mu = 1e-6; // only used in "full_rank_after_reg" test.  
     
@@ -77,21 +60,18 @@ class Test_rpc_svd_saso : public ::testing::Test
     virtual void TearDown() {};
 
     /*
-     * Generate an ill-conditioned 5000-by-100 matrix "A," which we
-     * interpret as being stored in either row-major or column-major
-     * format.
+     * Generate an ill-conditioned 500-by-10 matrix "A."
      * 
-     * Use an SJLT to sketch A down to 300-by-100; process the sketch to
-     * obtain an SVD-based preconditioner "M" in column-major format.
+     * Use an SJLT to sketch A down to 30-by-10; process the sketch to
+     * obtain an SVD-based preconditioner "M."
      * 
-     * Check that rank(M) == rank(A).
+     * Check that rank(M) == rank(A) == 10.
      * Compute A*M, check that its condition number is <= 10.
-     * 
+     * (This latter "10" has nothing to do with the former "10.")
     */
-   template <typename T>
+    template <typename T>
     void test_full_rank_without_reg(
         int key_index,
-        int nnz_index,
         blas::Layout layout
     ){  
         // construct "A" with cond(A) >= sqrt_cond^2.
@@ -103,7 +83,7 @@ class Test_rpc_svd_saso : public ::testing::Test
             .family = RandBLAS::dense::DenseDistName::Uniform
         };
         auto state = RandBLAS::base::RNGState(99);
-        RandBLAS::dense::fill_buff(a, D, state); // dead-store the next state
+        RandBLAS::dense::fill_buff(a, D, state);
     
         if (layout == blas::Layout::RowMajor) {
             // scale first row up by sqrt_cond
@@ -121,34 +101,41 @@ class Test_rpc_svd_saso : public ::testing::Test
 
         // apply the function under test (rpc_data_svd_saso)
         auto alg_state = RandBLAS::base::RNGState((uint32_t) keys[key_index]);
-        int64_t k = vec_nnzs[nnz_index];
         std::vector<T> M_wk(d*n, 0.0);
         std::vector<T> sigma_sk(n, 0.0);
         int64_t lda = (layout == blas::Layout::ColMajor) ? m : n;
-        RandLAPACK::rpc_data_svd_saso(layout, m, n, d, k, A.data(), lda, M_wk.data(), sigma_sk.data(), alg_state);
-        int64_t rank = RandLAPACK::make_right_orthogonalizer(n, M_wk.data(), sigma_sk.data(), 0.0);
+        RandBLAS::sparse::SparseDist SDist{.n_rows=d, .n_cols=m, .vec_nnz=8};
+        RandBLAS::sparse::SparseSkOp<T> S(SDist, alg_state);
+        RandBLAS::sparse::fill_sparse(S);
+        
+        RandLAPACK::rpc_data_svd(
+            layout, m, n, A.data(), lda, S, M_wk.data(), sigma_sk.data()
+        );
+        int64_t rank = RandLAPACK::make_right_orthogonalizer(
+            layout, n, M_wk.data(), sigma_sk.data(), 0.0
+        );
 
         // Check for correct output
-        check_condnum_after_precond<T>(A, M_wk, rank, m, n, layout);
+        check_condnum_after_precond<T>(layout, A, M_wk, rank, m, n);
     }
 
     /*
-     * Generate a 5000-by-100 matrix "A" in row-major format.
+     * Generate a 500-by-10 matrix "A" in row-major format.
      * Zero-out its first column, so it's rank-deficient.
      * 
-     * Use an SJLT "S" to sketch A down to 300-by-100; process
+     * Use an SJLT "S" to sketch A down to 30-by-10; process
      * the augmented sketch \hat{A}_sk = [S*A; sqrt(mu)*I] to
-     * obtain an SVD-based preconditioner "M" in column-major format.
+     * obtain an SVD-based preconditioner "M" in row-major format.
      * 
      * Check that rank(M) == n.
      * Check that cond([A; sqrt(mu)*I]*M) <= 10.
      * 
     */
     virtual void test_full_rank_after_reg(
-        uint64_t key_index,
-        uint64_t nnz_index
+        uint64_t key_index
     ){    
         // construct an ill-conditioned matrix, then zero out first column.
+        // After regularization the augmented matrix will still be full-rank.
         std::vector<double> A(m*n, 0.0);
         double *a = A.data();
         RandBLAS::dense::DenseDist D{
@@ -157,7 +144,7 @@ class Test_rpc_svd_saso : public ::testing::Test
             .family = RandBLAS::dense::DenseDistName::Uniform
         };
         auto state = RandBLAS::base::RNGState(99);
-        RandBLAS::dense::fill_buff(a, D, state);  // dead-store
+        RandBLAS::dense::fill_buff(a, D, state);
                       
         blas::scal(n, sqrt_cond, a, 1);
         double invscale = 1.0 / sqrt_cond;
@@ -168,69 +155,42 @@ class Test_rpc_svd_saso : public ::testing::Test
         std::vector<double> M_wk(d*n, 0.0);
         std::vector<double> sigma_sk(n, 0.0);
         auto alg_state = RandBLAS::base::RNGState(keys[key_index]);
-        int64_t k = vec_nnzs[nnz_index];
-
         RandLAPACK::rpc_data_svd_saso(
-            blas::Layout::RowMajor, m, n, d, k,
+            blas::Layout::RowMajor, m, n, d, 8,
             A.data(), n, M_wk.data(), sigma_sk.data(), alg_state
         );
         int64_t rank = RandLAPACK::make_right_orthogonalizer(
+            blas::Layout::RowMajor,
             n, M_wk.data(), sigma_sk.data(), mu
         );
-        
-        std::vector<double> A_aug_pc((m + n)*n, 0.0);
-        double *a_aug_pc = A_aug_pc.data(); // interpret as column-major
-        double *at = A.data(); // interpret as transpose in column-major
-        double *M = M_wk.data();
-        blas::gemm(
-            blas::Layout::ColMajor,
-            blas::Op::Trans,
-            blas::Op::NoTrans,
-            m, n, n,
-            1.0, at, n, M, n,
-            0.0, a_aug_pc, m + n 
-        );
-        double sqrt_mu = std::sqrt(mu);
-        double *sqrt_mu_eye = &a_aug_pc[m];  // offset by m. 
-        for (int i = 0; i < n; ++i) {
-            sqrt_mu_eye[(m+n)*i + i] = sqrt_mu;
-        }
-        
-        // check the result
         EXPECT_EQ(rank, n);
-        double *ignore = nullptr;
-        std::vector<double> s(n, 0.0);
-        lapack::gesvd(
-            lapack::Job::NoVec,
-            lapack::Job::NoVec,
-            m, n, a_aug_pc, m,
-            s.data(), ignore, 1, ignore, 1
-        );
-        double cond = s[0] / s[n-1];
-        EXPECT_LE(cond, 10);
+        
+        std::vector<double> A_aug((m + n)*n, 0.0);
+        double *a_aug = A_aug.data();
+        blas::copy(m*n, a, 1, a_aug, 1);
+        double sqrt_mu = std::sqrt(mu);
+        double *sqrt_mu_eye = &a_aug[m * n];
+        for (int i = 0; i < n; ++i)
+            sqrt_mu_eye[n*i + i] = sqrt_mu;
+
+        check_condnum_after_precond(blas::Layout::RowMajor, A_aug, M_wk, rank, m + n, n);
     }
 };
 
-TEST_F(Test_rpc_svd_saso, FullRankNoReg_rowmajor_double)
+TEST_F(Test_rpc_svd, FullRankNoReg_rowmajor_double)
 {
-    test_full_rank_without_reg<double>(0, 0, blas::Layout::RowMajor);
-    test_full_rank_without_reg<double>(0, 1, blas::Layout::RowMajor);
-    test_full_rank_without_reg<double>(1, 0, blas::Layout::RowMajor);
-    test_full_rank_without_reg<double>(1, 1, blas::Layout::RowMajor);
+    test_full_rank_without_reg<double>(0, blas::Layout::RowMajor);
+    test_full_rank_without_reg<double>(1, blas::Layout::RowMajor);
 }
 
-TEST_F(Test_rpc_svd_saso, FullRankNoReg_colmajor_double)
+TEST_F(Test_rpc_svd, FullRankNoReg_colmajor_double)
 {
-    test_full_rank_without_reg<double>(0, 0, blas::Layout::ColMajor);
-    test_full_rank_without_reg<double>(0, 1, blas::Layout::ColMajor);
-    test_full_rank_without_reg<double>(1, 0, blas::Layout::ColMajor);
-    test_full_rank_without_reg<double>(1, 1, blas::Layout::ColMajor);
+    test_full_rank_without_reg<double>(0, blas::Layout::ColMajor);
+    test_full_rank_without_reg<double>(1, blas::Layout::ColMajor);
 }
 
-TEST_F(Test_rpc_svd_saso, FullRankAfterReg)
+TEST_F(Test_rpc_svd, FullRankAfterReg)
 {
-    test_full_rank_after_reg(0, 0);
-    test_full_rank_after_reg(0, 1);
-    test_full_rank_after_reg(1, 0);
-    test_full_rank_after_reg(1, 1);
+    test_full_rank_after_reg(0);
+    test_full_rank_after_reg(1);
 }

--- a/test/comps/test_util.cc
+++ b/test/comps/test_util.cc
@@ -2,6 +2,7 @@
 #include "rl_blaspp.hh"
 
 #include <RandBLAS.hh>
+#include <RandBLAS/test_util.hh>
 
 #include <math.h>
 #include <chrono>
@@ -167,4 +168,40 @@ TEST_F(TestUtil, test_binary_rank_search_zero_mat) {
     std::vector<double> A(m * n, 0.0); 
 
     test_binary_rank_search_zero_mat<double>(m, n, A);
+}
+
+
+class Test_Inplace_Square_Transpose : public ::testing::Test
+{
+    protected:
+
+    virtual void SetUp() {};
+
+    virtual void TearDown() {};
+
+    virtual void apply(blas::Layout layout) {
+        int64_t n = 37;
+        RandBLAS::dense::DenseDist D{n, n};
+        RandBLAS::base::RNGState state(1);
+        double *A1 = new double[n*n];
+        state = RandBLAS::dense::fill_buff(A1, D, state);
+        double *A2 = new double[n*n];
+        blas::copy(n*n, A1, 1, A2, 1);
+        RandLAPACK::util::transpose_square(A2, n);
+        RandBLAS_Testing::Util::matrices_approx_equal(
+            layout, blas::Op::Trans, n, n, A1, n, A2, n, 
+            __PRETTY_FUNCTION__, __FILE__, __LINE__
+        );
+        delete [] A1;
+        delete [] A2;
+    }
+
+};
+
+TEST_F(Test_Inplace_Square_Transpose, random_matrix_colmajor) {
+    apply(blas::Layout::ColMajor);
+}
+
+TEST_F(Test_Inplace_Square_Transpose, random_matrix_rowmajor) {
+    apply(blas::Layout::RowMajor);
 }


### PR DESCRIPTION
get SVD-based preconditioning to work fully in row-major or fully in column-major (rather than requiring the right singular vectors to be in column-major). Also, implement a simple in-place transpose for square matrices; we use this function to avoid allocating extra workspace in computing preconditioners in the column-major case.