### PR TITLE
Chol check

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -58,6 +58,7 @@ add_benchmark(NAME CQRRPT_inner_speed CXX_SOURCES CQRRPT_inner_speed.cc  LINK_LI
 add_benchmark(NAME CQRRPT_embedding_speed_effect CXX_SOURCES CQRRPT_embedding_speed_effect.cc  LINK_LIBS ${Benchmark_libs})
 add_benchmark(NAME CQRRPT_vs_HQRRP_speed CXX_SOURCES CQRRPT_vs_HQRRP_speed.cc LINK_LIBS ${Benchmark_libs})
 add_benchmark(NAME QR_accuracy_stability_analysis CXX_SOURCES QR_accuracy_stability_analysis.cc LINK_LIBS ${Benchmark_libs})
+add_benchmark(NAME Chol_check CXX_SOURCES Chol_check.cc LINK_LIBS ${Benchmark_libs})
 
 # Data processing scripts for CQRRPT paper
 add_benchmark(NAME CQRRPT_vs_HQRRP_flops CXX_SOURCES CQRRPT_vs_HQRRP_flops.cc  LINK_LIBS ${Benchmark_libs})

--- a/benchmark/Chol_check.cc
+++ b/benchmark/Chol_check.cc
@@ -11,44 +11,46 @@ static void
 chol_check(int64_t m, int64_t k, RandBLAS::base::RNGState<RNG> state) {
 
     std::vector<T> A(m * m, 0.0);
-    std::vector<T> A_symm(k * k, 0.0);
-    std::vector<T> R_buf(k * k, 0.0);
+    std::vector<T> A_leading_submat_symm(k * k, 0.0);
+    std::vector<T> R_submat(k * k, 0.0);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, A, m, state, std::make_tuple(0, std::pow(10, 8), false));
 
     T* A_dat = A.data();
-    T* A_symm_dat = A_symm.data();
-    T* R_buf_dat = R_buf.data();
+    T* A_leading_submat_symm_dat = A_leading_submat_symm.data();
+    T* R_submat_dat = R_submat.data();
 
-    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, k, 1.0, A.data(), k, 0.0, A_symm.data(), k);
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, k, 1.0, A.data(), k, 0.0, A_leading_submat_symm.data(), k);
 
-    A[0] = A_symm[0];
+    A[0] = A_leading_submat_symm[0];
     for(int i = 1; i < k; ++i) {
         // Fill the upper-triangular part
-        blas::copy(i + 1, &A_symm_dat[(i * k)], 1, &A_dat[i * m], 1);
+        blas::copy(i + 1, &A_leading_submat_symm_dat[(i * k)], 1, &A_dat[i * m], 1);
         // Fill the lower-triangular part
-        blas::copy(k - i, &A_symm_dat[(i - 1) + (i * k)], k, &A_dat[i + ((i-1) * m)], 1);
+        blas::copy(k - i, &A_leading_submat_symm_dat[(i - 1) + (i * k)], k, &A_dat[i + ((i-1) * m)], 1);
         // Also fill the full symmetric matrix
-        blas::copy(k - i, &A_symm_dat[(i - 1) + (i * k)], k, &A_symm_dat[i + ((i-1) * k)], 1);
+        blas::copy(k - i, &A_leading_submat_symm_dat[(i - 1) + (i * k)], k, &A_leading_submat_symm_dat[i + ((i-1) * k)], 1);
     }
 
     // Now, the k by k portion of A is summetric and the rest is random
 
     if(lapack::potrf(Uplo::Upper, m, A_dat, m)) 
-        printf("CHOLESKY FAILED AS EXPECTED\n");
+        printf("Cholesky failed as expected.\n");
 
     // Copy the k by k portion of the R factor
-    lapack::lacpy(MatrixType::Upper, k, k, A_dat, m, R_buf_dat, k);
+    lapack::lacpy(MatrixType::Upper, k, k, A_dat, m, R_submat_dat, k);
 
     // Doing this through GEMM to perform subtraction immediately
-    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, k, 1.0, R_buf_dat, k, R_buf_dat, k, -1.0, A_symm_dat, k);
+    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, k, 1.0, R_submat_dat, k, R_submat_dat, k, -1.0, A_leading_submat_symm_dat, k);
 
-    T norm = lapack::lange(Norm::Fro, k, k, A_symm_dat, k);
+    T norm = lapack::lange(Norm::Fro, k, k, A_leading_submat_symm_dat, k);
     printf("||R[:k, :k]'*R[:k, :k] - A[:k, :k]||_F:  %e\n", norm);
 }
 
 int main() {
-    auto state = RandBLAS::base::RNGState();
-    chol_check<double, r123::Philox4x32>(1000, 500, state);
+    for(int i = 0; i < 10; ++i) {
+        auto state = RandBLAS::base::RNGState(i);
+        chol_check<double, r123::Philox4x32>(1000, 500, state);
+    }
     return 0;
 }

--- a/benchmark/Chol_check.cc
+++ b/benchmark/Chol_check.cc
@@ -1,0 +1,64 @@
+#include "RandLAPACK.hh"
+#include "rl_blaspp.hh"
+
+#include <RandBLAS.hh>
+#include <math.h>
+#include <chrono>
+/*
+Auxillary benchmark routine, computes flops using GEMM for a given system
+*/
+
+using namespace std::chrono;
+using namespace RandLAPACK;
+
+template <typename T, typename RNG>
+static void 
+chol_check(int64_t m, int64_t k, RandBLAS::base::RNGState<RNG> state) {
+
+    std::vector<T> A(m * m, 0.0);
+    std::vector<T> A_symm(k * k, 0.0);
+    std::vector<T> R_buf(k * k, 0.0);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, m, A, m, state, std::make_tuple(0, std::pow(10, 8), false));
+
+    T* A_dat = A.data();
+    T* A_symm_dat = A_symm.data();
+    T* R_buf_dat = R_buf.data();
+
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, k, 1.0, A.data(), k, 0.0, A_symm.data(), k);
+
+    A[0] = A_symm[0];
+    for(int i = 1; i < k; ++i) {
+        // Fill the upper-triangular part
+        blas::copy(i + 1, &A_symm_dat[(i * k)], 1, &A_dat[i * m], 1);
+        // Fill the lower-triangular part
+        blas::copy(k - i, &A_symm_dat[(i - 1) + (i * k)], k, &A_dat[i + ((i-1) * m)], 1);
+        // Also fill the full symmetric matrix
+        blas::copy(k - i, &A_symm_dat[(i - 1) + (i * k)], k, &A_symm_dat[i + ((i-1) * k)], 1);
+    }
+
+    // Now, the k by k portion of A is summetric and the rest is random
+
+    if(lapack::potrf(Uplo::Upper, m, A_dat, m)) 
+        printf("CHOLESKY FAILED AS EXPECTED\n");
+
+    //char name_R [] = "R"; 
+    //RandBLAS::util::print_colmaj(m, m, A_dat, name_R);
+
+    // Copy the k by k portion of the R factor
+    lapack::lacpy(MatrixType::Upper, k, k, A_dat, m, R_buf_dat, k);
+
+    //RandBLAS::util::print_colmaj(k, k, R_buf_dat, name_R);
+
+    // Doing this through GEMM to perform subtraction immediately
+    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, k, 1.0, R_buf_dat, k, R_buf_dat, k, -1.0, A_symm_dat, k);
+
+    T norm = lapack::lange(Norm::Fro, k, k, A_symm_dat, k);
+    printf("||R[:k, :k]'*R[:k, :k] - A[:k, :k]||_F:  %e\n", norm);
+}
+
+int main() {
+    auto state = RandBLAS::base::RNGState();
+    chol_check<double, r123::Philox4x32>(1000, 500, state);
+    return 0;
+}

--- a/benchmark/Chol_check.cc
+++ b/benchmark/Chol_check.cc
@@ -2,11 +2,6 @@
 #include "rl_blaspp.hh"
 
 #include <RandBLAS.hh>
-#include <math.h>
-#include <chrono>
-/*
-Auxillary benchmark routine, computes flops using GEMM for a given system
-*/
 
 using namespace std::chrono;
 using namespace RandLAPACK;
@@ -42,13 +37,8 @@ chol_check(int64_t m, int64_t k, RandBLAS::base::RNGState<RNG> state) {
     if(lapack::potrf(Uplo::Upper, m, A_dat, m)) 
         printf("CHOLESKY FAILED AS EXPECTED\n");
 
-    //char name_R [] = "R"; 
-    //RandBLAS::util::print_colmaj(m, m, A_dat, name_R);
-
     // Copy the k by k portion of the R factor
     lapack::lacpy(MatrixType::Upper, k, k, A_dat, m, R_buf_dat, k);
-
-    //RandBLAS::util::print_colmaj(k, k, R_buf_dat, name_R);
 
     // Doing this through GEMM to perform subtraction immediately
     blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, k, 1.0, R_buf_dat, k, R_buf_dat, k, -1.0, A_symm_dat, k);

--- a/benchmark/Chol_check.cc
+++ b/benchmark/Chol_check.cc
@@ -3,7 +3,6 @@
 
 #include <RandBLAS.hh>
 
-using namespace std::chrono;
 using namespace RandLAPACK;
 
 template <typename T, typename RNG>


### PR DESCRIPTION
Adding a benchmark for checking if a failed Cholesky factorization outputs garbage. 

Consider performing Cholesky factorization on a matrix $A$ with an SPD leading submatrix $A[:k, :k]$ and an arbitrarily-defined non-SPD residual part. Then, Cholesky factorization defined by LAPACKs `potrf()` function will naturally fail. However, from this benchmark we learned that the leading $k$ by $k$ submatrix of the output $R$ factor will be well-formed, i.e. 
```math
(R[:k, :k])^{*} R[:k, :k] = A[:k, :k],
``` 
at least with Intel MKL. This is useful for the cases when k is overestimated on line 4 in CQRRPT to the point that `potrf()` fails - we now know that we won't need to re-run cholesky factorization, but would rather just truncate whenever appropriate.