### PR TITLE
Adding reinforced rank estimation to CQRRPT.

### DIFF
--- a/RandLAPACK/comps/rl_util.hh
+++ b/RandLAPACK/comps/rl_util.hh
@@ -883,6 +883,5 @@ void eat_lda_slack(
     delete [] work;
 }
 
-
 } // end namespace util
 #endif

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -297,6 +297,12 @@ int CQRRPT<T, RNG>::call(
         // Clear R
         std::fill(R.begin(), R.end(), 0.0);
     }
+        // orth is 14 without
+        // orth is 13 with
+        k = 295;
+        this->rank = 295;
+
+    printf("FIRST RANK ESTIMATION %ld\n", k);
 
     if(this -> timing) {
         rank_reveal_t_stop = high_resolution_clock::now();
@@ -382,6 +388,8 @@ int CQRRPT<T, RNG>::call(
 
     k = new_rank;
     this->rank = new_rank;
+
+    printf("SECOND RANK ESTIMATION %ld\n", k);
 
     blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, 1.0, R_sp_dat, k, A_dat, m);
 

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -367,6 +367,21 @@ int CQRRPT<T, RNG>::call(
         return 1;
     }
 
+    // Re-estimate rank after we have the R-factor form Cholesky QR
+    // The strategy here is the same as in naive rank estimation
+    int64_t new_rank = k;
+    for(i = 0; i < k; ++i) {
+        if(std::abs(R_sp_dat[i * k + i]) / std::abs(R_sp_dat[0]) < this->eps) {
+            new_rank = i;
+            break;
+        }
+    }
+    // Beware of that R_sp_dat is k by k and needs to be downsized by rows
+    RandLAPACK::util::row_resize(k, k, R_sp, new_rank);
+
+    k = new_rank;
+    this->rank = new_rank;
+
     blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, 1.0, R_sp_dat, k, A_dat, m);
 
     if(this -> timing)

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -297,9 +297,8 @@ int CQRRPT<T, RNG>::call(
         // Clear R
         std::fill(R.begin(), R.end(), 0.0);
     }
-    k = n;
-    this->rank = k;
-    printf("FIRST RANK ESTIMATION %ld\n", k);
+
+    printf("INITIAL RANK ESTIMATION %ld\n", k);
 
     if(this -> timing) {
         rank_reveal_t_stop = high_resolution_clock::now();
@@ -375,7 +374,6 @@ int CQRRPT<T, RNG>::call(
     // This also automatically takes care of any potentical failures in Cholesky factorization.
     // Note that the diagonal of R_sp_dat may not be sorted, so we need to keep the running max/min
     // We expect the loss in the orthogonality of Q to be approximately equal to 10^-15 * cond(R_sp_dat)^2
-    /*
     int64_t new_rank = k;
     T running_max = R_sp_dat[0];
     T running_min = R_sp_dat[0];
@@ -388,29 +386,20 @@ int CQRRPT<T, RNG>::call(
         
         if(curr_entry < running_min) running_max = running_min;
         
-        if(running_max / running_min >= std::sqrt(this->eps / 10e-15)) {
-            printf("Re-adjusting rank\n");
-            new_rank = i - 1;
-            break;
-        }
+        printf("%e\n", std::sqrt(10e-14 / 10e-16));
+        //if(running_max / running_min >= std::sqrt(this->eps / 10e-16)) {
+        //    printf("Re-adjusting rank, cond is %e\n", running_max/running_min);
+            //new_rank = i - 1;
+            //break;
+        //}
     }
-    
-
-    char name [] = "A";
-    RandBLAS::util::print_colmaj(k, k, R_sp_dat, name);
-*/
-    int64_t new_rank = 5;
+    new_rank = 2;
     // Beware of that R_sp_dat is k by k and needs to be downsized by rows
     RandLAPACK::util::row_resize(k, k, R_sp, new_rank);
     RandLAPACK::util::row_resize(k, n, R, new_rank);
     
     k = new_rank;
     this->rank = k;
-    
-    char name [] = "A";
-    RandBLAS::util::print_colmaj(k, k, R_sp_dat, name);
-
-    //printf("SECOND RANK ESTIMATION %ld\n", new_rank);
 
     blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, 1.0, R_sp_dat, k, A_dat, m);
 
@@ -420,8 +409,6 @@ int CQRRPT<T, RNG>::call(
     // Get R
     // trmm
     blas::trmm(Layout::ColMajor, Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, k, n, 1.0, R_sp_dat, k, R_dat, k);
-
-    RandBLAS::util::print_colmaj(k, n, R_dat, name);
 
     if(this -> timing) {
         saso_t_dur        = duration_cast<microseconds>(saso_t_stop - saso_t_start).count();
@@ -440,7 +427,6 @@ int CQRRPT<T, RNG>::call(
         // Fill the data vector
         this -> times = {saso_t_dur, qrcp_t_dur, rank_reveal_t_dur, cholqr_t_dur, a_mod_piv_t_dur, a_mod_trsm_t_dur, copy_t_dur, resize_t_dur, t_rest, total_t_dur};
     }
-
     return 0;
 }
 

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -256,7 +256,7 @@ int CQRRPT<T, RNG>::call(
 
     int64_t k = n;
     int i;
-    T eps_initial_rank_estimation = 2 * std::numeric_limits<double>::epsilon();
+    T eps_initial_rank_estimation = 2 * std::pow(std::numeric_limits<double>::epsilon(), 0.95);
     if(this->naive_rank_estimate) {
         /// Using R[i,i] to approximate the i-th singular value of A_hat. 
         /// Truncate at the largest i where R[i,i] / R[0,0] >= eps.
@@ -389,6 +389,8 @@ int CQRRPT<T, RNG>::call(
             break;
         }
     }
+    //new_rank = 100;
+
     // Beware of that R_sp and R have k rows and need to be downsized by rows
     RandLAPACK::util::row_resize(k, k, R_sp, new_rank);
     RandLAPACK::util::row_resize(k, n, R, new_rank);

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -256,7 +256,7 @@ int CQRRPT<T, RNG>::call(
 
     int64_t k = n;
     int i;
-    T eps_initial_rank_estimation = 2 * std::pow(std::numeric_limits<double>::epsilon(), 0.95);
+    T eps_initial_rank_estimation = 2 * std::pow(std::numeric_limits<T>::epsilon(), 0.95);
     if(this->naive_rank_estimate) {
         /// Using R[i,i] to approximate the i-th singular value of A_hat. 
         /// Truncate at the largest i where R[i,i] / R[0,0] >= eps.
@@ -384,7 +384,7 @@ int CQRRPT<T, RNG>::call(
         if(curr_entry > running_max) running_max = curr_entry;
         if(curr_entry < running_min) running_max = running_min;
 
-        if(running_max / running_min >= std::sqrt(this->eps / 10e-16)) {
+        if(running_max / running_min >= std::sqrt(this->eps / std::numeric_limits<T>::epsilon())) {
             new_rank = i - 1;
             break;
         }

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -395,10 +395,13 @@ int CQRRPT<T, RNG>::call(
         }
     }
     */
-    int64_t new_rank = 298;
+    char name [] = "A";
+    RandBLAS::util::print_colmaj(k, k, R_sp.data(), name);
+    new_rank = 100;
     // Beware of that R_sp_dat is k by k and needs to be downsized by rows
     RandLAPACK::util::row_resize(k, k, R_sp, new_rank);
-
+    RandBLAS::util::print_colmaj(new_rank, new_rank, R_sp.data(), name);
+    
     k = new_rank;
     this->rank = new_rank;
 

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -367,8 +367,9 @@ int CQRRPT<T, RNG>::call(
         return 1;
     }
 
-    // Re-estimate rank after we have the R-factor form Cholesky QR
-    // The strategy here is the same as in naive rank estimation
+    // Re-estimate rank after we have the R-factor form Cholesky QR.
+    // The strategy here is the same as in naive rank estimation.
+    // This also automatically takes care of any potentical failures in Cholesky factorization.
     int64_t new_rank = k;
     for(i = 0; i < k; ++i) {
         if(std::abs(R_sp_dat[i * k + i]) / std::abs(R_sp_dat[0]) < this->eps) {

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -394,18 +394,23 @@ int CQRRPT<T, RNG>::call(
             break;
         }
     }
-    */
+    
+
     char name [] = "A";
-    RandBLAS::util::print_colmaj(k, k, R_sp.data(), name);
-    new_rank = 100;
+    RandBLAS::util::print_colmaj(k, k, R_sp_dat, name);
+*/
+    int64_t new_rank = 5;
     // Beware of that R_sp_dat is k by k and needs to be downsized by rows
     RandLAPACK::util::row_resize(k, k, R_sp, new_rank);
-    RandBLAS::util::print_colmaj(new_rank, new_rank, R_sp.data(), name);
+    RandLAPACK::util::row_resize(k, n, R, new_rank);
     
     k = new_rank;
-    this->rank = new_rank;
+    this->rank = k;
+    
+    char name [] = "A";
+    RandBLAS::util::print_colmaj(k, k, R_sp_dat, name);
 
-    printf("SECOND RANK ESTIMATION %ld\n", new_rank);
+    //printf("SECOND RANK ESTIMATION %ld\n", new_rank);
 
     blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, 1.0, R_sp_dat, k, A_dat, m);
 
@@ -415,6 +420,8 @@ int CQRRPT<T, RNG>::call(
     // Get R
     // trmm
     blas::trmm(Layout::ColMajor, Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, k, n, 1.0, R_sp_dat, k, R_dat, k);
+
+    RandBLAS::util::print_colmaj(k, n, R_dat, name);
 
     if(this -> timing) {
         saso_t_dur        = duration_cast<microseconds>(saso_t_stop - saso_t_start).count();

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -256,11 +256,12 @@ int CQRRPT<T, RNG>::call(
 
     int64_t k = n;
     int i;
+    T eps_initial_rank_estimation = 2 * std::numeric_limits<double>::epsilon();
     if(this->naive_rank_estimate) {
         /// Using R[i,i] to approximate the i-th singular value of A_hat. 
         /// Truncate at the largest i where R[i,i] / R[0,0] >= eps.
         for(i = 0; i < n; ++i) {
-            if(std::abs(A_hat_dat[i * d + i]) / std::abs(A_hat_dat[0]) < this->eps) {
+            if(std::abs(A_hat_dat[i * d + i]) / std::abs(A_hat_dat[0]) < eps_initial_rank_estimation) {
                 k = i;
                 break;
             }
@@ -282,23 +283,21 @@ int CQRRPT<T, RNG>::call(
         } else {
             // find l2 norm of the full R
             norm_R = RandLAPACK::util::estimate_spectral_norm(n, n, R_dat, 10, state);
-            this->eps = 5 * this->eps;
+            eps_initial_rank_estimation = 5 * eps_initial_rank_estimation;
         }
 
         T norm_R_sub = lapack::lange(Norm::Fro, 1, n, &R_dat[(n - 1) * n], 1);
         // Check if R is full column rank checking if||A[n - 1:, n - 1:]||_F > tau_trunk * ||A||_F
-        if ((norm_R_sub > this->eps * norm_R)) {
+        if ((norm_R_sub > eps_initial_rank_estimation * norm_R)) {
             k = n;
         } else {
-            k = RandLAPACK::util::rank_search_binary(0, n + 1, std::floor(n / 2), n, norm_R, this->eps, R_dat);
+            k = RandLAPACK::util::rank_search_binary(0, n + 1, std::floor(n / 2), n, norm_R, eps_initial_rank_estimation, R_dat);
         }
 
         this->rank = k;
         // Clear R
         std::fill(R.begin(), R.end(), 0.0);
     }
-
-    printf("INITIAL RANK ESTIMATION %ld\n", k);
 
     if(this -> timing) {
         rank_reveal_t_stop = high_resolution_clock::now();
@@ -383,18 +382,14 @@ int CQRRPT<T, RNG>::call(
         curr_entry = std::abs(R_sp[i * k + i]);
         
         if(curr_entry > running_max) running_max = curr_entry;
-        
         if(curr_entry < running_min) running_max = running_min;
-        
-        printf("%e\n", std::sqrt(10e-14 / 10e-16));
-        //if(running_max / running_min >= std::sqrt(this->eps / 10e-16)) {
-        //    printf("Re-adjusting rank, cond is %e\n", running_max/running_min);
-            //new_rank = i - 1;
-            //break;
-        //}
+
+        if(running_max / running_min >= std::sqrt(this->eps / 10e-16)) {
+            new_rank = i - 1;
+            break;
+        }
     }
-    new_rank = 2;
-    // Beware of that R_sp_dat is k by k and needs to be downsized by rows
+    // Beware of that R_sp and R have k rows and need to be downsized by rows
     RandLAPACK::util::row_resize(k, k, R_sp, new_rank);
     RandLAPACK::util::row_resize(k, n, R, new_rank);
     
@@ -418,11 +413,11 @@ int CQRRPT<T, RNG>::call(
         copy_t_dur       += duration_cast<microseconds>(copy_t_stop - copy_t_start).count();
         a_mod_piv_t_dur   = duration_cast<microseconds>(a_mod_piv_t_stop - a_mod_piv_t_start).count();
         a_mod_trsm_t_dur  = duration_cast<microseconds>(a_mod_trsm_t_stop - a_mod_trsm_t_start).count();
-        cholqr_t_dur    = duration_cast<microseconds>(cholqr_t_stop - cholqr_t_start).count();
+        cholqr_t_dur      = duration_cast<microseconds>(cholqr_t_stop - cholqr_t_start).count();
 
         total_t_stop = high_resolution_clock::now();
         total_t_dur  = duration_cast<microseconds>(total_t_stop - total_t_start).count();
-        long t_rest = total_t_dur - (saso_t_dur + qrcp_t_dur + rank_reveal_t_dur + cholqr_t_dur + a_mod_piv_t_dur + a_mod_trsm_t_dur + copy_t_dur + resize_t_dur);
+        long t_rest  = total_t_dur - (saso_t_dur + qrcp_t_dur + rank_reveal_t_dur + cholqr_t_dur + a_mod_piv_t_dur + a_mod_trsm_t_dur + copy_t_dur + resize_t_dur);
 
         // Fill the data vector
         this -> times = {saso_t_dur, qrcp_t_dur, rank_reveal_t_dur, cholqr_t_dur, a_mod_piv_t_dur, a_mod_trsm_t_dur, copy_t_dur, resize_t_dur, t_rest, total_t_dur};

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -127,7 +127,6 @@ class TestCQRRPT : public ::testing::Test
 };
 
 // Note: If Subprocess killed exception -> reload vscode
-/*
 TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp) {
     int64_t m = 10000;
     int64_t n = 200;
@@ -167,7 +166,6 @@ TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp) {
     norm_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
     test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
-*/
 
 // Using L2 norm rank estimation here is similar to using raive estimation. 
 // Fro norm underestimates rank even worse. 
@@ -177,7 +175,7 @@ TEST_F(TestCQRRPT, CQRRPT_bad_orth) {
     int64_t k = 0;
     int64_t d = 300;
     double norm_A = 0;
-    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.95);
+    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     printf("TOL IS %e\n", tol);
     auto state = RandBLAS::base::RNGState();
 

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -117,6 +117,7 @@ class TestCQRRPT : public ::testing::Test
         CQRRPT.call(m, n, all_data.A, d, all_data.R, all_data.J);
 
         all_data.rank = CQRRPT.rank;
+        printf("RANK AS RETURNED BY CQRRPT %ld\n", all_data.rank);
 
         RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1, all_data.J);
         RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2, all_data.J);
@@ -148,7 +149,7 @@ TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp)
     test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
 */
-/*
+
 TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp)
 {
     int64_t m = 10000;
@@ -169,8 +170,8 @@ TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp)
     norm_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
     test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
-*/
 
+/*
 TEST_F(TestCQRRPT, CQRRPT_bad_orth)
 {
     int64_t m = 10e4;
@@ -191,7 +192,7 @@ TEST_F(TestCQRRPT, CQRRPT_bad_orth)
     norm_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
     test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
-
+*/
 /*
 //shows that row_resize works well
 TEST_F(TestCQRRPT, sanity_check)

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -124,8 +124,9 @@ class TestCQRRPT : public ::testing::Test
         error_check(norm_A, all_data); 
     }
 };
-/*
+
 // Note: If Subprocess killed exception -> reload vscode
+/*
 TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp)
 {
     int64_t m = 10000;
@@ -146,7 +147,8 @@ TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp)
     norm_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
     test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
-
+*/
+/*
 TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp)
 {
     int64_t m = 10000;
@@ -168,6 +170,7 @@ TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp)
     test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
 */
+
 TEST_F(TestCQRRPT, CQRRPT_bad_orth)
 {
     int64_t m = 10e4;
@@ -188,3 +191,22 @@ TEST_F(TestCQRRPT, CQRRPT_bad_orth)
     norm_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
     test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
+
+/*
+//shows that row_resize works well
+TEST_F(TestCQRRPT, sanity_check)
+{
+    int64_t m = 5;
+    int64_t n = 5;
+    int64_t k = 5;
+    auto state = RandBLAS::base::RNGState();
+    std::vector<double> A (m * n, 0.0);
+
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, A, k, state, std::make_tuple(0, 2, false));
+    char name [] = "A";
+    RandBLAS::util::print_colmaj(m, n, A.data(), name);
+    RandLAPACK::util::row_resize(m, n, A, 3);
+    RandBLAS::util::print_colmaj(3, n, A.data(), name);
+    
+}
+*/

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -62,6 +62,8 @@ class TestCQRRPT : public ::testing::Test
         auto n = all_data.col;
         auto k = all_data.rank;
 
+        printf("RANK AS RETURNED BY CQRRPT %ld\n", all_data.rank);
+
         RandLAPACK::util::upsize(k * k, all_data.I_ref);
         RandLAPACK::util::eye(k, k, all_data.I_ref);
 

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -122,20 +122,13 @@ class TestCQRRPT : public ::testing::Test
         RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1, all_data.J);
         RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2, all_data.J);
 
-        int64_t k = all_data.rank;
-        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, k, 1.0, all_data.A.data(), m, all_data.R.data(), k, -1.0, all_data.A_cpy1.data(), m);
-        T norm_AQR = lapack::lange(Norm::Fro, m, n, all_data.A_cpy1.data(), m);
-        printf("REL NORM OF AP - QR: %15e\n", norm_AQR / norm_A);
-        ASSERT_NEAR(norm_AQR / norm_A,         0.0, 10 * std::pow(10, -13));
-
-        //error_check(norm_A, all_data); 
+        error_check(norm_A, all_data); 
     }
 };
 
 // Note: If Subprocess killed exception -> reload vscode
 /*
-TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp)
-{
+TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp) {
     int64_t m = 10000;
     int64_t n = 200;
     int64_t k = 200;
@@ -154,19 +147,12 @@ TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp)
     norm_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
     test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
-*/
 
 TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp) {
-    /*
     int64_t m = 10000;
     int64_t n = 200;
     int64_t k = 100;
     int64_t d = 400;
-    */
-    int64_t m = 10;
-    int64_t n = 7;
-    int64_t k = 5;
-    int64_t d = 10;
     double norm_A = 0;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
@@ -181,16 +167,18 @@ TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp) {
     norm_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
     test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
+*/
 
-/*
-TEST_F(TestCQRRPT, CQRRPT_bad_orth)
-{
+// Using L2 norm rank estimation here is similar to using raive estimation. 
+// Fro norm underestimates rank even worse. 
+TEST_F(TestCQRRPT, CQRRPT_bad_orth) {
     int64_t m = 10e4;
     int64_t n = 300;
     int64_t k = 0;
     int64_t d = 300;
     double norm_A = 0;
-    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
+    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.95);
+    printf("TOL IS %e\n", tol);
     auto state = RandBLAS::base::RNGState();
 
     CQRRPTTestData<double> all_data(m, n, k);
@@ -203,22 +191,3 @@ TEST_F(TestCQRRPT, CQRRPT_bad_orth)
     norm_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
     test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
-*/
-/*
-//shows that row_resize works well
-TEST_F(TestCQRRPT, sanity_check)
-{
-    int64_t m = 5;
-    int64_t n = 5;
-    int64_t k = 5;
-    auto state = RandBLAS::base::RNGState();
-    std::vector<double> A (m * n, 0.0);
-
-    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, A, k, state, std::make_tuple(0, 2, false));
-    char name [] = "A";
-    RandBLAS::util::print_colmaj(m, n, A.data(), name);
-    RandLAPACK::util::row_resize(m, n, A, 3);
-    RandBLAS::util::print_colmaj(3, n, A.data(), name);
-    
-}
-*/

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -19,43 +19,108 @@ class TestCQRRPT : public ::testing::Test
 
     template <typename T>
     struct CQRRPTTestData {
+        int64_t row;
+        int64_t col;
+        int64_t rank; // has to be modifiable
         std::vector<T> A;
         std::vector<T> R;
         std::vector<int64_t> J;
-        std::vector<T> A_cpy;
+        std::vector<T> A_cpy1;
+        std::vector<T> A_cpy2;
+        std::vector<T> I_ref;
 
-        CQRRPTTestData(int64_t m, int64_t n) :
+        CQRRPTTestData(int64_t m, int64_t n, int64_t k) :
         A(m * n, 0.0), 
         J(n, 0.0),  
-        A_cpy(m * n, 0.0) 
-        {}
+        A_cpy1(m * n, 0.0),
+        A_cpy2(m * n, 0.0),
+        I_ref(k * k, 0.0) 
+        {
+            row = m;
+            col = n;
+            rank = k;
+        }
     };
+
+    template <typename T, typename RNG>
+    static void norm_ident_and_copy_computational_helper(T& norm_A, CQRRPTTestData<T>& all_data) {
+        auto m = all_data.row;
+        auto n = all_data.col;
+        auto k = all_data.rank;
+
+        lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy1.data(), m);
+        lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy2.data(), m);
+        RandLAPACK::util::eye(k, k, all_data.I_ref);
+        norm_A = lapack::lange(Norm::Fro, m, n, all_data.A.data(), m);
+    }
+
+
+    /// This routine also appears in benchmarks, but idk if it should be put into utils
+    template <typename T>
+    static void
+    error_check(T& norm_A, CQRRPTTestData<T>& all_data) {
+
+        auto m = all_data.row;
+        auto n = all_data.col;
+        auto k = all_data.rank;
+
+        T* A_dat         = all_data.A_cpy1.data();
+        T const* A_cpy_dat = all_data.A_cpy2.data();
+        T const* Q_dat   = all_data.A.data();
+        T const* R_dat   = all_data.R.data();
+        T* I_ref_dat     = all_data.I_ref.data();
+
+        // Check orthogonality of Q
+        // Q' * Q  - I = 0
+        blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, Q_dat, m, -1.0, I_ref_dat, k);
+        T norm_0 = lapack::lansy(lapack::Norm::Fro, Uplo::Upper, k, I_ref_dat, k);
+
+        // A - QR
+        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, k, 1.0, Q_dat, m, R_dat, k, -1.0, A_dat, m);
+        
+        // Implementing max col norm metric
+        T max_col_norm = 0.0;
+        T col_norm = 0.0;
+        int max_idx = 0;
+        for(int i = 0; i < n; ++i) {
+            col_norm = blas::nrm2(m, &A_dat[m * i], 1);
+            if(max_col_norm < col_norm) {
+                max_col_norm = col_norm;
+                max_idx = i;
+            }
+        }
+        T col_norm_A = blas::nrm2(n, &A_cpy_dat[m * max_idx], 1);
+        T norm_AQR = lapack::lange(Norm::Fro, m, n, A_dat, m);
+        
+        printf("REL NORM OF AP - QR: %15e\n", norm_AQR / norm_A);
+        printf("MAX COL NORM METRIC: %15e\n", max_col_norm / col_norm_A);
+        printf("FRO NORM OF Q' * Q - I: %2e\n\n", norm_0);
+
+        ASSERT_NEAR(norm_AQR / norm_A,         0.0, 10 * std::pow(10, -13));
+        ASSERT_NEAR(max_col_norm / col_norm_A, 0.0, 10 * std::pow(10, -13));
+        ASSERT_NEAR(norm_0,                    0.0, 10 * std::pow(10, -13));
+    }
 
     /// General test for CQRRPT:
     /// Computes QR factorzation, and computes A[:, J] - QR.
     template <typename T, typename RNG>
     static void test_CQRRPT_general(
-        int64_t m, 
-        int64_t n, 
-        int64_t k, 
         int64_t d, 
+        T norm_A,
         CQRRPTTestData<T>& all_data,
         RandLAPACK::CQRRPT<T, RNG>& CQRRPT) {
 
+        auto m = all_data.row;
+        auto n = all_data.col;
+
         CQRRPT.call(m, n, all_data.A, d, all_data.R, all_data.J);
 
-        T* A_dat = all_data.A.data();
-        T* A_cpy_dat = all_data.A_cpy.data();
-        T* R_dat = all_data.R.data();
-        k = CQRRPT.rank;
+        all_data.rank = CQRRPT.rank;
 
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy, all_data.J);
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1, all_data.J);
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2, all_data.J);
 
-        // AP - QR
-        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, k, 1.0, A_dat, m, R_dat, k, -1.0, A_cpy_dat, m);
-
-        T norm_test = lapack::lange(Norm::Fro, m, n, A_cpy_dat, m);
-        printf("FRO NORM OF AP - QR:  %e\n", norm_test);
+        error_check(norm_A, all_data); 
     }
 };
 
@@ -66,18 +131,19 @@ TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp)
     int64_t n = 200;
     int64_t k = 200;
     int64_t d = 400;
+    double norm_A = 0;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
 
-    CQRRPTTestData<double> all_data(m, n);
+    CQRRPTTestData<double> all_data(m, n, k);
     RandLAPACK::CQRRPT<double, r123::Philox4x32> CQRRPT(false, false, state, tol);
     CQRRPT.nnz = 2;
     CQRRPT.num_threads = 4;
     CQRRPT.no_hqrrp = 1;
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
-    lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
-    test_CQRRPT_general<double, r123::Philox4x32>(m, n, k, d, all_data, CQRRPT);
+    norm_ident_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
+    test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }
 
 TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp)
@@ -86,16 +152,17 @@ TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp)
     int64_t n = 200;
     int64_t k = 100;
     int64_t d = 400;
+    double norm_A = 0;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::base::RNGState();
 
-    CQRRPTTestData<double> all_data(m, n);
+    CQRRPTTestData<double> all_data(m, n, k);
     RandLAPACK::CQRRPT<double, r123::Philox4x32> CQRRPT(false, false, state, tol);
     CQRRPT.nnz = 2;
     CQRRPT.num_threads = 4;
-    CQRRPT.no_hqrrp = 0;
+    CQRRPT.no_hqrrp = 1;
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2, false));
-    lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
-    test_CQRRPT_general<double, r123::Philox4x32>(m, n, k, d, all_data, CQRRPT);
+    norm_ident_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
+    test_CQRRPT_general<double, r123::Philox4x32>(d, norm_A, all_data, CQRRPT);
 }

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -133,7 +133,7 @@ TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp) {
     int64_t k = 200;
     int64_t d = 400;
     double norm_A = 0;
-    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
+    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.85);
     auto state = RandBLAS::base::RNGState();
 
     CQRRPTTestData<double> all_data(m, n, k);
@@ -153,7 +153,7 @@ TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp) {
     int64_t k = 100;
     int64_t d = 400;
     double norm_A = 0;
-    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
+    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.85);
     auto state = RandBLAS::base::RNGState();
 
     CQRRPTTestData<double> all_data(m, n, k);
@@ -176,7 +176,6 @@ TEST_F(TestCQRRPT, CQRRPT_bad_orth) {
     int64_t d = 300;
     double norm_A = 0;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
-    printf("TOL IS %e\n", tol);
     auto state = RandBLAS::base::RNGState();
 
     CQRRPTTestData<double> all_data(m, n, k);


### PR DESCRIPTION
Simple rank estimation in CQRRPT may cause issue in one of the two metrics:

- if $k$ is overestimated, we loose orthogonality in the $Q$ factor obtained via Cholesky QR.
- If $k$ is underestimated, the quality of final approximation will be insufficient.

We want to find the maximum k for wihich Q remains orthogonal then.
We know that condition number of $Q$ factor form Cholesky QR depends on the condition number of $A^{pre}$.  
Since $A^{pre}$ is already pivoted, we expect the factors obtained from an unpivoted QR factorization of $A^{pre}$ (in our case, Cholesky QR) to not have significant numerical differences from those obtained by pivoted QR. 
Hence, the diagonal entries in the $R$ factor obtained via cholesky QR should have relation to the singular values of $A^{pre}$.
Therefore, we can estimate rank of $A^{pre}$ by looking at the diagonal of $R$.
Furthermore, if Cholesky factorization done via <potrf()> was to fail, this rank re-adjustment would fix the issue by ignoring any garbage data in $R$ (see PR#46 for details).

The initial rank estimation is conrolled via a hardcoded epsilon parameter equaling to 2 * machine_eps^0.95.
This is done with a hope that the estimated rank will be small enough for the $R[:k, :k]$ (adjusted factor retuned from <qrcp()>) to be invertible, but large enough for the reinforced rank estimation to be able to adjust it.

Reinforced rank estimation is controlled by the user-specified <eps> parameter. 
Specifically, k is computed as:
$k = i - 1$ for $i$ such that:
$\max(\mathrm{diag}(R[:i, :i])) / \min(\mathrm{diag}(R[:i, :i])) >= \sqrt{\texttt{tol}/ \epsilon}$.
The right side of the expression comes from the idea that the orthogonality loss in Q is proportional to $\epsilon* \mathrm{cond}(A)^2$, stated [here](https://dl.acm.org/doi/pdf/10.1109/ScalA.2014.11).

I deliberately added a test into test_cqrrpt with a "bad" matrix, where we do need to perform rank re-adjustment.