### PR TITLE
Update RandBLAS submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+benchmark/build/**
+
 # vim
 *.sw*
 

--- a/RandLAPACK/comps/rl_preconditioners.hh
+++ b/RandLAPACK/comps/rl_preconditioners.hh
@@ -47,7 +47,7 @@ void rpc_data_svd(
         lda_sk = d;
     }
     RandBLAS::util::safe_scal(d*n, 0.0, A_sk, 1);
-    RandBLAS::ramm::ramm_general_left(
+    RandBLAS::sketch_general(
         layout,
         blas::Op::NoTrans,
         blas::Op::NoTrans,
@@ -127,7 +127,7 @@ void rpc_data_svd(
  *      time it needs an RNGState.
  */
 template <typename T, typename RNG>
-RandBLAS::base::RNGState<RNG> rpc_data_svd_saso(
+RandBLAS::RNGState<RNG> rpc_data_svd_saso(
     blas::Layout layout,
     int64_t m, // number of rows in A
     int64_t n, // number of columns in A
@@ -137,15 +137,15 @@ RandBLAS::base::RNGState<RNG> rpc_data_svd_saso(
     int64_t lda, // leading dimension for mat(A).
     T *V_sk, // buffer of size at least d*n.
     T *sigma_sk, //buffer of size at least n.
-    RandBLAS::base::RNGState<RNG> state
+    RandBLAS::RNGState<RNG> state
 ) {
-    RandBLAS::sparse::SparseDist D{
+    RandBLAS::SparseDist D{
         .n_rows = d,
         .n_cols = m,
         .vec_nnz = k
     };
-    RandBLAS::sparse::SparseSkOp<T> S(D, state);
-    auto next_state = RandBLAS::sparse::fill_sparse(S);
+    RandBLAS::SparseSkOp<T> S(D, state);
+    auto next_state = RandBLAS::fill_sparse(S);
     rpc_data_svd(layout, m, n, A, lda, S, V_sk, sigma_sk);
     return next_state;
 }

--- a/RandLAPACK/comps/rl_rs.hh
+++ b/RandLAPACK/comps/rl_rs.hh
@@ -36,7 +36,7 @@ class RS : public RowSketcher<T>
         RS(
             // Requires a stabilization algorithm object.
             RandLAPACK::Stabilization<T>& stab_obj,
-            RandBLAS::base::RNGState<RNG> state,
+            RandBLAS::RNGState<RNG> state,
             int64_t p,
             int64_t q,
             bool verb,
@@ -106,7 +106,7 @@ class RS : public RowSketcher<T>
         ) override;
 
         RandLAPACK::Stabilization<T>& Stab_Obj;
-        RandBLAS::base::RNGState<RNG> st;
+        RandBLAS::RNGState<RNG> st;
         int64_t passes_over_data;
         int64_t passes_per_stab;
         bool verbosity;
@@ -140,12 +140,12 @@ int RS<T, RNG>::call(
 
     if (p % 2 == 0) {
         // Fill n by k Omega
-        RandBLAS::dense::DenseDist  D{.n_rows = n, .n_cols = k};
-        RandBLAS::dense::fill_buff(Omega_dat, D, state);
+        RandBLAS::DenseDist D{.n_rows = n, .n_cols = k};
+        RandBLAS::fill_dense(D, Omega_dat, state);
     } else {
         // Fill m by k Omega_1
-        RandBLAS::dense::DenseDist D{.n_rows = m, .n_cols = k};
-        RandBLAS::dense::fill_buff(Omega_1_dat, D, state);
+        RandBLAS::DenseDist D{.n_rows = m, .n_cols = k};
+        RandBLAS::fill_dense(D, Omega_1_dat, state);
 
         // multiply A' by Omega results in n by k omega
         blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, k, m, 1.0, A_dat, m, Omega_1_dat, m, 0.0, Omega_dat, n);

--- a/RandLAPACK/comps/rl_syps.hh
+++ b/RandLAPACK/comps/rl_syps.hh
@@ -19,13 +19,13 @@ class SymmetricPowerSketch {
     public:
         virtual ~SymmetricPowerSketch() {}
 
-        virtual RandBLAS::dense::DenseSkOp<T,RNG> call(
+        virtual RandBLAS::DenseSkOp<T,RNG> call(
             blas::Uplo uplo,
             int64_t m,
             const std::vector<T>& A,
             int64_t lda,
             int64_t k,
-            RandBLAS::base::RNGState<RNG> state,
+            RandBLAS::RNGState<RNG> state,
             T* skop_buff = nullptr,
             T* work_buff = nullptr
         ) {
@@ -92,13 +92,13 @@ class SYPS : public SymmetricPowerSketch<T, RNG> {
         ///     An RNGState that the calling function should use the next
         ///     time it needs an RNGState.
         ///
-        RandBLAS::dense::DenseSkOp<T,RNG> call(
+        RandBLAS::DenseSkOp<T,RNG> call(
             blas::Uplo uplo,
             int64_t m,
             const std::vector<T>& A,
             int64_t lda,
             int64_t k,
-            RandBLAS::base::RNGState<RNG> state,
+            RandBLAS::RNGState<RNG> state,
             T* skop_buff,
             T* work_buff
         );
@@ -112,13 +112,13 @@ class SYPS : public SymmetricPowerSketch<T, RNG> {
 
 // -----------------------------------------------------------------------------
 template <typename T, typename RNG>
-RandBLAS::dense::DenseSkOp<T,RNG> SYPS<T, RNG>::call(
+RandBLAS::DenseSkOp<T,RNG> SYPS<T, RNG>::call(
     blas::Uplo uplo,
     int64_t m,
     const std::vector<T>& A,
     int64_t lda,
     int64_t k,
-    RandBLAS::base::RNGState<RNG> state,
+    RandBLAS::RNGState<RNG> state,
     T* skop_buff,
     T* work_buff
 ){
@@ -130,8 +130,8 @@ RandBLAS::dense::DenseSkOp<T,RNG> SYPS<T, RNG>::call(
      bool callers_skop_buff = skop_buff != nullptr;
      if (!callers_skop_buff)
          skop_buff = new T[m * k];
-    RandBLAS::dense::DenseDist D{m, k};
-    auto next_state = RandBLAS::dense::fill_buff(skop_buff, D, state);
+    RandBLAS::DenseDist D{m, k};
+    auto next_state = RandBLAS::fill_dense(D, skop_buff, state);
 
      bool callers_work_buff = work_buff != nullptr;
      if (!callers_work_buff)
@@ -157,7 +157,7 @@ RandBLAS::dense::DenseSkOp<T,RNG> SYPS<T, RNG>::call(
     if (p % 2 == 1)
         blas::copy(m * k, work_buff, 1, skop_buff, 1);
 
-    auto S = RandBLAS::dense::DenseSkOp(D, state, skop_buff, blas::Layout::ColMajor);
+    auto S = RandBLAS::DenseSkOp<T>(D, state, skop_buff);
     S.next_state = next_state;
 
     if (!callers_work_buff)

--- a/RandLAPACK/comps/rl_syrf.hh
+++ b/RandLAPACK/comps/rl_syrf.hh
@@ -21,13 +21,13 @@ class SymmetricRangeFinder {
     public:
         virtual ~SymmetricRangeFinder() {}
 
-        virtual RandBLAS::base::RNGState<RNG> call(
+        virtual RandBLAS::RNGState<RNG> call(
             blas::Uplo uplo,
             int64_t m,
             const std::vector<T>& A,
             int64_t k,
             std::vector<T>& Q,
-            RandBLAS::base::RNGState<RNG> state,
+            RandBLAS::RNGState<RNG> state,
             T* work_buff
         ) = 0;
 };
@@ -75,13 +75,13 @@ class SYRF : public SymmetricRangeFinder<T, RNG> {
         ///     An RNGState that the calling function should use the next
         ///     time it needs an RNGState.
         ///
-        RandBLAS::base::RNGState<RNG> call(
+        RandBLAS::RNGState<RNG> call(
             blas::Uplo uplo,
             int64_t m,
             const std::vector<T>& A,
             int64_t k,
             std::vector<T>& Q,
-            RandBLAS::base::RNGState<RNG> state,
+            RandBLAS::RNGState<RNG> state,
             T* work_buff
         ) override;
 
@@ -98,13 +98,13 @@ class SYRF : public SymmetricRangeFinder<T, RNG> {
 
 // -----------------------------------------------------------------------------
 template <typename T, typename RNG>
-RandBLAS::base::RNGState<RNG> SYRF<T, RNG>::call(
+RandBLAS::RNGState<RNG> SYRF<T, RNG>::call(
     blas::Uplo uplo,
     int64_t m,
     const std::vector<T>& A,
     int64_t k,
     std::vector<T>& Q,
-    RandBLAS::base::RNGState<RNG> state,
+    RandBLAS::RNGState<RNG> state,
     T* work_buff
 ){
 

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -56,7 +56,7 @@ class CQRRPT : public CQRRPTalg<T> {
         CQRRPT(
             bool verb,
             bool time_subroutines,
-            RandBLAS::base::RNGState<RNG> st,
+            RandBLAS::RNGState<RNG> st,
             T ep
         ) {
             verbosity = verb;
@@ -123,7 +123,7 @@ class CQRRPT : public CQRRPTalg<T> {
         bool verbosity;
         bool timing;
         bool cond_check;
-        RandBLAS::base::RNGState<RNG> state;
+        RandBLAS::RNGState<RNG> state;
         T eps;
         int64_t rank;
         int64_t b_sz;
@@ -219,13 +219,14 @@ int CQRRPT<T, RNG>::call(
         saso_t_start = high_resolution_clock::now();
     }
     
-    RandBLAS::sparse::SparseDist DS = {.n_rows = d, .n_cols = m, .vec_nnz = this->nnz};
-    RandBLAS::sparse::SparseSkOp<T, RNG> S(DS, state, NULL, NULL, NULL);
-    RandBLAS::sparse::fill_sparse(S);
+    RandBLAS::SparseDist DS = {.n_rows = d, .n_cols = m, .vec_nnz = this->nnz};
+    RandBLAS::SparseSkOp<T, RNG> S(DS, state);
+    RandBLAS::fill_sparse(S);
 
-    RandBLAS::sparse::lskges<T, RandBLAS::sparse::SparseSkOp<T>>(
+    RandBLAS::sketch_general(
         Layout::ColMajor, Op::NoTrans, Op::NoTrans,
-        d, n, m, 1.0, S, 0, 0, A.data(), m, 0.0, A_hat_dat, d);
+        d, n, m, 1.0, S, 0, 0, A.data(), m, 0.0, A_hat_dat, d
+    );
 
     if(this -> timing) {
         saso_t_stop = high_resolution_clock::now();

--- a/RandLAPACK/drivers/rl_hqrrp.hh
+++ b/RandLAPACK/drivers/rl_hqrrp.hh
@@ -606,7 +606,7 @@ template <typename T, typename RNG>
 int64_t hqrrp( 
     int64_t m_A, int64_t n_A, T * buff_A, int64_t ldim_A,
     int64_t * buff_jpvt, T * buff_tau,
-    int64_t nb_alg, int64_t pp, int64_t panel_pivoting, RandBLAS::base::RNGState<RNG> state) {
+    int64_t nb_alg, int64_t pp, int64_t panel_pivoting, RandBLAS::RNGState<RNG> state) {
 
     int64_t b, j, last_iter, mn_A, m_Y, n_Y, ldim_Y, m_V, n_V, ldim_V, 
             m_W, n_W, ldim_W, n_VR, m_AB1, n_AB1, ldim_T1_T,
@@ -664,8 +664,8 @@ int64_t hqrrp(
     ldim_G  = m_G;
 
     // Initialize matrices G and Y.
-    RandBLAS::dense::DenseDist D{.n_rows = nb_alg + pp, .n_cols = m_A, .family=RandBLAS::dense::DenseDistName::Uniform};
-    RandBLAS::dense::fill_buff(buff_G, D, state);
+    RandBLAS::DenseDist D{.n_rows = nb_alg + pp, .n_cols = m_A, .family=RandBLAS::DenseDistName::Uniform};
+    RandBLAS::fill_dense(D, buff_G, state);
     
     blas::gemm(blas::Layout::ColMajor,
                 blas::Op::NoTrans, blas::Op::NoTrans, m_Y, n_Y, m_A, 

--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -19,7 +19,7 @@ class REVD2alg {
 
         virtual ~REVD2alg() {}
 
-        virtual RandBLAS::base::RNGState<RNG> call(
+        virtual RandBLAS::RNGState<RNG> call(
             blas::Uplo uplo,
             int64_t m,
             std::vector<T>& A,
@@ -27,7 +27,7 @@ class REVD2alg {
             T tol,
             std::vector<T>& V,
             std::vector<T>& eigvals,
-            RandBLAS::base::RNGState<RNG> state
+            RandBLAS::RNGState<RNG> state
         ) = 0;
 };
 
@@ -82,7 +82,7 @@ class REVD2 : public REVD2alg<T, RNG> {
         ///     time it needs an RNGState.
         ///
 
-        RandBLAS::base::RNGState<RNG> call(
+        RandBLAS::RNGState<RNG> call(
             blas::Uplo uplo,
             int64_t m,
             std::vector<T>& A,
@@ -90,7 +90,7 @@ class REVD2 : public REVD2alg<T, RNG> {
             T tol,
             std::vector<T>& V,
             std::vector<T>& eigvals,
-            RandBLAS::base::RNGState<RNG> state
+            RandBLAS::RNGState<RNG> state
         ) override;
 
     public:
@@ -161,7 +161,7 @@ T power_error_est(
 
 
 template <typename T, typename RNG>
-RandBLAS::base::RNGState<RNG> REVD2<T, RNG>::call(
+RandBLAS::RNGState<RNG> REVD2<T, RNG>::call(
         blas::Uplo uplo,
         int64_t m,
         std::vector<T>& A,
@@ -169,12 +169,12 @@ RandBLAS::base::RNGState<RNG> REVD2<T, RNG>::call(
         T tol,
         std::vector<T>& V,
         std::vector<T>& eigvals,
-        RandBLAS::base::RNGState<RNG> state
+        RandBLAS::RNGState<RNG> state
 ){
     T err = 0;
     std::vector<T> symrf_work(0);
     auto next_state = state;
-    RandBLAS::base::RNGState<RNG> error_est_state(state.counter, state.key);
+    RandBLAS::RNGState<RNG> error_est_state(state.counter, state.key);
     error_est_state.key.incr(1);
     while(1) {
         T* A_dat = A.data();
@@ -242,8 +242,8 @@ RandBLAS::base::RNGState<RNG> REVD2<T, RNG>::call(
         // Using the first column of Omega as a buffer for a random vector
         // To perform the following safely, need to make sure Omega has at least 4 columns
         Omega_dat = util::upsize(m * 4, this->Omega);
-        RandBLAS::dense::DenseDist  g{.n_rows = m, .n_cols = 1};
-        error_est_state = RandBLAS::dense::fill_buff(Omega_dat, g, error_est_state);
+        RandBLAS::DenseDist  g{.n_rows = m, .n_cols = 1};
+        error_est_state = RandBLAS::fill_dense(g, Omega_dat, error_est_state);
 
         err = power_error_est(m, k, this->error_est_p, Omega_dat, V_dat, uplo, A_dat, Y_dat, eigvals.data()); 
 

--- a/benchmark/CQRRPT_accuracy.cc
+++ b/benchmark/CQRRPT_accuracy.cc
@@ -17,7 +17,7 @@ If the required folder structure does not exist, the files will not be saved.
 */
 
 template <typename T, typename RNG>
-    static void test_CQRRPT_approx_qual(int64_t m, int64_t n, int64_t k, int64_t d, int64_t nnz, T tol, const std::tuple<int, T, bool>& mat_type, RandBLAS::base::RNGState<RNG> state, int test_num, std::string path) {
+    static void test_CQRRPT_approx_qual(int64_t m, int64_t n, int64_t k, int64_t d, int64_t nnz, T tol, const std::tuple<int, T, bool>& mat_type, RandBLAS::RNGState<RNG> state, int test_num, std::string path) {
         
         printf("/-----------------------------------------CQRRPT ACCURACY BENCHMARK START-----------------------------------------/\n");
         
@@ -161,7 +161,7 @@ template <typename T, typename RNG>
 int main() {
     // Run with env OMP_NUM_THREADS=36 numactl --interleave all ./filename
     // Large condition number may not work for a small matrix
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     // Fast polynomial decay
     //test_CQRRPT_approx_qual<double>(131072, 2000, 2000, 2000, 1, std::numeric_limits<double>::epsilon(), std::make_tuple(0, 1e10, false), state, 1, "../testing/RandLAPACK-benchmarking/QR/accuracy/raw_data/");
     //test_CQRRPT_approx_qual<double>(131072, 2000, 2000, 2000, 1, std::numeric_limits<double>::epsilon(), std::make_tuple(0, 1e10, false), state, 2, "../testing/RandLAPACK-benchmarking/QR/accuracy/raw_data/");

--- a/benchmark/CQRRPT_embedding_speed_effect.cc
+++ b/benchmark/CQRRPT_embedding_speed_effect.cc
@@ -81,7 +81,7 @@ test_speed_helper(int64_t m,
                   int64_t nnz, 
                   int64_t num_threads, 
                   const std::tuple<int, T, bool>& mat_type, 
-                  RandBLAS::base::RNGState<RNG> state) {
+                  RandBLAS::RNGState<RNG> state) {
 
     int64_t size  = m * n;
     std::vector<T>       A_1(size, 0.0);
@@ -149,7 +149,7 @@ test_speed(int r_pow,
            T d_multiplier_max, 
            const std::tuple<int, T, bool>& mat_type,
            std::string path,
-           RandBLAS::base::RNGState<RNG> state) {
+           RandBLAS::RNGState<RNG> state) {
     printf("\n/-----------------------------------------EMBEDDING EFFECT BENCHMARK START-----------------------------------------/\n");
     int rows = std::pow(2, r_pow);
     // This variable is controls an additional iteration, used for initialization work
@@ -345,7 +345,7 @@ test_speed(int r_pow,
 
 int main(){
     // Run with env OMP_NUM_THREADS=36 numactl --interleave all ./filename  
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     test_speed<double, r123::Philox4x32>(17, 1024, 5, 1, 36, std::pow(std::numeric_limits<double>::epsilon(), 0.75), 1.0, 1.0, 4.0, std::make_tuple(6, 0, false), "../../testing/RandLAPACK-benchmarking/QR/speed/raw_data/", state);
     test_speed<double, r123::Philox4x32>(17, 2048, 5, 1, 36, std::pow(std::numeric_limits<double>::epsilon(), 0.75), 1.0, 1.0, 4.0, std::make_tuple(6, 0, false), "../../testing/RandLAPACK-benchmarking/QR/speed/raw_data/", state);
     test_speed<double, r123::Philox4x32>(17, 4096, 5, 1, 36, std::pow(std::numeric_limits<double>::epsilon(), 0.75), 1.0, 1.0, 4.0, std::make_tuple(6, 0, false), "../../testing/RandLAPACK-benchmarking/QR/speed/raw_data/", state);

--- a/benchmark/CQRRPT_inner_speed.cc
+++ b/benchmark/CQRRPT_inner_speed.cc
@@ -77,7 +77,7 @@ test_speed_helper(int64_t m,
                   int64_t nnz, 
                   int64_t num_threads, 
                   const std::tuple<int, T, bool>& mat_type, 
-                  RandBLAS::base::RNGState<RNG> state) {
+                  RandBLAS::RNGState<RNG> state) {
 
     int64_t size  = m * n;
     std::vector<T>       A_1(size, 0.0);
@@ -147,7 +147,7 @@ test_speed(int r_pow,
            T d_multiplier, 
            const std::tuple<int, T, bool>& mat_type,
            std::string path,
-           RandBLAS::base::RNGState<RNG> state) {
+           RandBLAS::RNGState<RNG> state) {
     printf("\n/-----------------------------------------CQRRPT INNER SPEED BENCHMARK START-----------------------------------------/\n");
     
     // This variable is controls an additional iteration, used for initialization work
@@ -345,7 +345,7 @@ test_speed(int r_pow,
 
 int main(){
     // Run with env OMP_NUM_THREADS=36 numactl --interleave all ./filename 
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     test_speed<double, r123::Philox4x32>(17, 17, 32, 16384, 5, 1, 36, std::pow(std::numeric_limits<double>::epsilon(), 0.75), 1.0, 1.0, std::make_tuple(6, 0, false), "../../testing/RandLAPACK-benchmarking/QR/speed/raw_data/cqrrpt_determine_rank/L2", state);
     return 0;
 }

--- a/benchmark/CQRRPT_vs_HQRRP_speed.cc
+++ b/benchmark/CQRRPT_vs_HQRRP_speed.cc
@@ -72,7 +72,7 @@ test_speed_helper(int64_t m,
                   int64_t nnz, 
                   int64_t num_threads, 
                   const std::tuple<int, T, bool>& mat_type, 
-                  RandBLAS::base::RNGState<RNG> state,
+                  RandBLAS::RNGState<RNG> state,
                   int apply_to_large) {
     using namespace blas;
     using namespace lapack;
@@ -245,7 +245,7 @@ test_speed(int r_pow,
            const std::tuple<int, T, bool> & mat_type,
            int apply_to_large,
            std::string path,
-           RandBLAS::base::RNGState<RNG> state) {
+           RandBLAS::RNGState<RNG> state) {
 
     printf("\n/-----------------------------------------HQRRP+CQRRPT BENCHMARK START-----------------------------------------/\n");
     // This variable is controls an additional iteration, used for initialization work
@@ -426,7 +426,7 @@ test_speed(int r_pow,
 
 int main(){
     // Run with env OMP_NUM_THREADS=36 numactl --interleave all ./filename 
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     test_speed<double, r123::Philox4x32>(17, 17, 512, 8192, 5, 32, 36, 1, 36, std::pow(std::numeric_limits<double>::epsilon(), 0.75), 1.0, 1.0, std::make_tuple(6, 0, false), 0, "../../testing/RandLAPACK-Testing/test_benchmark/QR/speed/raw_data/", state);
     return 0;
 }

--- a/benchmark/Chol_check.cc
+++ b/benchmark/Chol_check.cc
@@ -7,7 +7,7 @@ using namespace RandLAPACK;
 
 template <typename T, typename RNG>
 static void 
-chol_check(int64_t m, int64_t k, RandBLAS::base::RNGState<RNG> state) {
+chol_check(int64_t m, int64_t k, RandBLAS::RNGState<RNG> state) {
 
     std::vector<T> A(m * m, 0.0);
     std::vector<T> A_leading_submat_symm(k * k, 0.0);
@@ -48,7 +48,7 @@ chol_check(int64_t m, int64_t k, RandBLAS::base::RNGState<RNG> state) {
 
 int main() {
     for(int i = 0; i < 10; ++i) {
-        auto state = RandBLAS::base::RNGState(i);
+        auto state = RandBLAS::RNGState(i);
         chol_check<double, r123::Philox4x32>(1000, 500, state);
     }
     return 0;

--- a/benchmark/GEMM_flop_count.cc
+++ b/benchmark/GEMM_flop_count.cc
@@ -13,7 +13,7 @@ using namespace RandLAPACK;
 
 template <typename T, typename RNG>
 static void 
-test_flops(int64_t k, RandBLAS::base::RNGState<RNG> state) {
+test_flops(int64_t k, RandBLAS::RNGState<RNG> state) {
     printf("|===================================TEST SYSTEM FLOPS BEGIN====================================|\n");
     int size = k * k;
 
@@ -56,7 +56,7 @@ test_flops(int64_t k, RandBLAS::base::RNGState<RNG> state) {
 }
 
 int main() {
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     test_flops<double, r123::Philox4x32>(1000, state);
     return 0;
 }

--- a/benchmark/Orth_speed.cc
+++ b/benchmark/Orth_speed.cc
@@ -93,7 +93,7 @@ int GEQR<T>::call(
 
 template <typename T, typename RNG>
 static std::tuple<long, long, long, long> 
-test_speed_helper(int64_t m, int64_t n, RandBLAS::base::RNGState<RNG> state) {
+test_speed_helper(int64_t m, int64_t n, RandBLAS::RNGState<RNG> state) {
 
     int64_t size = m * n;
     std::vector<T> A(size, 0.0);
@@ -155,7 +155,7 @@ test_speed_helper(int64_t m, int64_t n, RandBLAS::base::RNGState<RNG> state) {
 
 template <typename T, typename RNG>
 static void 
-test_speed(int r_pow, int r_pow_max, int c_pow, int c_pow_max, int runs, RandBLAS::base::RNGState<RNG> state) {
+test_speed(int r_pow, int r_pow_max, int c_pow, int c_pow_max, int runs, RandBLAS::RNGState<RNG> state) {
     int64_t rows = 0;
     int64_t cols = 0;
 
@@ -219,7 +219,7 @@ test_speed(int r_pow, int r_pow_max, int c_pow, int c_pow_max, int runs, RandBLA
 
 template <typename T, typename RNG>
 static void 
-test_speed_mean(int r_pow, int r_pow_max, int col, int col_max, int runs, RandBLAS::base::RNGState<RNG> state)
+test_speed_mean(int r_pow, int r_pow_max, int col, int col_max, int runs, RandBLAS::RNGState<RNG> state)
 {
 
     // Clear all files
@@ -291,7 +291,7 @@ test_speed_mean(int r_pow, int r_pow_max, int col, int col_max, int runs, RandBL
 }
 
 int main() {
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     test_speed_mean<double, r123::Philox4x32>(12, 12, 64, 64, 3, state);
     return 0;
 }

--- a/benchmark/QB_cond_nums.cc
+++ b/benchmark/QB_cond_nums.cc
@@ -20,7 +20,7 @@ If the required folder structure does not exist, the files will not be saved.
 typedef std::pair<std::vector<double>, std::vector<double>>  vector_pair;
 
 template <typename T, typename RNG>
-static vector_pair test_QB2_plot_helper_run(int64_t m, int64_t n, int64_t k, int64_t p, int64_t block_sz, T tol, const std::tuple<int, T, bool>& mat_type, RandBLAS::base::RNGState<RNG> state) {
+static vector_pair test_QB2_plot_helper_run(int64_t m, int64_t n, int64_t k, int64_t p, int64_t block_sz, T tol, const std::tuple<int, T, bool>& mat_type, RandBLAS::RNGState<RNG> state) {
 
     // For running QB
     std::vector<T> A(m * n, 0.0);
@@ -79,7 +79,7 @@ static vector_pair test_QB2_plot_helper_run(int64_t m, int64_t n, int64_t k, int
 }
 
 template <typename T, typename RNG>
-static void test_QB2_plot(int64_t k, int64_t max_k, int64_t block_sz, int64_t max_b_sz, int64_t p, int64_t max_p, int mat_type, T decay, bool diagon, std::string path_RF, std::string path_RS, RandBLAS::base::RNGState<RNG> state)
+static void test_QB2_plot(int64_t k, int64_t max_k, int64_t block_sz, int64_t max_b_sz, int64_t p, int64_t max_p, int mat_type, T decay, bool diagon, std::string path_RF, std::string path_RS, RandBLAS::RNGState<RNG> state)
 {
     printf("|==================================TEST QB2 K PLOT BEGIN==================================|\n");
 
@@ -169,7 +169,7 @@ static void test_QB2_plot(int64_t k, int64_t max_k, int64_t block_sz, int64_t ma
 
 int main() 
 {   
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     // Slow_decay
     test_QB2_plot<double, r123::Philox4x32>(2048, 2048, 256, 256, 2, 2, 0, 2, true, "../", "../", state);
     // Fast decay

--- a/benchmark/QR_accuracy_stability_analysis.cc
+++ b/benchmark/QR_accuracy_stability_analysis.cc
@@ -59,7 +59,7 @@ static void
 cholqr_helper(int64_t m, 
                   int64_t n, 
                   const std::tuple<int, T, bool>& mat_type, 
-                  RandBLAS::base::RNGState<RNG> state) {
+                  RandBLAS::RNGState<RNG> state) {
 
     std::vector<T> A(m * n, 0.0);
     std::vector<T> A_hat(m * n, 0.0);
@@ -99,7 +99,7 @@ static void
 cqrrpt_helper(int64_t m, 
                 int64_t n, 
                 const std::tuple<int, T, bool>& mat_type, 
-                RandBLAS::base::RNGState<RNG> state,
+                RandBLAS::RNGState<RNG> state,
                 const std::vector<T>& additional_params) {
 
     int64_t true_k = additional_params[0];
@@ -150,7 +150,7 @@ static void
 scholqr_helper(int64_t m, 
                   int64_t n, 
                   const std::tuple<int, T, bool>& mat_type, 
-                  RandBLAS::base::RNGState<RNG> state,
+                  RandBLAS::RNGState<RNG> state,
                   const std::vector<T>& additional_params) {
 
     int64_t k = additional_params[0];
@@ -233,7 +233,7 @@ test_cond_orth(int row,
            T cond_start,
            T cond_end,
            T cond_step,
-           RandBLAS::base::RNGState<RNG> state,
+           RandBLAS::RNGState<RNG> state,
            int alg_type,
            int mat_type_num,
            std::vector<T> additional_params) {
@@ -263,7 +263,7 @@ test_cond_orth(int row,
 
 int main(){
     // Run with env OMP_NUM_THREADS=36 numactl --interleave all ./filename  
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     // Old tests
     //test_cond_orth<double>(10000, 1024, 1024, 1024, 1, 10, 10e16, 10, state, 0, 1, 0);
     //test_cond_orth<double>(1024, 5, 5, 5, 1, 10, 10, 10, state, 0, 1, 1);

--- a/benchmark/QR_speed.cc
+++ b/benchmark/QR_speed.cc
@@ -201,7 +201,7 @@ test_speed_helper(int64_t m,
                   int64_t nnz, 
                   int64_t num_threads, 
                   const std::tuple<int, T, bool>& mat_type, 
-                  RandBLAS::base::RNGState<RNG> state,
+                  RandBLAS::RNGState<RNG> state,
                   int apply_to_large) {
 
     int64_t size = m * n;
@@ -470,7 +470,7 @@ test_speed(int r_pow,
            const std::tuple<int, T, bool> & mat_type,
            int apply_to_large,
            std::string path,
-           RandBLAS::base::RNGState<RNG> state) {
+           RandBLAS::RNGState<RNG> state) {
 
     printf("\n/-----------------------------------------QRCP SPEED BENCHMARK START-----------------------------------------/\n");
     // This variable is controls an additional iteration, used for initialization work
@@ -765,7 +765,7 @@ test_speed(int r_pow,
 
 int main(){
     // Run with env OMP_NUM_THREADS=36 numactl --interleave all ./filename 
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     
     //test_speed<double>(17, 17, 512, 8192, 5, 1, 36, std::pow(std::numeric_limits<double>::epsilon(), 0.75), 1.0, 1.0, std::make_tuple(6, 0, false), 1, "../../testing/RandLAPACK-Testing/test_benchmark/QR/speed/raw_data/apply_Q_to_large/", state);
     test_speed<double, r123::Philox4x32>(17, 17, 512, 8192, 5, 1, 36, std::pow(std::numeric_limits<double>::epsilon(), 0.75), 1.0, 1.0, std::make_tuple(6, 0, false), 0, "../../testing/RandLAPACK-Testing/test_benchmark/QR/speed/raw_data/", state);

--- a/test/comps/test_determiter.cc
+++ b/test/comps/test_determiter.cc
@@ -5,9 +5,6 @@
 #include <math.h>
 #include <gtest/gtest.h>
 
-#define RELDTOL 1e-10;
-#define ABSDTOL 1e-12;
-
 
 class TestDetermiterOLS : public ::testing::Test
 {

--- a/test/comps/test_orth.cc
+++ b/test/comps/test_orth.cc
@@ -11,8 +11,6 @@
 #include <chrono>
 #include <gtest/gtest.h>
 
-#define RELDTOL 1e-10;
-#define ABSDTOL 1e-12;
 
 using namespace std::chrono;
 
@@ -50,7 +48,7 @@ class TestOrth : public ::testing::Test
 
     template <typename T, typename RNG>
     static void sketch_and_copy_computational_helper(
-        RandBLAS::base::RNGState<RNG> state,
+        RandBLAS::RNGState<RNG> state,
         OrthTestData<T>& all_data
     ) {
 
@@ -59,8 +57,8 @@ class TestOrth : public ::testing::Test
         auto k = all_data.rank;
 
         // Fill the gaussian random matrix
-        RandBLAS::dense::DenseDist D{.n_rows = n, .n_cols = k};
-        state = RandBLAS::dense::fill_buff(all_data.Omega.data(), D, state);
+        RandBLAS::DenseDist D{.n_rows = n, .n_cols = k};
+        state = RandBLAS::fill_dense(D, all_data.Omega.data(), state);
         
         // Generate a reference identity
         RandLAPACK::util::eye(k, k, all_data.I_ref);
@@ -105,7 +103,7 @@ TEST_F(TestOrth, Test_CholQRQ)
     int64_t m = 1000;
     int64_t n = 200;
     int64_t k = 200;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     
     OrthTestData<double> all_data(m, n, k);
     // Orthogonalization Constructor

--- a/test/comps/test_preconditioners.cc
+++ b/test/comps/test_preconditioners.cc
@@ -77,13 +77,13 @@ class Test_rpc_svd : public ::testing::Test
         // construct "A" with cond(A) >= sqrt_cond^2.
         std::vector<T> A(m*n, 0.0);
         T *a = A.data();
-        RandBLAS::dense::DenseDist D{
+        RandBLAS::DenseDist D{
             .n_rows = m,
             .n_cols = n,
-            .family = RandBLAS::dense::DenseDistName::Uniform
+            .family = RandBLAS::DenseDistName::Uniform
         };
-        auto state = RandBLAS::base::RNGState(99);
-        RandBLAS::dense::fill_buff(a, D, state);
+        auto state = RandBLAS::RNGState(99);
+        RandBLAS::fill_dense(D, a, state);
     
         if (layout == blas::Layout::RowMajor) {
             // scale first row up by sqrt_cond
@@ -100,13 +100,13 @@ class Test_rpc_svd : public ::testing::Test
         }
 
         // apply the function under test (rpc_data_svd_saso)
-        auto alg_state = RandBLAS::base::RNGState((uint32_t) keys[key_index]);
+        auto alg_state = RandBLAS::RNGState((uint32_t) keys[key_index]);
         std::vector<T> M_wk(d*n, 0.0);
         std::vector<T> sigma_sk(n, 0.0);
         int64_t lda = (layout == blas::Layout::ColMajor) ? m : n;
-        RandBLAS::sparse::SparseDist SDist{.n_rows=d, .n_cols=m, .vec_nnz=8};
-        RandBLAS::sparse::SparseSkOp<T> S(SDist, alg_state);
-        RandBLAS::sparse::fill_sparse(S);
+        RandBLAS::SparseDist SDist{.n_rows=d, .n_cols=m, .vec_nnz=8};
+        RandBLAS::SparseSkOp<T> S(SDist, alg_state);
+        RandBLAS::fill_sparse(S);
         
         RandLAPACK::rpc_data_svd(
             layout, m, n, A.data(), lda, S, M_wk.data(), sigma_sk.data()
@@ -138,13 +138,13 @@ class Test_rpc_svd : public ::testing::Test
         // After regularization the augmented matrix will still be full-rank.
         std::vector<double> A(m*n, 0.0);
         double *a = A.data();
-        RandBLAS::dense::DenseDist D{
+        RandBLAS::DenseDist D{
             .n_rows = m,
             .n_cols = n,
-            .family = RandBLAS::dense::DenseDistName::Uniform
+            .family = RandBLAS::DenseDistName::Uniform
         };
-        auto state = RandBLAS::base::RNGState(99);
-        RandBLAS::dense::fill_buff(a, D, state);
+        auto state = RandBLAS::RNGState(99);
+        RandBLAS::fill_dense(D, a, state);
                       
         blas::scal(n, sqrt_cond, a, 1);
         double invscale = 1.0 / sqrt_cond;
@@ -154,7 +154,7 @@ class Test_rpc_svd : public ::testing::Test
         // apply the function under test (rpc_svd_saso)
         std::vector<double> M_wk(d*n, 0.0);
         std::vector<double> sigma_sk(n, 0.0);
-        auto alg_state = RandBLAS::base::RNGState(keys[key_index]);
+        auto alg_state = RandBLAS::RNGState(keys[key_index]);
         RandLAPACK::rpc_data_svd_saso(
             blas::Layout::RowMajor, m, n, d, 8,
             A.data(), n, M_wk.data(), sigma_sk.data(), alg_state

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -69,7 +69,7 @@ class TestQB : public ::testing::Test
                             bool orth_check, 
                             int64_t p, 
                             int64_t passes_per_iteration, 
-                            RandBLAS::base::RNGState<RNG> state) :
+                            RandBLAS::RNGState<RNG> state) :
                             Stab(cond_check, verbosity),
                             RS(Stab, state, p, passes_per_iteration, verbosity, cond_check),
                             Orth_RF(cond_check, verbosity),
@@ -235,7 +235,7 @@ TEST_F(TestQB, Polynomial_Decay_general1)
     int64_t passes_per_iteration = 1;
     int64_t block_sz = 10;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     
     //Subroutine parameters
     bool verbosity = false;
@@ -259,7 +259,7 @@ TEST_F(TestQB, Polynomial_Decay_general2)
     int64_t passes_per_iteration = 1;
     int64_t block_sz = 2;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     
     //Subroutine parameters
     bool verbosity = false;
@@ -283,7 +283,7 @@ TEST_F(TestQB, Rand_diag_general)
     int64_t passes_per_iteration = 1;
     int64_t block_sz = 2;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     //Subroutine parameters
     bool verbosity = false;
@@ -307,7 +307,7 @@ TEST_F(TestQB, Polynomial_Decay_zero_tol1)
     int64_t passes_per_iteration = 1;
     int64_t block_sz = 10;
     double tol = (double) 0.1;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     //Subroutine parameters
     bool verbosity = false;
@@ -331,7 +331,7 @@ TEST_F(TestQB, Polynomial_Decay_zero_tol2)
     int64_t passes_per_iteration = 1;
     int64_t block_sz = 10;
     double tol = 0.0;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     //Subroutine parameters
     bool verbosity = false;

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -55,7 +55,7 @@ class TestRF : public ::testing::Test
             bool cond_check, 
             int64_t p, 
             int64_t passes_per_iteration, 
-            RandBLAS::base::RNGState<RNG> state
+            RandBLAS::RNGState<RNG> state
         ) :
             Stab(cond_check, verbosity),
             RS(Stab, state, p, passes_per_iteration, verbosity, cond_check),
@@ -146,7 +146,7 @@ TEST_F(TestRF, Polynomial_Decay_general1)
     int64_t k = 100;
     int64_t p = 5;
     int64_t passes_per_iteration = 1;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     //Subroutine parameters
     bool verbosity = false;
@@ -168,7 +168,7 @@ TEST_F(TestRF, Polynomial_Decay_general2)
     int64_t k = 50;
     int64_t p = 5;
     int64_t passes_per_iteration = 1;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     //Subroutine parameters
     bool verbosity = false;
@@ -190,7 +190,7 @@ TEST_F(TestRF, Rand_diag_general)
     int64_t k = 50;
     int64_t p = 5;
     int64_t passes_per_iteration = 1;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     //Subroutine parameters
     bool verbosity = false;

--- a/test/comps/test_syrf.cc
+++ b/test/comps/test_syrf.cc
@@ -61,7 +61,7 @@ class TestSYRF : public ::testing::Test
     };
 
     template <typename T, typename RNG>
-    static void orth_and_copy_computational_helper(RandBLAS::base::RNGState<RNG> state, SYRFTestData<T>& all_data) {
+    static void orth_and_copy_computational_helper(RandBLAS::RNGState<RNG> state, SYRFTestData<T>& all_data) {
         
         auto m = all_data.row;
         auto k = all_data.rank;
@@ -89,7 +89,7 @@ class TestSYRF : public ::testing::Test
     /// 4. A_k - QB = U_k\Sigma_k\transpose{V_k} - QB
     template <typename T, typename RNG>
     static void test_SYRF_general(
-        RandBLAS::base::RNGState<RNG> state,
+        RandBLAS::RNGState<RNG> state,
         SYRFTestData<T>& all_data, 
         algorithm_objects<T, RNG>& all_algs) {
 
@@ -148,7 +148,7 @@ TEST_F(TestSYRF, Polynomial_Decay_general1)
     int64_t k = 100;
     int64_t p = 5;
     int64_t passes_per_iteration = 1;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     //Subroutine parameters
     bool verbosity = false;
@@ -166,7 +166,7 @@ TEST_F(TestSYRF, Polynomial_Decay_general2)
     int64_t k = 50;
     int64_t p = 5;
     int64_t passes_per_iteration = 1;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     //Subroutine parameters
     bool verbosity = false;
@@ -184,7 +184,7 @@ TEST_F(TestSYRF, Rand_diag_general)
     int64_t k = 50;
     int64_t p = 5;
     int64_t passes_per_iteration = 1;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     //Subroutine parameters
     bool verbosity = false;

--- a/test/comps/test_util.cc
+++ b/test/comps/test_util.cc
@@ -16,8 +16,6 @@ TODO #4: L & pivotig tests.
 */
 using namespace std::chrono;
 
-#define RELDTOL 1e-10;
-#define ABSDTOL 1e-12;
 
 class TestUtil : public ::testing::Test
 {
@@ -63,7 +61,7 @@ class TestUtil : public ::testing::Test
 
     template <typename T, typename RNG>
     static void 
-    test_spectral_norm(RandBLAS::base::RNGState<RNG> state, SpectralTestData<T>& all_data) {
+    test_spectral_norm(RandBLAS::RNGState<RNG> state, SpectralTestData<T>& all_data) {
 
         auto m = all_data.row;
         auto n = all_data.col;
@@ -110,7 +108,7 @@ TEST_F(TestUtil, test_spectral_norm_polynomial_decay_double_precision) {
     
     int64_t m = 1000;
     int64_t n = 100;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     SpectralTestData<double> all_data(m, n);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(0, 2025, false));
@@ -122,7 +120,7 @@ TEST_F(TestUtil, test_spectral_norm_rank_def_mat_double_precision) {
     
     int64_t m = 1000;
     int64_t n = 100;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     SpectralTestData<double> all_data(m, n);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(9, std::pow(10, 15), false));
@@ -134,7 +132,7 @@ TEST_F(TestUtil, test_spectral_norm_polynomial_decay_single_precision) {
     
     int64_t m = 1000;
     int64_t n = 100;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     SpectralTestData<float> all_data(m, n);
 
     RandLAPACK::util::gen_mat_type<float, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(0, 2, false));
@@ -146,7 +144,7 @@ TEST_F(TestUtil, test_spectral_norm_rank_def_mat_single_precision) {
     
     int64_t m = 1000;
     int64_t n = 100;
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
     SpectralTestData<float> all_data(m, n);
 
     RandLAPACK::util::gen_mat_type<float, r123::Philox4x32>(m, n, all_data.A, n, state, std::make_tuple(9, std::pow(10, 7), false));
@@ -181,10 +179,10 @@ class Test_Inplace_Square_Transpose : public ::testing::Test
 
     virtual void apply(blas::Layout layout) {
         int64_t n = 37;
-        RandBLAS::dense::DenseDist D{n, n};
-        RandBLAS::base::RNGState state(1);
+        RandBLAS::DenseDist D{n, n};
+        RandBLAS::RNGState state(1);
         double *A1 = new double[n*n];
-        state = RandBLAS::dense::fill_buff(A1, D, state);
+        state = RandBLAS::fill_dense(D, A1, state);
         double *A2 = new double[n*n];
         blas::copy(n*n, A1, 1, A2, 1);
         RandLAPACK::util::transpose_square(A2, n);

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -6,8 +6,6 @@
 #include <fstream>
 #include <gtest/gtest.h>
 
-#define RELDTOL 1e-10;
-#define ABSDTOL 1e-12;
 
 class TestCQRRPT : public ::testing::Test
 {
@@ -93,13 +91,14 @@ class TestCQRRPT : public ::testing::Test
         T col_norm_A = blas::nrm2(n, &A_cpy_dat[m * max_idx], 1);
         T norm_AQR = lapack::lange(Norm::Fro, m, n, A_dat, m);
         
-        printf("REL NORM OF AP - QR: %15e\n", norm_AQR / norm_A);
-        printf("MAX COL NORM METRIC: %15e\n", max_col_norm / col_norm_A);
-        printf("FRO NORM OF Q' * Q - I: %2e\n\n", norm_0);
+        printf("REL NORM OF AP - QR:    %15e\n", norm_AQR / norm_A);
+        printf("MAX COL NORM METRIC:    %15e\n", max_col_norm / col_norm_A);
+        printf("FRO NORM OF (Q'Q - I)/sqrt(n): %2e\n\n", norm_0 / std::sqrt((T) n));
 
-        ASSERT_NEAR(norm_AQR / norm_A,         0.0, 10 * std::pow(10, -13));
-        ASSERT_NEAR(max_col_norm / col_norm_A, 0.0, 10 * std::pow(10, -13));
-        ASSERT_NEAR(norm_0,                    0.0, 10 * std::pow(10, -13));
+        T atol = std::pow(std::numeric_limits<T>::epsilon(), 0.75);
+        ASSERT_NEAR(norm_AQR / norm_A,         0.0, atol);
+        ASSERT_NEAR(max_col_norm / col_norm_A, 0.0, atol);
+        ASSERT_NEAR(norm_0 / std::sqrt((T) n), 0.0, atol);
     }
 
     /// General test for CQRRPT:
@@ -134,7 +133,7 @@ TEST_F(TestCQRRPT, CQRRPT_full_rank_no_hqrrp) {
     int64_t d = 400;
     double norm_A = 0;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.85);
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     CQRRPTTestData<double> all_data(m, n, k);
     RandLAPACK::CQRRPT<double, r123::Philox4x32> CQRRPT(false, false, state, tol);
@@ -154,7 +153,7 @@ TEST_F(TestCQRRPT, CQRRPT_low_rank_with_hqrrp) {
     int64_t d = 400;
     double norm_A = 0;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.85);
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     CQRRPTTestData<double> all_data(m, n, k);
     RandLAPACK::CQRRPT<double, r123::Philox4x32> CQRRPT(false, false, state, tol);
@@ -176,7 +175,7 @@ TEST_F(TestCQRRPT, CQRRPT_bad_orth) {
     int64_t d = 300;
     double norm_A = 0;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     CQRRPTTestData<double> all_data(m, n, k);
     RandLAPACK::CQRRPT<double, r123::Philox4x32> CQRRPT(false, false, state, tol);

--- a/test/drivers/test_revd2.cc
+++ b/test/drivers/test_revd2.cc
@@ -143,7 +143,7 @@ class TestREVD2 : public ::testing::Test
         T& norm_A, 
         REVD2TestData<T>& all_data,
         algorithm_objects<T, RNG>& all_algs,
-        RandBLAS::base::RNGState<RNG> state
+        RandBLAS::RNGState<RNG> state
     ) {
         
         auto m = all_data.dim;
@@ -181,7 +181,7 @@ class TestREVD2 : public ::testing::Test
         T err_expectation, 
         REVD2UploTestData<T>& all_data,
         algorithm_objects<T, RNG>& all_algs,
-        RandBLAS::base::RNGState<RNG> state
+        RandBLAS::RNGState<RNG> state
     ) {
         
         auto m = all_data.dim;
@@ -230,7 +230,7 @@ TEST_F(TestREVD2, Underestimation1) {
     int64_t num_syps_passes = 3;
     int64_t passes_per_syps_stabilization = 1;
     int64_t num_steps_power_iter_error_est = 10;
-    auto state = RandBLAS::base::RNGState(0);
+    auto state = RandBLAS::RNGState(0);
 
     //Subroutine parameters 
     bool verbose = false;
@@ -266,7 +266,7 @@ TEST_F(TestREVD2, Underestimation2) {
     int64_t num_syps_passes = 3;
     int64_t passes_per_syps_stabilization = 1;
     int64_t num_steps_power_iter_error_est = 10;
-    auto state = RandBLAS::base::RNGState(0);
+    auto state = RandBLAS::RNGState(0);
     //Subroutine parameters 
     bool verbose = false;
     bool cond_check = false;
@@ -301,7 +301,7 @@ TEST_F(TestREVD2, Overestimation1) {
     int64_t num_syps_passes = 3;
     int64_t passes_per_syps_stabilization = 1;
     int64_t num_steps_power_iter_error_est = 10;
-    auto state = RandBLAS::base::RNGState(0);
+    auto state = RandBLAS::RNGState(0);
     //Subroutine parameters 
     bool verbose = false;
     bool cond_check = false;
@@ -334,7 +334,7 @@ TEST_F(TestREVD2, Oversetimation2) {
     int64_t num_syps_passes = 3;
     int64_t passes_per_syps_stabilization = 1;
     int64_t num_steps_power_iter_error_est = 10;
-    auto state = RandBLAS::base::RNGState(0);
+    auto state = RandBLAS::RNGState(0);
     //Subroutine parameters 
     bool verbose = false;
     bool cond_check = false;
@@ -369,7 +369,7 @@ TEST_F(TestREVD2, Exactness) {
     int64_t num_syps_passes = 3;
     int64_t passes_per_syps_stabilization = 1;
     int64_t num_steps_power_iter_error_est = 10;
-    auto state = RandBLAS::base::RNGState(0);
+    auto state = RandBLAS::RNGState(0);
     //Subroutine parameters 
     bool verbose = false;
     bool cond_check = false;
@@ -400,7 +400,7 @@ TEST_F(TestREVD2, Uplo) {
     int64_t num_syps_passes = 3;
     int64_t passes_per_syps_stabilization = 1;
     int64_t num_steps_power_iter_error_est = 10;
-    auto state = RandBLAS::base::RNGState(0);
+    auto state = RandBLAS::RNGState(0);
     //Subroutine parameters 
     bool verbose = false;
     bool cond_check = false;

--- a/test/drivers/test_rsvd.cc
+++ b/test/drivers/test_rsvd.cc
@@ -6,8 +6,6 @@
 #include <fstream>
 #include <gtest/gtest.h>
 
-#define RELDTOL 1e-10;
-#define ABSDTOL 1e-12;
 
 class TestRSVD : public ::testing::Test
 {
@@ -82,7 +80,7 @@ class TestRSVD : public ::testing::Test
             int64_t p, 
             int64_t passes_per_iteration, 
             int64_t block_sz,
-            RandBLAS::base::RNGState<RNG> state
+            RandBLAS::RNGState<RNG> state
         ) :
             Stab(cond_check, verbosity),
             RS(Stab, state, p, passes_per_iteration, verbosity, cond_check),
@@ -170,7 +168,7 @@ TEST_F(TestRSVD, SimpleTest)
     int64_t passes_per_iteration = 1;
     int64_t block_sz = 2;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.5625);
-    auto state = RandBLAS::base::RNGState();
+    auto state = RandBLAS::RNGState();
 
     //Subroutine parameters
     bool verbosity = false;


### PR DESCRIPTION
This updates RandLAPACK to be in sync with RandBLAS following its PR [here](https://github.com/BallisticLA/RandBLAS/pull/55). 

I also changed the way that orthogonality loss is measured, dividing by ``sqrt(n)`` to make it relative error.