### PR TITLE
Krylov new

### DIFF
--- a/RandLAPACK/comps/rl_qb.hh
+++ b/RandLAPACK/comps/rl_qb.hh
@@ -167,6 +167,7 @@ int QB<T>::call(
     if(norm_A == 0.0) {
         // Zero matrix termination
         k = curr_sz;
+        throw std::runtime_error("Zero matrix termination.");
         return 1;
     }
 
@@ -220,14 +221,14 @@ int QB<T>::call(
 
         // Calling RangeFinder
         if(this->RF_Obj.call(m, n, A_cpy, block_sz, this->Q_i))
-            return 6; // RF failed
+            throw std::runtime_error("RangeFinder failed.");
 
         if(this->orth_check) {
             if (util::orthogonality_check(m, block_sz, block_sz, Q_i, Q_i_gram, this->verbosity)) {
                 // Lost orthonormality of Q
                 util::row_resize(this->curr_lim, n, B, curr_sz);
                 k = curr_sz;
-                return 4;
+                throw std::runtime_error("Lost orthonormality of Q_i.");
             }
         }
 
@@ -255,7 +256,7 @@ int QB<T>::call(
             // Only need to move B's data, no resizing
             util::row_resize(this->curr_lim, n, B, curr_sz);
             k = curr_sz;
-            return 2;
+            throw std::runtime_error("Error divergence early termination");
         }
 
         // Update the matrices Q and B
@@ -267,7 +268,7 @@ int QB<T>::call(
                 // Lost orthonormality of Q
                 util::row_resize(this->curr_lim, n, B, curr_sz);
                 k = curr_sz;
-                return 5;
+                throw std::runtime_error("Lost orthonormality of Q.");
             }
         }
 

--- a/RandLAPACK/comps/rl_qb.hh
+++ b/RandLAPACK/comps/rl_qb.hh
@@ -167,7 +167,6 @@ int QB<T>::call(
     if(norm_A == 0.0) {
         // Zero matrix termination
         k = curr_sz;
-        throw std::runtime_error("Zero matrix termination.");
         return 1;
     }
 
@@ -228,7 +227,6 @@ int QB<T>::call(
                 // Lost orthonormality of Q
                 util::row_resize(this->curr_lim, n, B, curr_sz);
                 k = curr_sz;
-                throw std::runtime_error("Lost orthonormality of Q_i.");
             }
         }
 
@@ -256,7 +254,6 @@ int QB<T>::call(
             // Only need to move B's data, no resizing
             util::row_resize(this->curr_lim, n, B, curr_sz);
             k = curr_sz;
-            throw std::runtime_error("Error divergence early termination");
         }
 
         // Update the matrices Q and B
@@ -268,7 +265,6 @@ int QB<T>::call(
                 // Lost orthonormality of Q
                 util::row_resize(this->curr_lim, n, B, curr_sz);
                 k = curr_sz;
-                throw std::runtime_error("Lost orthonormality of Q.");
             }
         }
 

--- a/RandLAPACK/comps/rl_rf.hh
+++ b/RandLAPACK/comps/rl_rf.hh
@@ -218,10 +218,6 @@ int BK<T, RNG>::call(
 
         if ((p_done % q == 0) && (this->Stab_Obj.call(m, numcols, Q)))
             throw std::runtime_error("Stabilization failed.");
-
-        char name [] = "S";
-        RandBLAS::util::print_colmaj(m, k, Q_dat, name);
-
     } else {
         // Compute the sketch size from the number of passes & block size.
         // In this case, we have an expression x = randn(n, numcols), x = Ax, K = [x AA'x, ...].
@@ -239,14 +235,10 @@ int BK<T, RNG>::call(
         // Need to take in a pointer
         if ((p_done % q == 0) && (this->Stab_Obj.call(m, numcols, Q)))
             throw std::runtime_error("Stabilization failed.");
-
-        char name [] = "S";
-        RandBLAS::util::print_colmaj(m, k, Q_dat, name);
     }
     // We have placed something into full Omega previously.
     ++ iters_done;
 
-    char name2 [] = "Work";
     int64_t offset = m * numcols;
     while (p - p_done > 0) {
 
@@ -264,8 +256,6 @@ int BK<T, RNG>::call(
         if ((p_done % q == 0) && (this->Stab_Obj.call(n, numcols, Work)))
             throw std::runtime_error("Stabilzation failed.");
 
-        RandBLAS::util::print_colmaj(n, numcols, Work_dat, name2);
-
         // At the last iteration, we may not be able to fit numcols columns into block Krylov matrix.
         // We then need to alter numcols.
         // Computation above is still done for a full numcols.
@@ -278,9 +268,6 @@ int BK<T, RNG>::call(
         ++ iters_done;
     }
 
-    char name3 [] = "K before qr";
-    RandBLAS::util::print_colmaj(m, k, Q_dat, name3);
-
     // Orthogonalization
     if (this->Orth_Obj.call(m, k, Q))
         throw std::runtime_error("Orthogonalization failed.");
@@ -288,10 +275,6 @@ int BK<T, RNG>::call(
     // Reorthogonalization - intended for CholQRQ
     if (this->Orth_Obj.call(m, k, Q))
         throw std::runtime_error("Orthogonalization failed.");
-
-    char name1 [] = "K";
-    RandBLAS::util::print_colmaj(m, k, Q_dat, name1);
-
 
     //successful termination
     return 0;

--- a/RandLAPACK/comps/rl_rf.hh
+++ b/RandLAPACK/comps/rl_rf.hh
@@ -136,5 +136,149 @@ int RF<T>::call(
     return 0;
 }
 
+
+template <typename T, typename RNG>
+class BK : public RangeFinder<T>
+{
+    public:
+
+        BK(
+            // Requires a stabilization algorithm object.
+            RandLAPACK::Stabilization<T>& stab_obj,
+            RandLAPACK::Stabilization<T>& orth_obj,
+            RandBLAS::RNGState<RNG> s,
+            int64_t p,
+            int64_t q,
+            bool verb,
+            bool cond
+        ) : Stab_Obj(stab_obj), Orth_Obj(orth_obj) {
+            verbosity = verb;
+            cond_check = cond;
+            st = s;
+            passes_over_data = p;
+            passes_per_stab = q;
+        }
+
+        int call(
+            int64_t m,
+            int64_t n,
+            const std::vector<T>& A,
+            int64_t k,
+            std::vector<T>& Q
+        ) override;
+
+        RandLAPACK::Stabilization<T>& Stab_Obj;
+        RandLAPACK::Stabilization<T>& Orth_Obj;
+        RandBLAS::RNGState<RNG> st;
+        int64_t passes_over_data;
+        int64_t passes_per_stab;
+        bool verbosity;
+        bool cond_check;
+
+        std::vector<T> Work;
+        std::vector<T> Work_2;
+        std::vector<T> s;
+
+        // Implementation-specific vars
+       std::vector<T> cond_nums; // Condition nubers of sketches
+};
+
+// -----------------------------------------------------------------------------
+template <typename T, typename RNG>
+int BK<T, RNG>::call(
+    int64_t m,
+    int64_t n,
+    const std::vector<T>& A,
+    int64_t k,
+    std::vector<T>& Q
+){
+
+    int64_t p = this->passes_over_data;
+    int64_t q = this->passes_per_stab;
+    int64_t p_done = 0;
+
+    const T* A_dat = A.data();
+    T* Q_dat       = RandLAPACK::util::upsize(m * k, Q);
+    T* Work_dat    = RandLAPACK::util::upsize(n * k, this->Work);
+    auto state     = this->st;
+
+    // Number of columns in a sketching operator
+    int64_t numcols = 0;
+    // Number of Krylov iterations done
+    int64_t iters_done = 0;
+    if (p % 2 == 0) {
+        // Compute the sketch size from the number of passes & block size.
+        // In this case, we have an expression x = randn(m, numcols), K = [x, AA'x, ...].
+        // Even number of passes over data, so numcols = ceil(k / ((p / 2) + 1).
+        numcols = (int64_t) std::ceil((float) k / ((p / 2) + 1));
+
+        // Place an n by numcols Sketching operator buffer into the full Omega matrix, n by block_sz
+        RandBLAS::DenseDist  D{.n_rows = m, .n_cols = numcols};
+        RandBLAS::fill_dense(D, Q_dat, state);
+    } else {
+        // Compute the sketch size from the number of passes & block size.
+        // In this case, we have an expression x = randn(n, numcols), x = Ax, K = [x AA'x, ...].
+        // Odd number of passes over data, so numcols = ceil(k / ((p - 1) / 2)).
+        // When block_sz is not evenly divisible by q+1, we allow for 
+        // a portion of the last (A'A)^q AS to be written into Krylov matrix.
+        numcols = (int64_t) std::ceil((float) 2 * k / (p - 1));
+
+        // Fill m by numcols Work buffer - we already have more space than we can ever need
+        RandBLAS::DenseDist D{.n_rows = n, .n_cols = numcols};
+        RandBLAS::fill_dense(D, Work_dat, state);
+
+        // Write an n by k product of A' Omega_1 into the full Omega matrix
+        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, numcols, n, 1.0, A_dat, m, Work_dat, n, 0.0, Q_dat, m);
+        ++ p_done;
+
+        // Need to take in a pointer
+        if ((p_done % q == 0) && (this->Stab_Obj.call(m, numcols, Q)))
+            throw std::runtime_error("Stabilization failed.");
+    }
+    // We have placed something into full Omega previously.
+    ++ iters_done;
+
+    // In case with (A'A)^q S, we will be performing block_sz / k iterations.
+    // In case with (A'A)^q A'S, we will be performing block_sz / k - 1 iterations,
+    // we account for that inside of a previous if statement.
+    // We always allow for an additional iteration of the loop below
+    // 'offset' - size of a matrix by which shift in the block Krylov matrix.
+    // Need a separate variable for it, as k may change at the last iteration.
+    int64_t offset = m * numcols;
+    while (p - p_done > 0) {
+
+        // A' * prev, write into workspace buffer
+        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, numcols, m, 1.0, A_dat, m, Q_dat + offset * (iters_done - 1), m, 0.0, Work_dat, n);
+        ++p_done;
+
+        // Optional condition number check
+        if(this->cond_check) {
+            RandLAPACK::util::upsize(n * k, this->Work_2);
+            this->cond_nums.push_back(util::cond_num_check(n, numcols, this->Work, this->Work_2, this->s, this->verbosity));
+        }
+
+        // Stabilizaton
+        if ((p_done % q == 0) && (this->Stab_Obj.call(n, numcols, Work)))
+            throw std::runtime_error("Stabilzation failed.");
+
+        // At the last iteration, we may not be able to fit numcols columns into block Krylov matrix.
+        // We then need to alter numcols.
+        // Computation above is still done for a full numcols.
+        if ((iters_done + 1) * numcols > k)
+            numcols = k - (iters_done * numcols);
+
+        // A * A' * prev, write into K
+        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, numcols, n, 1.0, A_dat, m, Work_dat, n, 0.0, Q_dat + offset * iters_done, m);
+        ++ p_done;
+    }
+
+    // Orthogonalization
+    if (this->Stab_Obj.call(m, k, Q))
+        throw std::runtime_error("Orthogonalization failed.");
+
+    //successful termination
+    return 0;
+}
+
 } // end namespace RandLAPACK
 #endif

--- a/RandLAPACK/comps/rl_rf.hh
+++ b/RandLAPACK/comps/rl_rf.hh
@@ -254,6 +254,9 @@ int BK<T, RNG>::call(
         blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, numcols, m, 1.0, A_dat, m, Q_dat + offset * (iters_done - 1), m, 0.0, Work_dat, n);
         ++p_done;
 
+        char buf_space [] = "WORKSPACE";
+         RandBLAS::util::print_colmaj(n, k, Work_dat, buf_space);
+
         // Optional condition number check
         if(this->cond_check) {
             RandLAPACK::util::upsize(n * k, this->Work_2);

--- a/RandLAPACK/comps/rl_rf.hh
+++ b/RandLAPACK/comps/rl_rf.hh
@@ -229,8 +229,8 @@ int BK<T, RNG>::call(
         // Compute the sketch size from the number of passes & block size.
         // In this case, we have an expression x = randn(n, numcols), x = Ax, K = [x AA'x, ...].
         // Odd number of passes over data, so numcols = ceil(k / ((p - 1) / 2)).
-        //numcols = (int64_t) std::ceil(2.0 * k / (p - 1)) - 1;
-        numcols = (int64_t) std::ceil(k / p);
+        numcols = (int64_t) std::ceil(2.0 * k / (p - 1)) - 1;
+        //numcols = (int64_t) std::ceil(k / p);
 
         // Fill m by numcols Work buffer - we already have more space than we can ever need
         RandBLAS::DenseDist D{.n_rows = n, .n_cols = numcols};

--- a/RandLAPACK/drivers/rl_hqrrp.hh
+++ b/RandLAPACK/drivers/rl_hqrrp.hh
@@ -606,7 +606,7 @@ template <typename T, typename RNG>
 int64_t hqrrp( 
     int64_t m_A, int64_t n_A, T * buff_A, int64_t ldim_A,
     int64_t * buff_jpvt, T * buff_tau,
-    int64_t nb_alg, int64_t pp, int64_t panel_pivoting, RandBLAS::RNGState<RNG> state) {
+    int64_t nb_alg, int64_t pp, int64_t panel_pivoting, RandBLAS::RNGState<RNG>& state) {
 
     int64_t b, j, last_iter, mn_A, m_Y, n_Y, ldim_Y, m_V, n_V, ldim_V, 
             m_W, n_W, ldim_W, n_VR, m_AB1, n_AB1, ldim_T1_T,
@@ -665,7 +665,7 @@ int64_t hqrrp(
 
     // Initialize matrices G and Y.
     RandBLAS::DenseDist D{.n_rows = nb_alg + pp, .n_cols = m_A, .family=RandBLAS::DenseDistName::Uniform};
-    RandBLAS::fill_dense(D, buff_G, state);
+    state = RandBLAS::fill_dense(D, buff_G, state);
     
     blas::gemm(blas::Layout::ColMajor,
                 blas::Op::NoTrans, blas::Op::NoTrans, m_Y, n_Y, m_A, 

--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -27,7 +27,7 @@ class REVD2alg {
             T tol,
             std::vector<T>& V,
             std::vector<T>& eigvals,
-            RandBLAS::RNGState<RNG> state
+            RandBLAS::RNGState<RNG>& state
         ) = 0;
 };
 
@@ -90,7 +90,7 @@ class REVD2 : public REVD2alg<T, RNG> {
             T tol,
             std::vector<T>& V,
             std::vector<T>& eigvals,
-            RandBLAS::RNGState<RNG> state
+            RandBLAS::RNGState<RNG>& state
         ) override;
 
     public:
@@ -169,7 +169,7 @@ RandBLAS::RNGState<RNG> REVD2<T, RNG>::call(
         T tol,
         std::vector<T>& V,
         std::vector<T>& eigvals,
-        RandBLAS::RNGState<RNG> state
+        RandBLAS::RNGState<RNG>& state
 ){
     T err = 0;
     std::vector<T> symrf_work(0);

--- a/RandLAPACK/rl_gen.hh
+++ b/RandLAPACK/rl_gen.hh
@@ -62,7 +62,7 @@ void gen_singvec(
     std::vector<T>& A,
     int64_t k,
     std::vector<T>& S,
-    RandBLAS::RNGState<RNG> state
+    RandBLAS::RNGState<RNG>& state
 ) {
     std::vector<T> U(m * k, 0.0);
     std::vector<T> V(n * k, 0.0);
@@ -108,7 +108,7 @@ void gen_poly_mat(
     T cond,
     T p,
     bool diagon,
-    RandBLAS::RNGState<RNG> state
+    RandBLAS::RNGState<RNG>& state
 ) {
 
     // Predeclare to all nonzero constants, start decay where needed
@@ -158,7 +158,7 @@ void gen_exp_mat(
     int64_t k,
     T cond,
     bool diagon,
-    RandBLAS::RNGState<RNG> state
+    RandBLAS::RNGState<RNG>& state
 ) {
 
     std::vector<T> s(k, 1.0);
@@ -206,7 +206,7 @@ void gen_step_mat(
     int64_t k,
     T cond,
     bool diagon,
-    RandBLAS::RNGState<RNG> state
+    RandBLAS::RNGState<RNG>& state
 ) {
 
     // Predeclare to all nonzero constants, start decay where needed
@@ -246,14 +246,14 @@ void gen_spiked_mat(
     int64_t& n,
     std::vector<T>& A,
     T spike_scale,
-    RandBLAS::RNGState<RNG> state
+    RandBLAS::RNGState<RNG>& state
 ) {
     int64_t num_rows_sampled = n / 2;
 
     /// sample from [m] without replacement. Get the row indices for a tall LASO with a single column.
     RandBLAS::SparseDist DS = {.n_rows = m, .n_cols = 1, .vec_nnz = num_rows_sampled, .major_axis = RandBLAS::MajorAxis::Long};
     RandBLAS::SparseSkOp<T, RNG> S(DS, state);
-    RandBLAS::fill_sparse(S);
+    state = RandBLAS::fill_sparse(S);
 
     std::vector<T> V(n * n, 0.0);
     std::vector<T> tau(n, 0.0);
@@ -296,7 +296,7 @@ void gen_oleg_adversarial_mat(
     int64_t& n,
     std::vector<T>& A,
     T sigma,
-    RandBLAS::RNGState<RNG> state
+    RandBLAS::RNGState<RNG>& state
 ) {
 
     T scaling_factor_U = sigma;
@@ -351,7 +351,7 @@ void gen_bad_cholqr_mat(
     int64_t k,
     T cond,
     bool diagon,
-    RandBLAS::RNGState<RNG> state
+    RandBLAS::RNGState<RNG>& state
 ) {
 
     std::vector<T> s(n, 1.0);
@@ -393,7 +393,7 @@ template <typename T, typename RNG>
 void mat_gen(
     mat_gen_info<T> info,
     std::vector<T>& A,
-    RandBLAS::RNGState<RNG> state
+    RandBLAS::RNGState<RNG>& state
 ) {
     // Base parameters
     int64_t m = info.rows;
@@ -414,7 +414,7 @@ void mat_gen(
         case gaussian: {
                 // Gaussian random matrix
                 RandBLAS::DenseDist D{.n_rows = m, .n_cols = n};
-                RandBLAS::fill_dense(D, A_dat, state);
+                state = RandBLAS::fill_dense(D, A_dat, state);
             }
             break;
         case step: {

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -248,7 +248,7 @@ class TestQB : public ::testing::Test
         }
     }
 };
-
+/*
 TEST_F(TestQB, Polynomial_Decay_Krylov_odd)
 {
     int64_t m = 10;
@@ -280,7 +280,7 @@ TEST_F(TestQB, Polynomial_Decay_Krylov_odd)
     svd_and_copy_computational_helper<double>(all_data);
     test_QB2_low_exact_rank<double, r123::Philox4x32, algorithm_objects_krylov<double, r123::Philox4x32>>(block_sz, tol, all_data, all_algs);
 }
-/*
+*/
 TEST_F(TestQB, Polynomial_Decay_Krylov_odd)
 {
     int64_t m = 100;
@@ -338,7 +338,7 @@ TEST_F(TestQB, Polynomial_Decay_Krylov_even)
     svd_and_copy_computational_helper<double>(all_data);
     test_QB2_low_exact_rank<double, r123::Philox4x32, algorithm_objects_krylov<double, r123::Philox4x32>>(block_sz, tol, all_data, all_algs);
 }
-*/
+
 TEST_F(TestQB, Polynomial_Decay_general1)
 {
     int64_t m = 100;

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -85,7 +85,7 @@ class TestQB : public ::testing::Test
         RandLAPACK::HQRQ<T> Stab;
         RandLAPACK::HQRQ<T> Orth;
         RandLAPACK::BK<T, RNG> RF;
-        RandLAPACK::CholQRQ<T> Orth_QB;
+        RandLAPACK::HQRQ<T> Orth_QB;
         RandLAPACK::QB<T> QB;
 
         algorithm_objects_krylov(bool verbosity, 
@@ -251,12 +251,12 @@ class TestQB : public ::testing::Test
 
 TEST_F(TestQB, Polynomial_Decay_general1)
 {
-    int64_t m = 100;
-    int64_t n = 100;
-    int64_t k = 100;
+    int64_t m = 10;
+    int64_t n = 10;
+    int64_t k = 10;
     int64_t p = 4;
     int64_t passes_per_iteration = 1;
-    int64_t block_sz = 100;
+    int64_t block_sz = 5;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::RNGState();
     
@@ -269,6 +269,10 @@ TEST_F(TestQB, Polynomial_Decay_general1)
     algorithm_objects_krylov<double, r123::Philox4x32> all_algs(verbosity, cond_check, orth_check, p, passes_per_iteration, state);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
+    
+    char name [] = "A";
+    RandBLAS::util::print_colmaj(m, n, all_data.A.data(), name);
+    
     svd_and_copy_computational_helper<double>(all_data);
     test_QB2_low_exact_rank<double, r123::Philox4x32>(block_sz, tol, all_data, all_algs);
 }

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -251,6 +251,38 @@ class TestQB : public ::testing::Test
 
 TEST_F(TestQB, Polynomial_Decay_Krylov_odd)
 {
+    int64_t m = 10;
+    int64_t n = 10;
+    int64_t k = 5;
+    int64_t p = 2;
+    int64_t passes_per_iteration = 1;
+    int64_t block_sz = 5;
+    double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
+    auto state = RandBLAS::RNGState();
+    
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+    bool orth_check = true;
+
+    QBTestData<double> all_data(m, n, k);
+    algorithm_objects_krylov<double, r123::Philox4x32> all_algs(verbosity, cond_check, orth_check, p, passes_per_iteration, state);
+    
+    RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::exponential);
+    m_info.cond_num = 2025;
+    m_info.rank = k;
+    m_info.exponent = 2.0;
+    RandLAPACK::gen::mat_gen<double, r123::Philox4x32>(m_info, all_data.A, state);
+    
+    char name [] = "A";
+    RandBLAS::util::print_colmaj(m, n, all_data.A.data(), name);
+
+    svd_and_copy_computational_helper<double>(all_data);
+    test_QB2_low_exact_rank<double, r123::Philox4x32, algorithm_objects_krylov<double, r123::Philox4x32>>(block_sz, tol, all_data, all_algs);
+}
+/*
+TEST_F(TestQB, Polynomial_Decay_Krylov_odd)
+{
     int64_t m = 100;
     int64_t n = 100;
     int64_t k = 50;
@@ -306,7 +338,7 @@ TEST_F(TestQB, Polynomial_Decay_Krylov_even)
     svd_and_copy_computational_helper<double>(all_data);
     test_QB2_low_exact_rank<double, r123::Philox4x32, algorithm_objects_krylov<double, r123::Philox4x32>>(block_sz, tol, all_data, all_algs);
 }
-
+*/
 TEST_F(TestQB, Polynomial_Decay_general1)
 {
     int64_t m = 100;

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -85,7 +85,7 @@ class TestQB : public ::testing::Test
         RandLAPACK::HQRQ<T> Stab;
         RandLAPACK::HQRQ<T> Orth;
         RandLAPACK::BK<T, RNG> RF;
-        RandLAPACK::HQRQ<T> Orth_QB;
+        RandLAPACK::CholQRQ<T> Orth_QB;
         RandLAPACK::QB<T> QB;
 
         algorithm_objects_krylov(bool verbosity, 
@@ -269,10 +269,6 @@ TEST_F(TestQB, Polynomial_Decay_general1)
     algorithm_objects_krylov<double, r123::Philox4x32> all_algs(verbosity, cond_check, orth_check, p, passes_per_iteration, state);
 
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    
-    char name [] = "A";
-    RandBLAS::util::print_colmaj(m, n, all_data.A.data(), name);
-    
     svd_and_copy_computational_helper<double>(all_data);
     test_QB2_low_exact_rank<double, r123::Philox4x32>(block_sz, tol, all_data, all_algs);
 }

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -249,7 +249,7 @@ class TestQB : public ::testing::Test
     }
 };
 
-TEST_F(TestQB, Polynomial_Decay_general1)
+TEST_F(TestQB, Polynomial_Decay_Krylov1)
 {
     int64_t m = 10;
     int64_t n = 10;
@@ -268,7 +268,12 @@ TEST_F(TestQB, Polynomial_Decay_general1)
     QBTestData<double> all_data(m, n, k);
     algorithm_objects_krylov<double, r123::Philox4x32> all_algs(verbosity, cond_check, orth_check, p, passes_per_iteration, state);
 
-    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
+    RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::exponential);
+    m_info.cond_num = 2025;
+    m_info.rank = k;
+    m_info.exponent = 2.0;
+    RandLAPACK::gen::mat_gen<double, r123::Philox4x32>(m_info, all_data.A, state);
+    
     svd_and_copy_computational_helper<double>(all_data);
     test_QB2_low_exact_rank<double, r123::Philox4x32>(block_sz, tol, all_data, all_algs);
 }

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -251,12 +251,12 @@ class TestQB : public ::testing::Test
 
 TEST_F(TestQB, Polynomial_Decay_Krylov1)
 {
-    int64_t m = 10;
-    int64_t n = 10;
-    int64_t k = 10;
-    int64_t p = 4;
+    int64_t m = 100;
+    int64_t n = 100;
+    int64_t k = 100;
+    int64_t p = 7;
     int64_t passes_per_iteration = 1;
-    int64_t block_sz = 5;
+    int64_t block_sz = 50;
     double tol = std::pow(std::numeric_limits<double>::epsilon(), 0.75);
     auto state = RandBLAS::RNGState();
     

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -158,7 +158,7 @@ class TestRF : public ::testing::Test
         ASSERT_NEAR(std::min(norm1_test_2, norm2_test_2), 0, test_tol);
     }
 };
-
+/*
 TEST_F(TestRF, Polynomial_Decay_general1)
 {
     int64_t m = 100;
@@ -265,5 +265,5 @@ TEST_F(TestRF, Polynomial_Decay2_Krylov)
     orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
     
     test_RF_general<double, r123::Philox4x32, algorithm_objects_krylov<double, r123::Philox4x32>>(all_data, all_algs);
-    
 }
+*/

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -67,8 +67,8 @@ class TestRF : public ::testing::Test
 
     template <typename T, typename RNG>
     struct algorithm_objects_krylov {
-        RandLAPACK::HQRQ<T> Stab;
-        RandLAPACK::HQRQ<T> Orth;
+        RandLAPACK::PLUL<T> Stab;
+        RandLAPACK::CholQRQ<T> Orth;
         RandLAPACK::BK<T, RNG> RF;
 
         algorithm_objects_krylov(

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -45,13 +45,13 @@ class TestRF : public ::testing::Test
     };
 
     template <typename T, typename RNG>
-    struct algorithm_objects {
+    struct algorithm_objects_standard {
         RandLAPACK::PLUL<T> Stab;
         RandLAPACK::RS<T, RNG> RS;
         RandLAPACK::HQRQ<T> Orth_RF;
         RandLAPACK::RF<T> RF;
 
-        algorithm_objects(
+        algorithm_objects_standard(
             bool verbosity, 
             bool cond_check, 
             int64_t p, 
@@ -62,6 +62,25 @@ class TestRF : public ::testing::Test
             RS(Stab, state, p, passes_per_iteration, verbosity, cond_check),
             Orth_RF(cond_check, verbosity),
             RF(RS, Orth_RF, verbosity, cond_check)
+            {}
+    };
+
+    template <typename T, typename RNG>
+    struct algorithm_objects_krylov {
+        RandLAPACK::PLUL<T> Stab;
+        RandLAPACK::HQRQ<T> Orth;
+        RandLAPACK::BK<T, RNG> RF;
+
+        algorithm_objects_krylov(
+            bool verbosity, 
+            bool cond_check, 
+            int64_t p, 
+            int64_t passes_per_iteration, 
+            RandBLAS::RNGState<RNG> state
+        ) :
+            Stab(cond_check, verbosity),
+            Orth(cond_check, verbosity),
+            RF(Stab, Orth, state, p, passes_per_iteration, verbosity, cond_check)
             {}
     };
 
@@ -88,7 +107,61 @@ class TestRF : public ::testing::Test
     template <typename T, typename RNG>
     static void test_RF_general(
         RFTestData<T>& all_data, 
-        algorithm_objects<T, RNG>& all_algs) {
+        algorithm_objects_standard<T, RNG>& all_algs) {
+
+        auto m = all_data.row;
+        auto n = all_data.col;
+        auto k = all_data.rank;
+
+        all_algs.RF.call(m, n, all_data.A, k, all_data.Q);
+
+        // Reassing pointers because Q, B have been resized
+        T* Q_dat = all_data.Q.data();
+        T* Q_cpy_dat = all_data.Q_cpy.data();
+        T* Buf1_dat = all_data.Buf1.data();
+        T* Buf2_dat = all_data.Buf2.data();
+        T* Q_hat_dat = all_data.A_cpy.data();
+        T* Q_hat_cpy_dat = all_data.Q_hat_cpy.data();
+
+        lapack::lacpy(MatrixType::General, m, k, Q_dat, m, Q_cpy_dat, m);
+
+        std::vector<T> Ident(k * k, 0.0);
+        T* Ident_dat = Ident.data();
+        // Generate a reference identity
+        RandLAPACK::util::eye(k, k, Ident);
+
+        // TEST 1: Q'Q = I
+        blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, Q_dat, m, -1.0, Ident_dat, k);
+
+        // TEST 2:
+        // Q' * Q_hat = Buf1
+        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, n, m, 1.0, Q_dat, m, Q_hat_dat, m, 0.0, Buf1_dat, k);
+        // Q * Buf1 - Q_hat
+        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, k, 1.0, Q_dat, m, Buf1_dat, k, -1.0, Q_hat_cpy_dat, m);
+
+        // Q_hat' * Q = Buf2
+        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, k, m, 1.0, Q_hat_dat, m, Q_dat, m, 0.0, Buf2_dat, n);
+        // Q_hat * Buf2 - Q
+        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, n, 1.0, Q_hat_dat, m, Buf2_dat, n, -1.0, Q_cpy_dat, m);
+
+        T test_tol = std::pow(std::numeric_limits<T>::epsilon(), 0.625);
+        // Test 1 Output
+        T norm_test_1 = lapack::lansy(lapack::Norm::Fro, Uplo::Upper, k, Ident_dat, k);
+        printf("FRO NORM OF Q'Q - I:   %e\n", norm_test_1);
+        ASSERT_NEAR(norm_test_1, 0, test_tol);
+
+        // Test 1 Output
+        T norm1_test_2 = lapack::lange(Norm::Fro, m, n, Q_hat_cpy_dat, m);
+        T norm2_test_2 = lapack::lange(Norm::Fro, m, k, Q_cpy_dat, m);
+        printf("FRO NORM OF QQ' * Q_hat - Q_hat:   %e\n", norm1_test_2);
+        printf("FRO NORM OF Q_hat Q_hat' * Q = Q:   %e\n", norm2_test_2);
+        ASSERT_NEAR(std::min(norm1_test_2, norm2_test_2), 0, test_tol);
+    }
+
+    template <typename T, typename RNG>
+    static void test_RF_krylov(
+        RFTestData<T>& all_data, 
+        algorithm_objects_krylov<T, RNG>& all_algs) {
 
         auto m = all_data.row;
         auto n = all_data.col;
@@ -154,7 +227,7 @@ TEST_F(TestRF, Polynomial_Decay_general1)
     bool cond_check = true;
 
     RFTestData<double> all_data(m, n, k);
-    algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
+    algorithm_objects_standard<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
     RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::polynomial);
     m_info.cond_num = 2025;
@@ -181,7 +254,7 @@ TEST_F(TestRF, Polynomial_Decay_general2)
     bool cond_check = true;
 
     RFTestData<double> all_data(m, n, k);
-    algorithm_objects<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
+    algorithm_objects_standard<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
     RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::polynomial);
     m_info.cond_num = 2025;
@@ -192,4 +265,26 @@ TEST_F(TestRF, Polynomial_Decay_general2)
     orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
     
     test_RF_general<double, r123::Philox4x32>(all_data, all_algs);
+}
+
+TEST_F(TestRF, Polynomial_Decay_Krylov)
+{
+    int64_t m = 100;
+    int64_t n = 100;
+    int64_t k = 100;
+    int64_t p = 5;
+    int64_t passes_per_iteration = 1;
+    auto state = RandBLAS::RNGState();
+
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+
+    RFTestData<double> all_data(m, n, k);
+    algorithm_objects_krylov<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
+    
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
+    orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
+    
+    test_RF_krylov<double, r123::Philox4x32>(all_data, all_algs);
 }

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -267,7 +267,7 @@ TEST_F(TestRF, Polynomial_Decay_general2)
     test_RF_general<double, r123::Philox4x32>(all_data, all_algs);
 }
 
-TEST_F(TestRF, Polynomial_Decay_Krylov)
+TEST_F(TestRF, Polynomial_Decay1_Krylov)
 {
     int64_t m = 100;
     int64_t n = 100;
@@ -285,6 +285,28 @@ TEST_F(TestRF, Polynomial_Decay_Krylov)
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
     orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
+
+    test_RF_krylov<double, r123::Philox4x32>(all_data, all_algs);
+}
+
+TEST_F(TestRF, Polynomial_Decay2_Krylov)
+{
+    int64_t m = 100;
+    int64_t n = 100;
+    int64_t k = 50;
+    int64_t p = 4;
+    int64_t passes_per_iteration = 1;
+    auto state = RandBLAS::RNGState();
+
+    //Subroutine parameters
+    bool verbosity = false;
+    bool cond_check = true;
+
+    RFTestData<double> all_data(m, n, k);
+    algorithm_objects_krylov<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
+    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
+    orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
+
     test_RF_krylov<double, r123::Philox4x32>(all_data, all_algs);
 }

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -309,4 +309,9 @@ TEST_F(TestRF, Polynomial_Decay2_Krylov)
     orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
 
     test_RF_krylov<double, r123::Philox4x32>(all_data, all_algs);
+
+    double nrm_A = 1.000000000000090;
+    double nrm_B = 1.000000000000089;
+    printf("%.15e\n", std::sqrt((nrm_A - nrm_B) * (nrm_A + nrm_B)) / nrm_A);
+    
 }

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -283,9 +283,14 @@ TEST_F(TestRF, Polynomial_Decay1_Krylov)
     RFTestData<double> all_data(m, n, k);
     algorithm_objects_krylov<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
-    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
+    RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::polynomial);
+    m_info.cond_num = 2025;
+    m_info.rank = k;
+    m_info.exponent = 2.0;
+    RandLAPACK::gen::mat_gen<double, r123::Philox4x32>(m_info, all_data.A, state);
 
+    orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
+    
     test_RF_krylov<double, r123::Philox4x32>(all_data, all_algs);
 }
 
@@ -305,13 +310,14 @@ TEST_F(TestRF, Polynomial_Decay2_Krylov)
     RFTestData<double> all_data(m, n, k);
     algorithm_objects_krylov<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
-    RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
+    RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::polynomial);
+    m_info.cond_num = 2025;
+    m_info.rank = k;
+    m_info.exponent = 2.0;
+    RandLAPACK::gen::mat_gen<double, r123::Philox4x32>(m_info, all_data.A, state);
+
     orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
-
+    
     test_RF_krylov<double, r123::Philox4x32>(all_data, all_algs);
-
-    double nrm_A = 1.000000000000090;
-    double nrm_B = 1.000000000000089;
-    printf("%.15e\n", std::sqrt((nrm_A - nrm_B) * (nrm_A + nrm_B)) / nrm_A);
     
 }

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -269,10 +269,10 @@ TEST_F(TestRF, Polynomial_Decay_general2)
 
 TEST_F(TestRF, Polynomial_Decay_Krylov)
 {
-    int64_t m = 100;
-    int64_t n = 100;
-    int64_t k = 100;
-    int64_t p = 5;
+    int64_t m = 10;
+    int64_t n = 10;
+    int64_t k = 10;
+    int64_t p = 4;
     int64_t passes_per_iteration = 1;
     auto state = RandBLAS::RNGState();
 

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -269,10 +269,10 @@ TEST_F(TestRF, Polynomial_Decay_general2)
 
 TEST_F(TestRF, Polynomial_Decay_Krylov)
 {
-    int64_t m = 10;
-    int64_t n = 10;
-    int64_t k = 10;
-    int64_t p = 4;
+    int64_t m = 100;
+    int64_t n = 100;
+    int64_t k = 50;
+    int64_t p = 5;
     int64_t passes_per_iteration = 1;
     auto state = RandBLAS::RNGState();
 
@@ -284,9 +284,6 @@ TEST_F(TestRF, Polynomial_Decay_Krylov)
     algorithm_objects_krylov<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
-    
-    char name [] = "A";
-    RandBLAS::util::print_colmaj(m, n, all_data.A.data(), name);
     orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
     
     test_RF_krylov<double, r123::Philox4x32>(all_data, all_algs);

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -67,7 +67,7 @@ class TestRF : public ::testing::Test
 
     template <typename T, typename RNG>
     struct algorithm_objects_krylov {
-        RandLAPACK::PLUL<T> Stab;
+        RandLAPACK::HQRQ<T> Stab;
         RandLAPACK::HQRQ<T> Orth;
         RandLAPACK::BK<T, RNG> RF;
 
@@ -284,6 +284,9 @@ TEST_F(TestRF, Polynomial_Decay_Krylov)
     algorithm_objects_krylov<double, r123::Philox4x32> all_algs(verbosity, cond_check, p, passes_per_iteration, state);
     
     RandLAPACK::util::gen_mat_type<double, r123::Philox4x32>(m, n, all_data.A, k, state, std::make_tuple(0, 2025, false));
+    
+    char name [] = "A";
+    RandBLAS::util::print_colmaj(m, n, all_data.A.data(), name);
     orth_and_copy_computational_helper<double, r123::Philox4x32>(all_data);
     
     test_RF_krylov<double, r123::Philox4x32>(all_data, all_algs);


### PR DESCRIPTION
1. Adding an alternative to RangeFinder based on block Krylov method. Current implementation passes RangeFinder tests, but fails to serve as a substitution for a classical range finder in QB scheme.
2. Making sure that random states are properly updated and passes around in functions. The convention is that every time RandBLAS generates matrices, we need to manually update random states. This process revealed a RandBLAS issue described [here](https://github.com/BallisticLA/RandBLAS/issues/57).

Note that in practice, QB with rapidly-computed Frobenius norm stopping criterion does not detect errors smaller than `sqrt(epsillon<T>)`.
This does not seem to ever be an explicit issue whenever using a conventional rangefinder, but is occasionally exposed through use of Krylov rangefinder in situations like the following:
 Then, consider the expression for a QB error indicator described in Section 3.1 of [this](https://arxiv.org/pdf/1606.09402.pdf) paper:

```math
\|A - QB\|_{F} = \sqrt{\|A\|^{2}_{F} - \|B\|^{2}_{F}} = \sqrt{(\|A\|_{F} - \|B\|_{F})(\|A\|_{F} + \|B\|_{F})}.
``` 

In terms of accuracy, the best possible outcome of this expression is dictated by the case when Frobenius norms of $A$ and $B$ differ by $10^{-15}$ (we can only have 15 digits of accuracy after decimal point in double-precision arithmetic).
However, $\sqrt(10^{-15}) \approx 3.1 \cdot 10^{-8}$, which seems to be Our realistic accuracy bound for double precision computations. 
This limitation is also described in Section 3.3 of the aforementioned paper. 
For that reason, in MATLAB's "svdsketch()" routine that uses QB method, the default approximation tolerance is set to `eps(class(A))^(1/4)`.
