### PR TITLE
Style for white space when passing by address

### DIFF
--- a/RandLAPACK/comps/rl_determiter.hh
+++ b/RandLAPACK/comps/rl_determiter.hh
@@ -21,7 +21,7 @@ void pcg(
     const T* b, // length m
     const T* c, // length n
     T delta, // >= 0
-    std::vector<T>& resid_vec, // re
+    std::vector<T> &resid_vec, // re
     T tol, //  > 0
     int64_t k,
     const T* M, // n-by-k

--- a/RandLAPACK/comps/rl_orth.hh
+++ b/RandLAPACK/comps/rl_orth.hh
@@ -19,7 +19,7 @@ class Stabilization {
         virtual int call(
             int64_t m,
             int64_t k,
-            std::vector<T>& Q
+            std::vector<T> &Q
         ) = 0;
 };
 
@@ -56,7 +56,7 @@ class CholQRQ : public Stabilization<T> {
         int call(
             int64_t m,
             int64_t k,
-            std::vector<T>& Q
+            std::vector<T> &Q
         );
 
     public:
@@ -75,7 +75,7 @@ template <typename T>
 int CholQRQ<T>::call(
     int64_t m,
     int64_t k,
-    std::vector<T>& Q
+    std::vector<T> &Q
 ){
 
     T* Q_gram_dat = util::upsize(k * k, this->Q_gram);
@@ -143,7 +143,7 @@ class HQRQ : public Stabilization<T> {
         int call(
             int64_t m,
             int64_t k,
-            std::vector<T>& Q
+            std::vector<T> &Q
         );
 
     public:
@@ -157,7 +157,7 @@ template <typename T>
 int HQRQ<T>::call(
     int64_t m,
     int64_t n,
-    std::vector<T>& A
+    std::vector<T> &A
 ) {
     // Done via regular LAPACK's QR
     // tau The vector tau of length min(m,n). The scalar factors of the elementary reflectors (see Further Details).
@@ -210,7 +210,7 @@ class PLUL : public Stabilization<T> {
         int call(
             int64_t m,
             int64_t k,
-            std::vector<T>& Q
+            std::vector<T> &Q
         );
 
     public:
@@ -225,7 +225,7 @@ template <typename T>
 int PLUL<T>::call(
     int64_t m,
     int64_t n,
-    std::vector<T>& A
+    std::vector<T> &A
 ){
     auto ipiv = this->ipiv;
     // Not using utility bc vector of int

--- a/RandLAPACK/comps/rl_qb.hh
+++ b/RandLAPACK/comps/rl_qb.hh
@@ -24,13 +24,13 @@ class QBalg {
         virtual int call(
             int64_t m,
             int64_t n,
-            std::vector<T>& A,
-            int64_t& k,
+            std::vector<T> &A,
+            int64_t &k,
             int64_t block_sz,
             T tol,
-            std::vector<T>& Q,
-            std::vector<T>& B,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &Q,
+            std::vector<T> &B,
+            RandBLAS::RNGState<RNG> &state
         ) = 0;
 };
 
@@ -41,9 +41,9 @@ class QB : public QBalg<T, RNG> {
         // Constructor
         QB(
             // Requires a RangeFinder scheme object.
-            RandLAPACK::RangeFinder<T, RNG>& rf_obj,
+            RandLAPACK::RangeFinder<T, RNG> &rf_obj,
             // Requires a stabilization algorithm object.
-            RandLAPACK::Stabilization<T>& orth_obj,
+            RandLAPACK::Stabilization<T> &orth_obj,
             bool verb,
             bool orth
         ) : RF_Obj(rf_obj), Orth_Obj(orth_obj) {
@@ -115,18 +115,18 @@ class QB : public QBalg<T, RNG> {
         int call(
             int64_t m,
             int64_t n,
-            std::vector<T>& A,
-            int64_t& k,
+            std::vector<T> &A,
+            int64_t &k,
             int64_t block_sz,
             T tol,
-            std::vector<T>& Q,
-            std::vector<T>& B,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &Q,
+            std::vector<T> &B,
+            RandBLAS::RNGState<RNG> &state
         ) override;
 
     public:
-        RandLAPACK::RangeFinder<T, RNG>& RF_Obj;
-        RandLAPACK::Stabilization<T>& Orth_Obj;
+        RandLAPACK::RangeFinder<T, RNG> &RF_Obj;
+        RandLAPACK::Stabilization<T> &Orth_Obj;
         bool verbosity;
         bool orth_check;
 
@@ -151,13 +151,13 @@ template <typename T, typename RNG>
 int QB<T, RNG>::call(
     int64_t m,
     int64_t n,
-    std::vector<T>& A,
-    int64_t& k,
+    std::vector<T> &A,
+    int64_t &k,
     int64_t block_sz,
     T tol,
-    std::vector<T>& Q,
-    std::vector<T>& B,
-    RandBLAS::RNGState<RNG>& state
+    std::vector<T> &Q,
+    std::vector<T> &B,
+    RandBLAS::RNGState<RNG> &state
 ){
 
     int64_t curr_sz = 0;

--- a/RandLAPACK/comps/rl_rf.hh
+++ b/RandLAPACK/comps/rl_rf.hh
@@ -22,10 +22,10 @@ class RangeFinder {
         virtual int call(
             int64_t m,
             int64_t n,
-            const std::vector<T>& A,
+            const std::vector<T> &A,
             int64_t k,
-            std::vector<T>& Q,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &Q,
+            RandBLAS::RNGState<RNG> &state
         ) = 0;
 };
 
@@ -35,9 +35,9 @@ class RF : public RangeFinder<T, RNG> {
 
         RF(
             // Requires a RowSketcher scheme object.
-            RandLAPACK::RowSketcher<T, RNG>& rs_obj,
+            RandLAPACK::RowSketcher<T, RNG> &rs_obj,
             // Requires a stabilization algorithm object.
-            RandLAPACK::Stabilization<T>& orth_obj,
+            RandLAPACK::Stabilization<T> &orth_obj,
             bool verb,
             bool cond
         ) : RS_Obj(rs_obj), Orth_Obj(orth_obj) {
@@ -86,16 +86,16 @@ class RF : public RangeFinder<T, RNG> {
         int call(
             int64_t m,
             int64_t n,
-            const std::vector<T>& A,
+            const std::vector<T> &A,
             int64_t k,
-            std::vector<T>& Q,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &Q,
+            RandBLAS::RNGState<RNG> &state
         ) override;
 
     public:
        // Instantiated in the constructor
-       RandLAPACK::RowSketcher<T, RNG>& RS_Obj;
-       RandLAPACK::Stabilization<T>& Orth_Obj;
+       RandLAPACK::RowSketcher<T, RNG> &RS_Obj;
+       RandLAPACK::Stabilization<T> &Orth_Obj;
        bool verbosity;
        bool cond_check;
        std::vector<T> Omega;
@@ -112,10 +112,10 @@ template <typename T, typename RNG>
 int RF<T, RNG>::call(
     int64_t m,
     int64_t n,
-    const std::vector<T>& A,
+    const std::vector<T> &A,
     int64_t k,
-    std::vector<T>& Q,
-    RandBLAS::RNGState<RNG>& state
+    std::vector<T> &Q,
+    RandBLAS::RNGState<RNG> &state
 ){
 
     T* Omega_dat = util::upsize(n * k, this->Omega);

--- a/RandLAPACK/comps/rl_rs.hh
+++ b/RandLAPACK/comps/rl_rs.hh
@@ -22,10 +22,10 @@ class RowSketcher
         virtual int call(
             int64_t m,
             int64_t n,
-            const std::vector<T>& A,
+            const std::vector<T> &A,
             int64_t k,
-            std::vector<T>& Omega,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &Omega,
+            RandBLAS::RNGState<RNG> &state
         ) = 0;
 };
 
@@ -36,7 +36,7 @@ class RS : public RowSketcher<T, RNG>
 
         RS(
             // Requires a stabilization algorithm object.
-            RandLAPACK::Stabilization<T>& stab_obj,
+            RandLAPACK::Stabilization<T> &stab_obj,
             int64_t p,
             int64_t q,
             bool verb,
@@ -99,13 +99,13 @@ class RS : public RowSketcher<T, RNG>
         int call(
             int64_t m,
             int64_t n,
-            const std::vector<T>& A,
+            const std::vector<T> &A,
             int64_t k,
-            std::vector<T>& Omega,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &Omega,
+            RandBLAS::RNGState<RNG> &state
         ) override;
 
-        RandLAPACK::Stabilization<T>& Stab_Obj;
+        RandLAPACK::Stabilization<T> &Stab_Obj;
         int64_t passes_over_data;
         int64_t passes_per_stab;
         bool verbosity;
@@ -123,10 +123,10 @@ template <typename T, typename RNG>
 int RS<T, RNG>::call(
     int64_t m,
     int64_t n,
-    const std::vector<T>& A,
+    const std::vector<T> &A,
     int64_t k,
-    std::vector<T>& Omega,
-    RandBLAS::RNGState<RNG>& state
+    std::vector<T> &Omega,
+    RandBLAS::RNGState<RNG> &state
 ){
 
     int64_t p = this->passes_over_data;

--- a/RandLAPACK/comps/rl_syps.hh
+++ b/RandLAPACK/comps/rl_syps.hh
@@ -26,16 +26,16 @@ class SymmetricPowerSketch {
             const T* A,
             int64_t lda,
             int64_t k,
-            RandBLAS::RNGState<RNG>& state,
-            T*& skop_buff = nullptr,
+            RandBLAS::RNGState<RNG> &state,
+            T* &skop_buff = nullptr,
             T* work_buff = nullptr
         ) = 0;
 
         virtual int call(
             SymmetricLinearOperator<T> &A,
             int64_t k,
-            RandBLAS::RNGState<RNG>& state,
-            T*& skop_buff = nullptr,
+            RandBLAS::RNGState<RNG> &state,
+            T* &skop_buff = nullptr,
             T* work_buff = nullptr
         ) = 0;
 
@@ -104,7 +104,7 @@ class SYPS : public SymmetricPowerSketch<T, RNG> {
             int64_t lda,
             int64_t k,
             RandBLAS::RNGState<RNG> &state,
-            T*& skop_buff,
+            T* &skop_buff,
             T* work_buff
         );
 
@@ -112,7 +112,7 @@ class SYPS : public SymmetricPowerSketch<T, RNG> {
             SymmetricLinearOperator<T> &A,
             int64_t k,
             RandBLAS::RNGState<RNG> &state,
-            T*& skop_buff,
+            T* &skop_buff,
             T* work_buff
         );
     
@@ -128,8 +128,8 @@ template <typename T, typename RNG>
 int SYPS<T, RNG>::call(
     SymmetricLinearOperator<T> &A,
     int64_t k,
-    RandBLAS::RNGState<RNG>& state,
-    T*& skop_buff,
+    RandBLAS::RNGState<RNG> &state,
+    T* &skop_buff,
     T* work_buff
 ){
     int64_t m = A.m;
@@ -183,8 +183,8 @@ int SYPS<T, RNG>::call(
     const T* A,
     int64_t lda,
     int64_t k,
-    RandBLAS::RNGState<RNG>& state,
-    T*& skop_buff,
+    RandBLAS::RNGState<RNG> &state,
+    T* &skop_buff,
     T* work_buff
 ) {
     ExplicitSymLinOp<T> A_linop(m, uplo, A, lda, Layout::ColMajor);

--- a/RandLAPACK/comps/rl_syrf.hh
+++ b/RandLAPACK/comps/rl_syrf.hh
@@ -25,8 +25,8 @@ class SymmetricRangeFinder {
         virtual int call(
             SymmetricLinearOperator<T> &A,
             int64_t k,
-            std::vector<T>& Q,
-            RandBLAS::RNGState<RNG>& state,
+            std::vector<T> &Q,
+            RandBLAS::RNGState<RNG> &state,
             T* work_buff
         ) = 0;
 
@@ -35,7 +35,7 @@ class SymmetricRangeFinder {
             int64_t m,
             const T* A,
             int64_t k,
-            std::vector<T>& Q,
+            std::vector<T> &Q,
             RandBLAS::RNGState<RNG> &state,
             T* work_buff
         ) = 0;
@@ -46,8 +46,8 @@ class SYRF : public SymmetricRangeFinder<T, RNG> {
     public:
 
         SYRF(
-            RandLAPACK::SymmetricPowerSketch<T, RNG>& syps_obj,
-            RandLAPACK::Stabilization<T>& orth_obj,
+            RandLAPACK::SymmetricPowerSketch<T, RNG> &syps_obj,
+            RandLAPACK::Stabilization<T> &orth_obj,
             bool verb = false,
             bool cond = false
         ) : SYPS_Obj(syps_obj), Orth_Obj(orth_obj) {
@@ -89,7 +89,7 @@ class SYRF : public SymmetricRangeFinder<T, RNG> {
             int64_t m,
             const T* A,
             int64_t k,
-            std::vector<T>& Q,
+            std::vector<T> &Q,
             RandBLAS::RNGState<RNG> &state,
             T* work_buff
         ) override;
@@ -97,7 +97,7 @@ class SYRF : public SymmetricRangeFinder<T, RNG> {
         int call(
             SymmetricLinearOperator<T> &A,
             int64_t k,
-            std::vector<T>& Q,
+            std::vector<T> &Q,
             RandBLAS::RNGState<RNG> &state,
             T* work_buff
         ) override;
@@ -105,8 +105,8 @@ class SYRF : public SymmetricRangeFinder<T, RNG> {
 
     public:
        // Instantiated in the constructor
-       RandLAPACK::SymmetricPowerSketch<T, RNG>& SYPS_Obj;
-       RandLAPACK::Stabilization<T>& Orth_Obj;
+       RandLAPACK::SymmetricPowerSketch<T, RNG> &SYPS_Obj;
+       RandLAPACK::Stabilization<T> &Orth_Obj;
        bool verbose;
        bool cond_check;
        std::vector<T> cond_work_mat;
@@ -119,8 +119,8 @@ template <typename T, typename RNG>
 int SYRF<T, RNG>::call(
     SymmetricLinearOperator<T> &A,
     int64_t k,
-    std::vector<T>& Q,
-    RandBLAS::RNGState<RNG>& state,
+    std::vector<T> &Q,
+    RandBLAS::RNGState<RNG> &state,
     T* work_buff
 ) {
     int64_t m = A.m;
@@ -158,7 +158,7 @@ int SYRF<T, RNG>::call(
     int64_t m,
     const T* A,
     int64_t k,
-    std::vector<T>& Q,
+    std::vector<T> &Q,
     RandBLAS::RNGState<RNG> &state,
     T* work_buff
 ) {

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -25,10 +25,10 @@ class CQRRPTalg {
         virtual int call(
             int64_t m,
             int64_t n,
-            std::vector<T>& A,
+            std::vector<T> &A,
             int64_t d,
-            std::vector<T>& R,
-            std::vector<int64_t>& J
+            std::vector<T> &R,
+            std::vector<int64_t> &J
         ) = 0;
 };
 
@@ -112,10 +112,10 @@ class CQRRPT : public CQRRPTalg<T> {
         int call(
             int64_t m,
             int64_t n,
-            std::vector<T>& A,
+            std::vector<T> &A,
             int64_t d,
-            std::vector<T>& R,
-            std::vector<int64_t>& J
+            std::vector<T> &R,
+            std::vector<int64_t> &J
         ) override;
 
     public:
@@ -159,10 +159,10 @@ template <typename T, typename RNG>
 int CQRRPT<T, RNG>::call(
     int64_t m,
     int64_t n,
-    std::vector<T>& A,
+    std::vector<T> &A,
     int64_t d,
-    std::vector<T>& R,
-    std::vector<int64_t>& J
+    std::vector<T> &R,
+    std::vector<int64_t> &J
 ){
     //-------TIMING VARS--------/
     high_resolution_clock::time_point saso_t_stop;

--- a/RandLAPACK/drivers/rl_hqrrp.hh
+++ b/RandLAPACK/drivers/rl_hqrrp.hh
@@ -605,7 +605,7 @@ template <typename T, typename RNG>
 int64_t hqrrp( 
     int64_t m_A, int64_t n_A, T * buff_A, int64_t ldim_A,
     int64_t * buff_jpvt, T * buff_tau,
-    int64_t nb_alg, int64_t pp, int64_t panel_pivoting, RandBLAS::RNGState<RNG>& state) {
+    int64_t nb_alg, int64_t pp, int64_t panel_pivoting, RandBLAS::RNGState<RNG> &state) {
 
     int64_t b, j, last_iter, mn_A, m_Y, n_Y, ldim_Y, m_V, n_V, ldim_V, 
             m_W, n_W, ldim_W, n_VR, m_AB1, n_AB1, ldim_T1_T,

--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -24,20 +24,20 @@ class REVD2alg {
             Uplo uplo,
             int64_t m,
             const T* A,
-            int64_t& k,
+            int64_t &k,
             T tol,
-            std::vector<T>& V,
-            std::vector<T>& eigvals,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &V,
+            std::vector<T> &eigvals,
+            RandBLAS::RNGState<RNG> &state
         ) = 0;
 
         virtual int call(
             SymmetricLinearOperator<T> &A,
-            int64_t& k,
+            int64_t &k,
             T tol,
-            std::vector<T>& V,
-            std::vector<T>& eigvals,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &V,
+            std::vector<T> &eigvals,
+            RandBLAS::RNGState<RNG> &state
         ) = 0;
 };
 
@@ -47,7 +47,7 @@ class REVD2 : public REVD2alg<T, RNG> {
 
         // Constructor
         REVD2(
-            RandLAPACK::SymmetricRangeFinder<T, RNG>& syrf_obj,
+            RandLAPACK::SymmetricRangeFinder<T, RNG> &syrf_obj,
             int error_est_power_iters,
             bool verb = false
         ) : SYRF_Obj(syrf_obj) {
@@ -91,24 +91,24 @@ class REVD2 : public REVD2alg<T, RNG> {
             Uplo uplo,
             int64_t m,
             const T* A,
-            int64_t& k,
+            int64_t &k,
             T tol,
-            std::vector<T>& V,
-            std::vector<T>& eigvals,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &V,
+            std::vector<T> &eigvals,
+            RandBLAS::RNGState<RNG> &state
         ) override;
 
         int call(
             SymmetricLinearOperator<T> &A,
-            int64_t& k,
+            int64_t &k,
             T tol,
-            std::vector<T>& V,
-            std::vector<T>& eigvals,
+            std::vector<T> &V,
+            std::vector<T> &eigvals,
             RandBLAS::RNGState<RNG> &state
         ) override;
 
     public:
-        RandLAPACK::SymmetricRangeFinder<T, RNG>& SYRF_Obj;
+        RandLAPACK::SymmetricRangeFinder<T, RNG> &SYRF_Obj;
         int error_est_p;
         bool verbose;
 
@@ -178,11 +178,11 @@ T power_error_est(
 template <typename T, typename RNG>
 int REVD2<T, RNG>::call(
         SymmetricLinearOperator<T> &A,
-        int64_t& k,
+        int64_t &k,
         T tol,
-        std::vector<T>& V,
-        std::vector<T>& eigvals,
-        RandBLAS::RNGState<RNG>& state
+        std::vector<T> &V,
+        std::vector<T> &eigvals,
+        RandBLAS::RNGState<RNG> &state
 ) {
     int64_t m = A.m;
     T err = 0;
@@ -274,10 +274,10 @@ int REVD2<T, RNG>::call(
         Uplo uplo,
         int64_t m,
         const T* A,
-        int64_t& k,
+        int64_t &k,
         T tol,
-        std::vector<T>& V,
-        std::vector<T>& eigvals,
+        std::vector<T> &V,
+        std::vector<T> &eigvals,
         RandBLAS::RNGState<RNG> &state
 ) {
     ExplicitSymLinOp<T> A_linop(m, uplo, A, m, Layout::ColMajor);

--- a/RandLAPACK/drivers/rl_rsvd.hh
+++ b/RandLAPACK/drivers/rl_rsvd.hh
@@ -21,13 +21,13 @@ class RSVDalg {
         virtual int call(
             int64_t m,
             int64_t n,
-            std::vector<T>& A,
-            int64_t& k,
+            std::vector<T> &A,
+            int64_t &k,
             T tol,
-            std::vector<T>& U,
-            std::vector<T>& S,
-            std::vector<T>& VT,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &U,
+            std::vector<T> &S,
+            std::vector<T> &VT,
+            RandBLAS::RNGState<RNG> &state
         ) = 0;
 };
 
@@ -38,7 +38,7 @@ class RSVD : public RSVDalg<T, RNG> {
         // Constructor
         RSVD(
             // Requires a QB algorithm object.
-            RandLAPACK::QBalg<T, RNG>& qb_obj,
+            RandLAPACK::QBalg<T, RNG> &qb_obj,
             bool verb,
             int64_t b_sz
         ) : QB_Obj(qb_obj) {
@@ -97,17 +97,17 @@ class RSVD : public RSVDalg<T, RNG> {
         int call(
             int64_t m,
             int64_t n,
-            std::vector<T>& A,
-            int64_t& k,
+            std::vector<T> &A,
+            int64_t &k,
             T tol,
-            std::vector<T>& U,
-            std::vector<T>& S,
-            std::vector<T>& VT,
-            RandBLAS::RNGState<RNG>& state
+            std::vector<T> &U,
+            std::vector<T> &S,
+            std::vector<T> &VT,
+            RandBLAS::RNGState<RNG> &state
         ) override;
 
     public:
-        RandLAPACK::QBalg<T, RNG>& QB_Obj;
+        RandLAPACK::QBalg<T, RNG> &QB_Obj;
         bool verbosity;
         int64_t block_sz;
 
@@ -121,13 +121,13 @@ template <typename T, typename RNG>
 int RSVD<T, RNG>::call(
     int64_t m,
     int64_t n,
-    std::vector<T>& A,
-    int64_t& k,
+    std::vector<T> &A,
+    int64_t &k,
     T tol,
-    std::vector<T>& U,
-    std::vector<T>& S,
-    std::vector<T>& VT,
-    RandBLAS::RNGState<RNG>& state
+    std::vector<T> &U,
+    std::vector<T> &S,
+    std::vector<T> &VT,
+    RandBLAS::RNGState<RNG> &state
 ){
     // Q and B sizes will be adjusted automatically
     this->QB_Obj.call(m, n, A, k, this->block_sz, tol, this->Q, this->B, state);

--- a/RandLAPACK/misc/rl_gen.hh
+++ b/RandLAPACK/misc/rl_gen.hh
@@ -58,10 +58,10 @@ template <typename T, typename RNG>
 void gen_singvec(
     int64_t m,
     int64_t n,
-    std::vector<T>& A,
+    std::vector<T> &A,
     int64_t k,
-    std::vector<T>& S,
-    RandBLAS::RNGState<RNG>& state
+    std::vector<T> &S,
+    RandBLAS::RNGState<RNG> &state
 ) {
     std::vector<T> U(m * k, 0.0);
     std::vector<T> V(n * k, 0.0);
@@ -100,14 +100,14 @@ void gen_singvec(
 /// The output matrix has k singular values. 
 template <typename T, typename RNG>
 void gen_poly_mat(
-    int64_t& m,
-    int64_t& n,
-    std::vector<T>& A,
+    int64_t &m,
+    int64_t &n,
+    std::vector<T> &A,
     int64_t k,
     T cond,
     T p,
     bool diagon,
-    RandBLAS::RNGState<RNG>& state
+    RandBLAS::RNGState<RNG> &state
 ) {
 
     // Predeclare to all nonzero constants, start decay where needed
@@ -123,7 +123,7 @@ void gen_poly_mat(
     // apply lambda function to every entry of s
     std::for_each(s.begin() + offset, s.end(),
         // Lambda expression begins
-        [&p, &offset, &a, &b](T& entry) {
+        [&p, &offset, &a, &b](T &entry) {
                 entry = 1 / (a * std::pow(offset + b, p));
                 ++offset;
         }
@@ -151,13 +151,13 @@ void gen_poly_mat(
 /// The output matrix has k singular values. 
 template <typename T, typename RNG>
 void gen_exp_mat(
-    int64_t& m,
-    int64_t& n,
-    std::vector<T>& A,
+    int64_t &m,
+    int64_t &n,
+    std::vector<T> &A,
     int64_t k,
     T cond,
     bool diagon,
-    RandBLAS::RNGState<RNG>& state
+    RandBLAS::RNGState<RNG> &state
 ) {
 
     std::vector<T> s(k, 1.0);
@@ -173,7 +173,7 @@ void gen_exp_mat(
     // Please make sure that the first singular value is always 1
     std::for_each(s.begin() + offset, s.end(),
         // Lambda expression begins
-        [&t, &cnt](T& entry) {
+        [&t, &cnt](T &entry) {
                 entry = (std::exp(++cnt * -t));
         }
     );
@@ -199,13 +199,13 @@ void gen_exp_mat(
 /// Parameter 'cond' signfies the condition number of a generated matrix.
 template <typename T, typename RNG>
 void gen_step_mat(
-    int64_t& m,
-    int64_t& n,
-    std::vector<T>& A,
+    int64_t &m,
+    int64_t &n,
+    std::vector<T> &A,
     int64_t k,
     T cond,
     bool diagon,
-    RandBLAS::RNGState<RNG>& state
+    RandBLAS::RNGState<RNG> &state
 ) {
 
     // Predeclare to all nonzero constants, start decay where needed
@@ -241,11 +241,11 @@ void gen_step_mat(
 /// Right singular vectors are sampled uniformly at random.
 template <typename T, typename RNG>
 void gen_spiked_mat(
-    int64_t& m,
-    int64_t& n,
-    std::vector<T>& A,
+    int64_t &m,
+    int64_t &n,
+    std::vector<T> &A,
     T spike_scale,
-    RandBLAS::RNGState<RNG>& state
+    RandBLAS::RNGState<RNG> &state
 ) {
     int64_t num_rows_sampled = n / 2;
 
@@ -291,11 +291,11 @@ void gen_spiked_mat(
 /// orthonormalized Gaussian matrix with modified diagonal entries to diag(V) *= [1, 10^-15, . . . , 10^-15, 10^-15].
 template <typename T, typename RNG>
 void gen_oleg_adversarial_mat(
-    int64_t& m,
-    int64_t& n,
-    std::vector<T>& A,
+    int64_t &m,
+    int64_t &n,
+    std::vector<T> &A,
     T sigma,
-    RandBLAS::RNGState<RNG>& state
+    RandBLAS::RNGState<RNG> &state
 ) {
 
     T scaling_factor_U = sigma;
@@ -344,13 +344,13 @@ void gen_oleg_adversarial_mat(
 /// Parameter 'cond' signfies the condition number of a generated matrix.
 template <typename T, typename RNG>
 void gen_bad_cholqr_mat(
-    int64_t& m,
-    int64_t& n,
-    std::vector<T>& A,
+    int64_t &m,
+    int64_t &n,
+    std::vector<T> &A,
     int64_t k,
     T cond,
     bool diagon,
-    RandBLAS::RNGState<RNG>& state
+    RandBLAS::RNGState<RNG> &state
 ) {
 
     std::vector<T> s(n, 1.0);
@@ -367,7 +367,7 @@ void gen_bad_cholqr_mat(
     // Please make sure that the first singular value is always 1
     std::for_each(s.begin() + offset, s.end(),
         // Lambda expression begins
-        [&t, &cnt](T& entry) {
+        [&t, &cnt](T &entry) {
                 entry = (std::exp(t) / std::pow(10, 8)) * (std::exp(++cnt * -t));
         }
     );
@@ -391,8 +391,8 @@ void gen_bad_cholqr_mat(
 template <typename T, typename RNG>
 void mat_gen(
     mat_gen_info<T> info,
-    std::vector<T>& A,
-    RandBLAS::RNGState<RNG>& state
+    std::vector<T> &A,
+    RandBLAS::RNGState<RNG> &state
 ) {
     // Base parameters
     int64_t m = info.rows;

--- a/RandLAPACK/misc/rl_util.hh
+++ b/RandLAPACK/misc/rl_util.hh
@@ -42,9 +42,9 @@ template <typename T>
 void diag(
     int64_t m,
     int64_t n,
-    const std::vector<T>& s,
+    const std::vector<T> &s,
     int64_t k, // size of s, < min(m, n)
-    std::vector<T>& S // Assuming S is m by n
+    std::vector<T> &S // Assuming S is m by n
 ) {
 
     if(k > std::min(m, n)) 
@@ -59,8 +59,8 @@ void extract_diag(
     int64_t m,
     int64_t n,
     int64_t k,
-    const std::vector<T>& A,
-    std::vector<T>& buf
+    const std::vector<T> &A,
+    std::vector<T> &buf
 ) {
     if(k > std::min(m, n)) 
         throw std::runtime_error("Incorrect rank parameter.");
@@ -100,8 +100,8 @@ template <typename T>
 void get_U(
     int64_t m,
     int64_t n,
-    const std::vector<T>& A,
-    std::vector<T>& U // We are assuming U is n by n
+    const std::vector<T> &A,
+    std::vector<T> &U // We are assuming U is n by n
 ) {
     // Vector end pointer
     int size = m * n;
@@ -119,7 +119,7 @@ template <typename T>
 void get_U(
     int64_t m,
     int64_t n,
-    std::vector<T>& A
+    std::vector<T> &A
 ) {
     T* A_dat = A.data();
     for(int i = 0; i < n - 1; ++i) {
@@ -134,7 +134,7 @@ void col_swap(
     int64_t m,
     int64_t n,
     int64_t k,
-    std::vector<T>& A,
+    std::vector<T> &A,
     std::vector<int64_t> idx
 ) {
 
@@ -167,7 +167,7 @@ void col_swap(
 template <typename T>
 T* upsize(
     int64_t target_sz,
-    std::vector<T>& A
+    std::vector<T> &A
 ) {
     if ((int64_t) A.size() < target_sz)
         A.resize(target_sz, 0);
@@ -181,7 +181,7 @@ template <typename T>
 T* row_resize(
     int64_t m,
     int64_t n,
-    std::vector<T>& A,
+    std::vector<T> &A,
     int64_t k
 ) {
 
@@ -216,9 +216,9 @@ template <typename T>
 T cond_num_check(
     int64_t m,
     int64_t n,
-    const std::vector<T>& A,
-    std::vector<T>& A_cpy,
-    std::vector<T>& s,
+    const std::vector<T> &A,
+    std::vector<T> &A_cpy,
+    std::vector<T> &s,
     bool verbose
 ) {
 
@@ -248,7 +248,7 @@ template <typename T>
 int64_t rank_check(
     int64_t m,
     int64_t n,
-    const std::vector<T>& A
+    const std::vector<T> &A
 ) {
     std::vector<T> A_pre_cpy;
     std::vector<T> s;
@@ -267,8 +267,8 @@ bool orthogonality_check(
     int64_t m,
     int64_t n,
     int64_t k,
-    const std::vector<T>& A,
-    std::vector<T>& A_gram,
+    const std::vector<T> &A,
+    std::vector<T> &A_gram,
     bool verbose
 ) {
 
@@ -365,8 +365,8 @@ template <typename T>
 void normc(
     int64_t m,
     int64_t n,
-    const std::vector<T>& A,
-    std::vector<T>& A_norm
+    const std::vector<T> &A,
+    std::vector<T> &A_norm
 ) {
     util::upsize(m * n, A_norm);
 

--- a/test/comps/test_orth.cc
+++ b/test/comps/test_orth.cc
@@ -50,7 +50,7 @@ class TestOrth : public ::testing::Test
     template <typename T, typename RNG>
     static void sketch_and_copy_computational_helper(
         RandBLAS::RNGState<RNG> state,
-        OrthTestData<T>& all_data
+        OrthTestData<T> &all_data
     ) {
 
         auto m = all_data.row;
@@ -72,8 +72,8 @@ class TestOrth : public ::testing::Test
     /// Checks I - \transpose{Q}Q.
     template <typename T, typename RNG>
     static void test_orth_sketch(
-        OrthTestData<T>& all_data, 
-        RandLAPACK::CholQRQ<T>& CholQRQ
+        OrthTestData<T> &all_data, 
+        RandLAPACK::CholQRQ<T> &CholQRQ
     ) {
 
         auto m = all_data.row;

--- a/test/comps/test_qb.cc
+++ b/test/comps/test_qb.cc
@@ -80,7 +80,7 @@ class TestQB : public ::testing::Test
     };
 
     template <typename T>
-    static void svd_and_copy_computational_helper(QBTestData<T>& all_data) {
+    static void svd_and_copy_computational_helper(QBTestData<T> &all_data) {
         
         auto m = all_data.row;
         auto n = all_data.col;
@@ -104,9 +104,9 @@ class TestQB : public ::testing::Test
     static void test_QB2_low_exact_rank(
         int64_t block_sz, 
         T tol,  
-        QBTestData<T>& all_data,
-        alg_type& all_algs,
-        RandBLAS::RNGState<RNG>& state) {
+        QBTestData<T> &all_data,
+        alg_type &all_algs,
+        RandBLAS::RNGState<RNG> &state) {
 
         auto m = all_data.row;
         auto n = all_data.col;
@@ -183,10 +183,10 @@ class TestQB : public ::testing::Test
     static void test_QB2_k_eq_min(
         int64_t block_sz, 
         T tol, 
-        T& norm_A, 
-        QBTestData<T>& all_data,
-        algorithm_objects<T, RNG>& all_algs,
-        RandBLAS::RNGState<RNG>& state) {
+        T &norm_A, 
+        QBTestData<T> &all_data,
+        algorithm_objects<T, RNG> &all_algs,
+        RandBLAS::RNGState<RNG> &state) {
 
         auto m = all_data.row;
         auto n = all_data.col;

--- a/test/comps/test_rf.cc
+++ b/test/comps/test_rf.cc
@@ -65,7 +65,7 @@ class TestRF : public ::testing::Test
     };
 
     template <typename T, typename RNG>
-    static void orth_and_copy_computational_helper(RFTestData<T>& all_data) {
+    static void orth_and_copy_computational_helper(RFTestData<T> &all_data) {
         
         auto m = all_data.row;
         auto n = all_data.col;
@@ -86,9 +86,9 @@ class TestRF : public ::testing::Test
     /// 4. A_k - QB = U_k\Sigma_k\transpose{V_k} - QB
     template <typename T, typename RNG, typename alg_type>
     static void test_RF_general(
-        RFTestData<T>& all_data, 
-        alg_type& all_algs,
-        RandBLAS::RNGState<RNG>& state) {
+        RFTestData<T> &all_data, 
+        alg_type &all_algs,
+        RandBLAS::RNGState<RNG> &state) {
 
         auto m = all_data.row;
         auto n = all_data.col;

--- a/test/comps/test_syrf.cc
+++ b/test/comps/test_syrf.cc
@@ -62,7 +62,7 @@ class TestSYRF : public ::testing::Test
     };
 
     template <typename T, typename RNG>
-    static void orth_and_copy_computational_helper(SYRFTestData<T>& all_data) {
+    static void orth_and_copy_computational_helper(SYRFTestData<T> &all_data) {
         
         auto m = all_data.row;
 
@@ -89,8 +89,8 @@ class TestSYRF : public ::testing::Test
     template <typename T, typename RNG>
     static void test_SYRF_general(
         RandBLAS::RNGState<RNG> state,
-        SYRFTestData<T>& all_data, 
-        algorithm_objects<T, RNG>& all_algs) {
+        SYRFTestData<T> &all_data, 
+        algorithm_objects<T, RNG> &all_algs) {
 
         auto m = all_data.row;
         auto k = all_data.rank;

--- a/test/comps/test_util.cc
+++ b/test/comps/test_util.cc
@@ -62,7 +62,7 @@ class TestUtil : public ::testing::Test
 
     template <typename T, typename RNG>
     static void 
-    test_spectral_norm(RandBLAS::RNGState<RNG> state, SpectralTestData<T>& all_data) {
+    test_spectral_norm(RandBLAS::RNGState<RNG> state, SpectralTestData<T> &all_data) {
 
         auto m = all_data.row;
         auto n = all_data.col;
@@ -77,7 +77,7 @@ class TestUtil : public ::testing::Test
 
     template <typename T>
     static void 
-    test_normc(NormcTestData<T>& all_data) {
+    test_normc(NormcTestData<T> &all_data) {
         
         auto m = all_data.row;
 
@@ -96,7 +96,7 @@ class TestUtil : public ::testing::Test
 
     template <typename T>
     static void 
-    test_binary_rank_search_zero_mat(int64_t m, int64_t n, std::vector<T>& A) {
+    test_binary_rank_search_zero_mat(int64_t m, int64_t n, std::vector<T> &A) {
         
         int64_t k = RandLAPACK::util::rank_search_binary(0, m, 0, n, 0.0, std::pow(std::numeric_limits<T>::epsilon(), 0.75), A.data());
 

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -42,7 +42,7 @@ class TestCQRRPT : public ::testing::Test
     };
 
     template <typename T, typename RNG>
-    static void norm_and_copy_computational_helper(T& norm_A, CQRRPTTestData<T>& all_data) {
+    static void norm_and_copy_computational_helper(T &norm_A, CQRRPTTestData<T> &all_data) {
         auto m = all_data.row;
         auto n = all_data.col;
 
@@ -55,7 +55,7 @@ class TestCQRRPT : public ::testing::Test
     /// This routine also appears in benchmarks, but idk if it should be put into utils
     template <typename T>
     static void
-    error_check(T& norm_A, CQRRPTTestData<T>& all_data) {
+    error_check(T &norm_A, CQRRPTTestData<T> &all_data) {
 
         auto m = all_data.row;
         auto n = all_data.col;
@@ -108,8 +108,8 @@ class TestCQRRPT : public ::testing::Test
     static void test_CQRRPT_general(
         int64_t d, 
         T norm_A,
-        CQRRPTTestData<T>& all_data,
-        RandLAPACK::CQRRPT<T, RNG>& CQRRPT) {
+        CQRRPTTestData<T> &all_data,
+        RandLAPACK::CQRRPT<T, RNG> &CQRRPT) {
 
         auto m = all_data.row;
         auto n = all_data.col;

--- a/test/drivers/test_revd2.cc
+++ b/test/drivers/test_revd2.cc
@@ -98,7 +98,7 @@ class TestREVD2 : public ::testing::Test
     };
 
     template <typename T, typename RNG>
-    static void symm_mat_and_copy_computational_helper(T& norm_A, REVD2TestData<T>& all_data) {
+    static void symm_mat_and_copy_computational_helper(T &norm_A, REVD2TestData<T> &all_data) {
         auto m = all_data.dim;
         // We're using Nystrom, the original must be positive semidefinite
         blas::syrk(
@@ -114,7 +114,7 @@ class TestREVD2 : public ::testing::Test
     }
 
     template <typename T, typename RNG>
-    static void uplo_computational_helper(REVD2UploTestData<T>& all_data) {
+    static void uplo_computational_helper(REVD2UploTestData<T> &all_data) {
         auto m = all_data.dim;
         T* A_u_dat = all_data.A_u.data();
         T* A_l_dat = all_data.A_l.data();
@@ -141,9 +141,9 @@ class TestREVD2 : public ::testing::Test
         T tol,
         int rank_expectation, 
         T err_expectation, 
-        T& norm_A, 
-        REVD2TestData<T>& all_data,
-        algorithm_objects<T, RNG>& all_algs,
+        T &norm_A, 
+        REVD2TestData<T> &all_data,
+        algorithm_objects<T, RNG> &all_algs,
         RandBLAS::RNGState<RNG> state
     ) {
         
@@ -180,8 +180,8 @@ class TestREVD2 : public ::testing::Test
         int64_t k_start, 
         T tol,
         T err_expectation, 
-        REVD2UploTestData<T>& all_data,
-        algorithm_objects<T, RNG>& all_algs,
+        REVD2UploTestData<T> &all_data,
+        algorithm_objects<T, RNG> &all_algs,
         RandBLAS::RNGState<RNG> state
     ) {
         

--- a/test/drivers/test_rsvd.cc
+++ b/test/drivers/test_rsvd.cc
@@ -93,7 +93,7 @@ class TestRSVD : public ::testing::Test
     };
 
     template <typename T>
-    static void computational_helper(RSVDTestData<T>& all_data) {
+    static void computational_helper(RSVDTestData<T> &all_data) {
 
         auto m = all_data.row;
         auto n = all_data.col;
@@ -109,9 +109,9 @@ class TestRSVD : public ::testing::Test
     template <typename T, typename RNG>
     static void test_RSVD1_general(
         T tol, 
-        RSVDTestData<T>& all_data,
-        algorithm_objects<T, RNG>& all_algs,
-        RandBLAS::RNGState<RNG>& state) {
+        RSVDTestData<T> &all_data,
+        algorithm_objects<T, RNG> &all_algs,
+        RandBLAS::RNGState<RNG> &state) {
 
         auto m = all_data.row;
         auto n = all_data.col;


### PR DESCRIPTION
Resolves #54. We now use the format ``T &var``, with a single space between the type and the ampersand and no space between the ampersand and variable name.