### PR TITLE
Replace class-inheritance-based APIs for symmetric matrix algorithms with abstract templating APIs

### DIFF
--- a/RandLAPACK/comps/rl_determiter.hh
+++ b/RandLAPACK/comps/rl_determiter.hh
@@ -368,7 +368,7 @@ int64_t posm_square(
  *      A boolean. If true, then logging information is printed to stdout.
  * 
  */
-template <typename T, linops::SymmetricLinearOperator FG, typename FSeminorm, typename FN>
+template <typename T, typename FG, typename FSeminorm, typename FN>
 void pcg(
     FG &G,
     const T* H,
@@ -510,7 +510,7 @@ void pcg(
  *       
  * The main purpose of this wrapper is backward-compatibility with existing code.
  */
-template <typename T, linops::SymmetricLinearOperator FG, typename FN, typename FSeminorm = StatefulFrobeniusNorm<T>>
+template <typename T, typename FG, typename FN, typename FSeminorm = StatefulFrobeniusNorm<T>>
 FSeminorm pcg(
     FG &G,
     const std::vector<T> &H,

--- a/RandLAPACK/comps/rl_determiter.hh
+++ b/RandLAPACK/comps/rl_determiter.hh
@@ -290,7 +290,7 @@ int64_t posm_square(
  *  G_i * x_i = h_i for i in {1, ..., s}        (Eq. 1)
  *
  * with preconditioners N_1, ..., N_s. The linear systems all have the same number 
- * of variables, m, so X = [x_1,..., x_s] and H = [h_1, ..., h_s] are passed as m-by-s matrices. 
+ * of variables, dim, so X = [x_1,..., x_s] and H = [h_1, ..., h_s] are passed as dim-by-s matrices. 
  * 
  * Arguments "G" and "N" act as operator-overloaded containers for the G_i and N_i.
  * We template these arguments abstractly. See below for details.
@@ -308,11 +308,11 @@ int64_t posm_square(
  *                  If G.num_ops >  1, then we assume each G_i is distinct, and 
  *                  we require that G.num_ops == s.
  *
- *              G.m = the number of rows and columns in each G_i.
+ *              G.dim = the number of rows and columns in each G_i.
  *
  *              G(blas::Layout::ColMajor, s, alpha, B, ldb, beta, C, ldc) updates
  *                  c_i := alpha G_i * b_i + beta c_i
- *              where C = [c_1, ..., c_s] and B = [b_1, ..., b_s] are m-by-s matrices stored
+ *              where C = [c_1, ..., c_s] and B = [b_1, ..., b_s] are dim-by-s matrices stored
  *              in column-major order with strides ldc and ldb, respectively.
  * 
  *      If G.num_ops == 1 then we solve (Eq. 1) using block PCG with block size s. If G.num_ops > 1
@@ -324,15 +324,15 @@ int64_t posm_square(
  *      (G_1,...,G_s) with one matrix-matrix multiply (against A) followed by cheap postprocessing. 
  * 
  * @param[in] H
- *      Pointer to a column-major matrix of shape (G.m, s) with stride parameter G.m.
+ *      Pointer to a column-major matrix of shape (G.dim, s) with stride parameter G.dim.
  *      Defines the right-hand sides in (Eq. 1).
  * 
  * @param[in] s
  *      The number of linear systems to be solved.
  *
  * @param[in,out] seminorm
- *      Callable as val = seminorm(m, s, R), where R is a pointer to an array of type T
- *      read as a column-major matrix of shape (m, s) with stride equal to m. One valid
+ *      Callable as val = seminorm(dim, s, R), where R is a pointer to an array of type T
+ *      read as a column-major matrix of shape (dim, s) with stride equal to dim. One valid
  *      implementation is 
  *
  *          auto seminorm = [](int64_t rows, int64_t cols, T* R) {
@@ -360,7 +360,7 @@ int64_t posm_square(
  *     Each N_i should be an approximate inverse for G_i.
  *
   * @param[in,out] X
- *      Pointer to a column-major matrix of shape (G.m, s) with stride parameter G.m.
+ *      Pointer to a column-major matrix of shape (G.dim, s) with stride parameter G.dim.
  *      The values of its columns on entry are used to initialize PCG solves of (Eq. 1).
  *      The values of its columns on exit contain the results of the PCG solves.
  *
@@ -368,7 +368,7 @@ int64_t posm_square(
  *      A boolean. If true, then logging information is printed to stdout.
  * 
  */
-template <typename T, typename FG, typename FSeminorm, typename FN>
+template <typename T, linops::SymmetricLinearOperator FG, typename FSeminorm, typename FN>
 void pcg(
     FG &G,
     const T* H,
@@ -380,8 +380,7 @@ void pcg(
     T* X,
     bool verbose
 ) {
-    int64_t n = G.m;
-    randblas_require(n == N.m);
+    int64_t n = G.dim;
     int64_t ns = n*s;
     int64_t ss = s*s;
     bool treat_as_separable = G.num_ops > 1;
@@ -511,7 +510,7 @@ void pcg(
  *       
  * The main purpose of this wrapper is backward-compatibility with existing code.
  */
-template <typename T, typename FG, typename FN, typename FSeminorm = StatefulFrobeniusNorm<T>>
+template <typename T, linops::SymmetricLinearOperator FG, typename FN, typename FSeminorm = StatefulFrobeniusNorm<T>>
 FSeminorm pcg(
     FG &G,
     const std::vector<T> &H,
@@ -522,7 +521,7 @@ FSeminorm pcg(
     bool verbose
 ) {
     FSeminorm seminorm{};
-    int64_t s = ((int64_t) H.size()) / G.m;
+    int64_t s = ((int64_t) H.size()) / G.dim;
     pcg(G, H.data(), s, seminorm, tol, max_iters, N, X.data(), verbose);
     return seminorm;
 }

--- a/RandLAPACK/comps/rl_preconditioners.hh
+++ b/RandLAPACK/comps/rl_preconditioners.hh
@@ -288,20 +288,23 @@ RandBLAS::RNGState<RNG> nystrom_pc_data(
     int64_t num_syps_passes = 3,
     int64_t num_steps_power_iter_error_est = 10
 ) {
-    RandLAPACK::SYPS<T, RNG> SYPS(num_syps_passes, 1, false, false);
+    using SYPS_t = RandLAPACK::SYPS<T, RNG>;
+    using Orth_t = RandLAPACK::HQRQ<T>;
+    using SYRF_t = RandLAPACK::SYRF<SYPS_t, Orth_t>;
+    SYPS_t SYPS(num_syps_passes, 1, false, false);
     // ^ Define a symmetric power sketch algorithm.
     //      (*) Stabilize power iteration with pivoted-LU after every
     //          mulitplication with A.
     //      (*) Do not check condition numbers or log to std::out.
-    RandLAPACK::HQRQ<T> Orth(false, false); 
+    Orth_t Orth(false, false); 
     // ^ Define an orthogonalizer for a symmetric rangefinder.
     //      (*) Get a dense representation of Q from Householder QR.
     //      (*) Do not check condition numbers or log to std::out.
-    RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>> SYRF(SYPS, Orth, false, false);
+    SYRF_t SYRF(SYPS, Orth, false, false);
     // ^ Define the symmetric rangefinder algorithm.
     //      (*) Use power sketching followed by Householder orthogonalization.
     //      (*) Do not check condition numbers or log to std::out.
-    RandLAPACK::REVD2<RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>>> NystromAlg(SYRF, num_steps_power_iter_error_est, false);
+    RandLAPACK::REVD2<SYRF_t> NystromAlg(SYRF, num_steps_power_iter_error_est, false);
     // ^ Define the algorithm for low-rank approximation via Nystrom.
     //      (*) Handle accuracy requests by estimating ||A - V diag(eigvals) V'||
     //          with "num_steps_power_iter_error_est" steps of power iteration.

--- a/RandLAPACK/comps/rl_preconditioners.hh
+++ b/RandLAPACK/comps/rl_preconditioners.hh
@@ -296,7 +296,7 @@ RandBLAS::RNGState<RNG> nystrom_pc_data(
     // ^ Define an orthogonalizer for a symmetric rangefinder.
     //      (*) Get a dense representation of Q from Householder QR.
     //      (*) Do not check condition numbers or log to std::out.
-    RandLAPACK::SYRF<T, RNG> SYRF(SYPS, Orth, false, false);
+    RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>, T, RNG> SYRF(SYPS, Orth, false, false);
     // ^ Define the symmetric rangefinder algorithm.
     //      (*) Use power sketching followed by Householder orthogonalization.
     //      (*) Do not check condition numbers or log to std::out.

--- a/RandLAPACK/comps/rl_preconditioners.hh
+++ b/RandLAPACK/comps/rl_preconditioners.hh
@@ -21,6 +21,7 @@
 
 namespace RandLAPACK {
 
+
 // Note: This function is not intended for end-users at this time.
 // We have it here to simplify unittests later on.
 template <typename T, typename SKOP>
@@ -296,11 +297,11 @@ RandBLAS::RNGState<RNG> nystrom_pc_data(
     // ^ Define an orthogonalizer for a symmetric rangefinder.
     //      (*) Get a dense representation of Q from Householder QR.
     //      (*) Do not check condition numbers or log to std::out.
-    RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>, T, RNG> SYRF(SYPS, Orth, false, false);
+    RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>> SYRF(SYPS, Orth, false, false);
     // ^ Define the symmetric rangefinder algorithm.
     //      (*) Use power sketching followed by Householder orthogonalization.
     //      (*) Do not check condition numbers or log to std::out.
-    RandLAPACK::REVD2<T, RNG> NystromAlg(SYRF, num_steps_power_iter_error_est, false);
+    RandLAPACK::REVD2<RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>>> NystromAlg(SYRF, num_steps_power_iter_error_est, false);
     // ^ Define the algorithm for low-rank approximation via Nystrom.
     //      (*) Handle accuracy requests by estimating ||A - V diag(eigvals) V'||
     //          with "num_steps_power_iter_error_est" steps of power iteration.

--- a/RandLAPACK/comps/rl_preconditioners.hh
+++ b/RandLAPACK/comps/rl_preconditioners.hh
@@ -276,9 +276,9 @@ int64_t make_right_orthogonalizer(
  *      An RNGState that the calling function should use the next
  *      time it needs an RNGState.
  */
-template <typename T, typename RNG>
+template <typename T, typename RNG, linops::SymmetricLinearOperator SLO>
 RandBLAS::RNGState<RNG> nystrom_pc_data(
-    linops::SymLinOp<T> &A,
+    SLO &A,
     std::vector<T> &V,
     std::vector<T> &eigvals,
     int64_t &k,

--- a/RandLAPACK/comps/rl_preconditioners.hh
+++ b/RandLAPACK/comps/rl_preconditioners.hh
@@ -244,7 +244,7 @@ int64_t make_right_orthogonalizer(
  * 
  * @param[in] A
  *      An object conforming to the SymmetricLinearOperator interface.
- *      It represents a matrix of order A.m. It is callable, and responsible
+ *      It represents a matrix of order A.dim. It is callable, and responsible
  *      for allocating any memory it might need when called.
  * @param[out] V
  *      A std::vector that gives a column-major representation of an m-by-k_out

--- a/RandLAPACK/comps/rl_preconditioners.hh
+++ b/RandLAPACK/comps/rl_preconditioners.hh
@@ -291,20 +291,20 @@ RandBLAS::RNGState<RNG> nystrom_pc_data(
     using SYPS_t = RandLAPACK::SYPS<T, RNG>;
     using Orth_t = RandLAPACK::HQRQ<T>;
     using SYRF_t = RandLAPACK::SYRF<SYPS_t, Orth_t>;
-    SYPS_t SYPS(num_syps_passes, 1, false, false);
+    SYPS_t syps(num_syps_passes, 1, false, false);
     // ^ Define a symmetric power sketch algorithm.
     //      (*) Stabilize power iteration with pivoted-LU after every
     //          mulitplication with A.
     //      (*) Do not check condition numbers or log to std::out.
-    Orth_t Orth(false, false); 
+    Orth_t orth(false, false); 
     // ^ Define an orthogonalizer for a symmetric rangefinder.
     //      (*) Get a dense representation of Q from Householder QR.
     //      (*) Do not check condition numbers or log to std::out.
-    SYRF_t SYRF(SYPS, Orth, false, false);
+    SYRF_t syrf(syps, orth, false, false);
     // ^ Define the symmetric rangefinder algorithm.
     //      (*) Use power sketching followed by Householder orthogonalization.
     //      (*) Do not check condition numbers or log to std::out.
-    RandLAPACK::REVD2<SYRF_t> NystromAlg(SYRF, num_steps_power_iter_error_est, false);
+    RandLAPACK::REVD2<SYRF_t> NystromAlg(syrf, num_steps_power_iter_error_est, false);
     // ^ Define the algorithm for low-rank approximation via Nystrom.
     //      (*) Handle accuracy requests by estimating ||A - V diag(eigvals) V'||
     //          with "num_steps_power_iter_error_est" steps of power iteration.

--- a/RandLAPACK/comps/rl_preconditioners.hh
+++ b/RandLAPACK/comps/rl_preconditioners.hh
@@ -278,7 +278,7 @@ int64_t make_right_orthogonalizer(
  */
 template <typename T, typename RNG>
 RandBLAS::RNGState<RNG> nystrom_pc_data(
-    linops::SymmetricLinearOperator<T> &A,
+    linops::SymLinOp<T> &A,
     std::vector<T> &V,
     std::vector<T> &eigvals,
     int64_t &k,

--- a/RandLAPACK/comps/rl_qb.hh
+++ b/RandLAPACK/comps/rl_qb.hh
@@ -45,7 +45,7 @@ class QB : public QBalg<T, RNG> {
             RandLAPACK::Stabilization<T> &orth_obj,
             bool verb,
             bool orth
-        ) : RF_Obj(rf_obj), orth(orth_obj) {
+        ) : rf(rf_obj), orth(orth_obj) {
             verbose = verb;
             orth_check = orth;
         }
@@ -123,7 +123,7 @@ class QB : public QBalg<T, RNG> {
         ) override;
 
     public:
-        RandLAPACK::RangeFinder<T, RNG> &RF_Obj;
+        RandLAPACK::RangeFinder<T, RNG> &rf;
         RandLAPACK::Stabilization<T> &orth;
         bool verbose;
         bool orth_check;
@@ -188,7 +188,7 @@ int QB<T, RNG>::call(
         BT_i = &BT[n * curr_sz];
 
         // Calling RangeFinder
-        if(this->RF_Obj.call(m, n, A_cpy, b_sz, Q_i, state)) {
+        if(this->rf.call(m, n, A_cpy, b_sz, Q_i, state)) {
             // RF failed
             k = curr_sz;
             free(A_cpy);

--- a/RandLAPACK/comps/rl_qb.hh
+++ b/RandLAPACK/comps/rl_qb.hh
@@ -45,7 +45,7 @@ class QB : public QBalg<T, RNG> {
             RandLAPACK::Stabilization<T> &orth_obj,
             bool verb,
             bool orth
-        ) : RF_Obj(rf_obj), Orth_Obj(orth_obj) {
+        ) : RF_Obj(rf_obj), orth(orth_obj) {
             verbose = verb;
             orth_check = orth;
         }
@@ -124,7 +124,7 @@ class QB : public QBalg<T, RNG> {
 
     public:
         RandLAPACK::RangeFinder<T, RNG> &RF_Obj;
-        RandLAPACK::Stabilization<T> &Orth_Obj;
+        RandLAPACK::Stabilization<T> &orth;
         bool verbose;
         bool orth_check;
 };
@@ -211,7 +211,7 @@ int QB<T, RNG>::call(
             // Q_i = orth(Q_i - Q(Q'Q_i))
             blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, curr_sz, b_sz, m, 1.0, Q, m, Q_i, m, 0.0, QtQi, next_sz);
             blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, b_sz, curr_sz, -1.0, Q, m, QtQi, next_sz, 1.0, Q_i, m);
-            this->Orth_Obj.call(m, b_sz, Q_i);
+            this->orth.call(m, b_sz, Q_i);
         }
 
         //B_i' = A' * Q_i'

--- a/RandLAPACK/comps/rl_rf.hh
+++ b/RandLAPACK/comps/rl_rf.hh
@@ -39,7 +39,7 @@ class RF : public RangeFinder<T, RNG> {
             RandLAPACK::Stabilization<T> &orth_obj,
             bool verb,
             bool cond
-        ) : RS_Obj(rs_obj), orth(orth_obj) {
+        ) : rs(rs_obj), orth(orth_obj) {
             verbose = verb;
             cond_check = cond;
         }
@@ -93,7 +93,7 @@ class RF : public RangeFinder<T, RNG> {
 
     public:
        // Instantiated in the constructor
-       RandLAPACK::RowSketcher<T, RNG> &RS_Obj;
+       RandLAPACK::RowSketcher<T, RNG> &rs;
        RandLAPACK::Stabilization<T> &orth;
        bool verbose;
        bool cond_check;
@@ -115,7 +115,7 @@ int RF<T, RNG>::call(
 
     T* Omega  = ( T * ) calloc( n * k, sizeof( T ) );
 
-    if(this->RS_Obj.call(m, n, A, k, Omega, state)) {
+    if(this->rs.call(m, n, A, k, Omega, state)) {
         free(Omega);
         return 1;
     }

--- a/RandLAPACK/comps/rl_rf.hh
+++ b/RandLAPACK/comps/rl_rf.hh
@@ -39,7 +39,7 @@ class RF : public RangeFinder<T, RNG> {
             RandLAPACK::Stabilization<T> &orth_obj,
             bool verb,
             bool cond
-        ) : RS_Obj(rs_obj), Orth_Obj(orth_obj) {
+        ) : RS_Obj(rs_obj), orth(orth_obj) {
             verbose = verb;
             cond_check = cond;
         }
@@ -94,7 +94,7 @@ class RF : public RangeFinder<T, RNG> {
     public:
        // Instantiated in the constructor
        RandLAPACK::RowSketcher<T, RNG> &RS_Obj;
-       RandLAPACK::Stabilization<T> &Orth_Obj;
+       RandLAPACK::Stabilization<T> &orth;
        bool verbose;
        bool cond_check;
 
@@ -127,7 +127,7 @@ int RF<T, RNG>::call(
         // Writes into this->cond_nums
         this->cond_nums.push_back(util::cond_num_check(m, k, Q, this->verbose));
 
-    if(this->Orth_Obj.call(m, k, Q))
+    if(this->orth.call(m, k, Q))
         return 2; // Orthogonalization failed
 
     // Normal termination

--- a/RandLAPACK/comps/rl_syps.hh
+++ b/RandLAPACK/comps/rl_syps.hh
@@ -31,7 +31,7 @@ class SymmetricPowerSketch {
         ) = 0;
 
         virtual int call(
-            linops::SymmetricLinearOperator<T> &A,
+            linops::SymLinOp<T> &A,
             int64_t k,
             RandBLAS::RNGState<RNG> &state,
             T* &skop_buff = nullptr,
@@ -108,7 +108,7 @@ class SYPS : public SymmetricPowerSketch<T, RNG> {
         );
 
         int call(
-            linops::SymmetricLinearOperator<T> &A,
+            linops::SymLinOp<T> &A,
             int64_t k,
             RandBLAS::RNGState<RNG> &state,
             T* &skop_buff,
@@ -125,7 +125,7 @@ class SYPS : public SymmetricPowerSketch<T, RNG> {
 // -----------------------------------------------------------------------------
 template <typename T, typename RNG>
 int SYPS<T, RNG>::call(
-    linops::SymmetricLinearOperator<T> &A,
+    linops::SymLinOp<T> &A,
     int64_t k,
     RandBLAS::RNGState<RNG> &state,
     T* &skop_buff,

--- a/RandLAPACK/comps/rl_syps.hh
+++ b/RandLAPACK/comps/rl_syps.hh
@@ -126,7 +126,7 @@ class SYPS {
             T* &skop_buff,
             T* work_buff
         ) {
-            int64_t m = A.m;
+            int64_t m = A.dim;
             int64_t p = this->passes_over_data;
             int64_t q = this->passes_per_stab;
             int64_t p_done = 0;

--- a/RandLAPACK/comps/rl_syps.hh
+++ b/RandLAPACK/comps/rl_syps.hh
@@ -16,31 +16,6 @@
 
 namespace RandLAPACK {
 
-/*
-Looks like there's no way to define a concept for a single type, SYPS_t,
-where SYPS_t satisftying the SymmetricPowerSketcherConcept implies that 
-objects of type SYPS_t have a call(...) method whose first argument is
-templated to accept any object whose type satisfies SymmetricLinearOperator.
-
-I can only define a concept that accepts two template parameters. Those
-can, in principle, be used for templating with patterns of the form
-
-    template <typename SYPS_t, typename SLO>
-    requires SymmetricPowerSketchConcept<SYPS_t, SLO>
-    // ... definition here ...
-
-*/
-
-// In the concept below the template parameters T and RNG are just aliases for readibility.
-// Because they have default values, an expression "SymmetricPowerSketchConcept<SYPS_t, SLO>""
-// is a well-formed way of enforcing the SymmetricPowerSketchConcept requirement on (SYPS_t, SLO).
-template <typename SYPS_t, typename SLO, typename T = SYPS_t::scalar_t, typename RNG = SYPS_t::RNG_t>
-concept SymmetricPowerSketchConcept = 
-    linops::SymmetricLinearOperator<SLO> &&
-    requires(SYPS_t obj, Uplo uplo, int64_t m, const T* A, int64_t lda, int64_t k, RandBLAS::RNGState<RNG> &state, T* skop_buff, T* work_buff) {
-        { obj.call(uplo, m, A, lda, k, state, skop_buff, work_buff) } -> std::same_as<int>;
-        { obj.call(std::declval<SLO>(), k, state, skop_buff, work_buff) } -> std::same_as<int>;
-};
 
 template <typename T, typename RNG>
 class SYPS {

--- a/RandLAPACK/comps/rl_syps.hh
+++ b/RandLAPACK/comps/rl_syps.hh
@@ -14,37 +14,6 @@
 
 namespace RandLAPACK {
 
-// template <typename T, typename RNG>
-// class SymmetricPowerSketch {
-//     public:
-//         virtual ~SymmetricPowerSketch() {}
-
-//         virtual int call(
-//             Uplo uplo,
-//             int64_t m,
-//             const T* A,
-//             int64_t lda,
-//             int64_t k,
-//             RandBLAS::RNGState<RNG> &state,
-//             T* &skop_buff = nullptr,
-//             T* work_buff = nullptr
-//         ) = 0;
-
-//         virtual int call(
-//             linops::SymLinOp<T> &A,
-//             int64_t k,
-//             RandBLAS::RNGState<RNG> &state,
-//             T* &skop_buff = nullptr,
-//             T* work_buff = nullptr
-//         ) = 0;
-
-// };
-
-// template <typename SYPS_t, typename T, typename RNG>
-// concept SymmetricPowerSketch = requires(SYPS_t obj, Uplo uplo, int64_t m, const T* A, int64_t lda, int64_t k, RandBLAS::RNGState<RNG> &state, T* skop_buff, T* work_buff) {
-//     { obj.call(uplo, m, A, lda, k, state, skop_buff, work_buff) } -> std::same_as<int>;
-//     { obj.call(std::declval<linops::SymmetricLinearOperator>(), k, state, skop_buff, work_buff) } -> std::same_as<int>;
-// };
 
 template <typename SYPS_t, typename Op, typename T, typename RNG>
 concept SymmetricPowerSketchConcept = 
@@ -60,6 +29,8 @@ concept SymmetricPowerSketchConcept =
 template <typename T, typename RNG>
 class SYPS {
     public:
+        using scalar_t = T;
+        using RNG_t    = RNG;
         int64_t passes_over_data;
         int64_t passes_per_stab;
         bool verbose;
@@ -126,7 +97,10 @@ class SYPS {
             RandBLAS::RNGState<RNG> &state,
             T* &skop_buff,
             T* work_buff
-        );
+        ) {
+            linops::ExplicitSymLinOp<T> A_linop(m, uplo, A, lda, Layout::ColMajor);
+            return call(A_linop, k, state, skop_buff, work_buff);
+        }
 
         template <linops::SymmetricLinearOperator SLO>
         int call(
@@ -179,23 +153,6 @@ class SYPS {
         }
     
 };
-
-
-// -----------------------------------------------------------------------------
-template <typename T, typename RNG>
-int SYPS<T, RNG>::call(
-    Uplo uplo,
-    int64_t m,
-    const T* A,
-    int64_t lda,
-    int64_t k,
-    RandBLAS::RNGState<RNG> &state,
-    T* &skop_buff,
-    T* work_buff
-) {
-    linops::ExplicitSymLinOp<T> A_linop(m, uplo, A, lda, Layout::ColMajor);
-    return call(A_linop, k, state, skop_buff, work_buff);
-}
 
 
 } // end namespace RandLAPACK

--- a/RandLAPACK/comps/rl_syrf.hh
+++ b/RandLAPACK/comps/rl_syrf.hh
@@ -40,12 +40,20 @@ class SymmetricRangeFinder {
         ) = 0;
 };
 
-template <typename T, typename RNG>
+template <typename SYPS_t, typename T, typename RNG>
 class SYRF : public SymmetricRangeFinder<T, RNG> {
     public:
+    //    RandLAPACK::SymmetricPowerSketch<T, RNG> &SYPS_Obj;
+       SYPS_t &SYPS_Obj;
+       RandLAPACK::Stabilization<T> &Orth_Obj;
+       bool verbose;
+       bool cond_check;
+       std::vector<T> cond_work_mat;
+       std::vector<T> cond_work_vec;
+       std::vector<T> cond_nums; // Condition nubers of sketches
 
         SYRF(
-            RandLAPACK::SymmetricPowerSketch<T, RNG> &syps_obj,
+            SYPS_t &syps_obj,
             RandLAPACK::Stabilization<T> &orth_obj,
             bool verb = false,
             bool cond = false
@@ -101,21 +109,11 @@ class SYRF : public SymmetricRangeFinder<T, RNG> {
             T* work_buff
         ) override;
 
-
-    public:
-       // Instantiated in the constructor
-       RandLAPACK::SymmetricPowerSketch<T, RNG> &SYPS_Obj;
-       RandLAPACK::Stabilization<T> &Orth_Obj;
-       bool verbose;
-       bool cond_check;
-       std::vector<T> cond_work_mat;
-       std::vector<T> cond_work_vec;
-       std::vector<T> cond_nums; // Condition nubers of sketches
 };
 
 // -----------------------------------------------------------------------------
-template <typename T, typename RNG>
-int SYRF<T, RNG>::call(
+template <typename SYPS_t, typename T, typename RNG>
+int SYRF<SYPS_t, T, RNG>::call(
     linops::SymLinOp<T> &A,
     int64_t k,
     std::vector<T> &Q,
@@ -151,8 +149,8 @@ int SYRF<T, RNG>::call(
 }
 
 // -----------------------------------------------------------------------------
-template <typename T, typename RNG>
-int SYRF<T, RNG>::call(
+template <typename SYPS_t, typename T, typename RNG>
+int SYRF<SYPS_t, T, RNG>::call(
     Uplo uplo,
     int64_t m,
     const T* A,

--- a/RandLAPACK/comps/rl_syrf.hh
+++ b/RandLAPACK/comps/rl_syrf.hh
@@ -17,18 +17,6 @@
 namespace RandLAPACK {
 
 
-template <typename SYRF_t, typename Op, typename T, typename RNG>
-concept SymmetricRangeFinderConcept = 
-    // Ensure Op conforms to the SymmetricLinearOperator concept
-    linops::SymmetricLinearOperator<Op> &&
-    requires(SYRF_t obj, Uplo uplo, int64_t m, const T* A, int64_t lda, int64_t k, std::vector<T> Q, RandBLAS::RNGState<RNG> &state, T* work_buff) {
-        // First version of call
-        { obj.call(uplo, m, A, lda, k, Q, state, work_buff) } -> std::same_as<int>;
-        // Second version of call, templated on a type that satisfies SymmetricLinearOperator
-        { obj.call(std::declval<Op>(), k, Q, state, work_buff) } -> std::same_as<int>;
-};
-
-
 template <typename SYPS_t, typename Orth_t>
 class SYRF {
     public:

--- a/RandLAPACK/comps/rl_syrf.hh
+++ b/RandLAPACK/comps/rl_syrf.hh
@@ -22,7 +22,7 @@ class SymmetricRangeFinder {
         virtual ~SymmetricRangeFinder() {}
 
         virtual int call(
-            linops::SymmetricLinearOperator<T> &A,
+            linops::SymLinOp<T> &A,
             int64_t k,
             std::vector<T> &Q,
             RandBLAS::RNGState<RNG> &state,
@@ -94,7 +94,7 @@ class SYRF : public SymmetricRangeFinder<T, RNG> {
         ) override;
 
         int call(
-            linops::SymmetricLinearOperator<T> &A,
+            linops::SymLinOp<T> &A,
             int64_t k,
             std::vector<T> &Q,
             RandBLAS::RNGState<RNG> &state,
@@ -116,7 +116,7 @@ class SYRF : public SymmetricRangeFinder<T, RNG> {
 // -----------------------------------------------------------------------------
 template <typename T, typename RNG>
 int SYRF<T, RNG>::call(
-    linops::SymmetricLinearOperator<T> &A,
+    linops::SymLinOp<T> &A,
     int64_t k,
     std::vector<T> &Q,
     RandBLAS::RNGState<RNG> &state,

--- a/RandLAPACK/comps/rl_syrf.hh
+++ b/RandLAPACK/comps/rl_syrf.hh
@@ -29,13 +29,13 @@ concept SymmetricRangeFinderConcept =
 };
 
 
-template <typename SYPS_t>
+template <typename SYPS_t, typename Orth_t>
 class SYRF {
     public:
-        using T = typename SYPS_t::scalar_t;
+        using T  = typename SYPS_t::scalar_t;
         using RNG = typename SYPS_t::RNG_t;
-        SYPS_t &SYPS_Obj;
-        RandLAPACK::Stabilization<T> &Orth_Obj;
+        SYPS_t &syps;
+        Orth_t &orth;
         bool verbose;
         bool cond_check;
         std::vector<T> cond_work_mat;
@@ -44,10 +44,10 @@ class SYRF {
 
         SYRF(
             SYPS_t &syps_obj,
-            RandLAPACK::Stabilization<T> &orth_obj,
+            Orth_t &orth_obj,
             bool verb = false,
             bool cond = false
-        ) : SYPS_Obj(syps_obj), Orth_Obj(orth_obj) {
+        ) : syps(syps_obj), orth(orth_obj) {
             verbose = verb;
             cond_check = cond;
         }
@@ -110,7 +110,7 @@ class SYRF {
             RandBLAS::util::safe_scal(m * k, (T) 0.0, work_buff, 1);
 
             T* Q_dat = util::upsize(m * k, Q);
-            SYPS_Obj.call(A, k, state, work_buff, Q_dat);
+            syps.call(A, k, state, work_buff, Q_dat);
 
             // Q = orth(A * Omega)
             A(Layout::ColMajor, k, (T) 1.0, work_buff, m, (T) 0.0, Q_dat, m);
@@ -121,7 +121,7 @@ class SYRF {
                     util::cond_num_check(m, k, Q.data(), this->verbose)
                 );
             }
-            if(this->Orth_Obj.call(m, k, Q.data()))
+            if(this->orth.call(m, k, Q.data()))
                 throw std::runtime_error("Orthogonalization failed.");
             
             if (!callers_work_buff)

--- a/RandLAPACK/comps/rl_syrf.hh
+++ b/RandLAPACK/comps/rl_syrf.hh
@@ -32,7 +32,7 @@ concept SymmetricRangeFinderConcept =
 template <typename SYPS_t>
 class SYRF {
     public:
-        using T   = typename SYPS_t::scalar_t;
+        using T = typename SYPS_t::scalar_t;
         using RNG = typename SYPS_t::RNG_t;
         SYPS_t &SYPS_Obj;
         RandLAPACK::Stabilization<T> &Orth_Obj;

--- a/RandLAPACK/comps/rl_syrf.hh
+++ b/RandLAPACK/comps/rl_syrf.hh
@@ -102,7 +102,7 @@ class SYRF {
             RandBLAS::RNGState<RNG> &state,
             T* work_buff
         ) {
-            int64_t m = A.m;
+            int64_t m = A.dim;
             bool callers_work_buff = work_buff != nullptr;
             if (!callers_work_buff)
                 work_buff = new T[m * k];

--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -31,7 +31,7 @@ T power_error_est(
     T* Mat_buf,
     T* eigvals
 ) {
-    int64_t m = A.m;
+    int64_t m = A.dim;
     T err = 0;
     for(int i = 0; i < p; ++i) {
         T g_norm = blas::nrm2(m, vector_buf, 1);
@@ -150,7 +150,7 @@ class REVD2 {
             std::vector<T> &eigvals,
             RandBLAS::RNGState<RNG> &state
         ) {
-            int64_t m = A.m;
+            int64_t m = A.dim;
             T err = 0;
             RandBLAS::RNGState<RNG> error_est_state(state.counter, state.key);
             error_est_state.key.incr(1);

--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -13,40 +13,81 @@
 
 namespace RandLAPACK {
 
-template <typename T, typename RNG>
-class REVD2alg {
+
+// -----------------------------------------------------------------------------
+/// Power scheme for error estimation, based on Algorithm E.1 from https://arxiv.org/pdf/2110.02820.pdf.
+/// This routine is too specialized to be included into RandLAPACK::utils
+/// p - number of algorithm iterations
+/// vector_buf - buffer for vector operations
+/// Mat_buf - buffer for matrix operations
+/// All other parameters come from REVD2
+template <typename T, linops::SymmetricLinearOperator SLO>
+T power_error_est(
+    SLO &A,
+    int64_t k,
+    int p,
+    T* vector_buf,
+    T* V,
+    T* Mat_buf,
+    T* eigvals
+) {
+    int64_t m = A.m;
+    T err = 0;
+    for(int i = 0; i < p; ++i) {
+        T g_norm = blas::nrm2(m, vector_buf, 1);
+        // Compute g = g / ||g|| - we need this because dot product does not take in an alpha
+        blas::scal(m, 1 / g_norm, vector_buf, 1);
+
+        // Compute V' * g / ||g||
+        // Using the second column of vector_buff as a buffer for matrix-vector product
+        gemv(Layout::ColMajor, Op::Trans, m, k, 1.0, V, m, vector_buf, 1, 0.0, &vector_buf[m], 1);
+
+        // Compute V*E, eigvals diag
+        // Using Mat_buf as a buffer for V * diag(eigvals).
+        for (int i = 0, j = 0; i < m * k; ++i) {
+            Mat_buf[i] = V[i] * eigvals[j];
+            if((i + 1) % m == 0 && i != 0)
+                ++j;
+        }
+
+        // Compute V * diag(eigvals) * V' * g / ||g||
+        // Using the third column of vector_buf as a buffer for matrix-vector product
+        gemv(Layout::ColMajor, Op::NoTrans, m, k, 1.0, Mat_buf, m, &vector_buf[m], 1, 0.0, &vector_buf[2 * m], 1);
+        // Compute A * g / ||g||
+        // Using the forth column of vector_buff as a buffer for matrix-vector product
+        A(Layout::ColMajor, 1, 1.0, vector_buf, m, 0.0, &vector_buf[3*m], m);
+        // symv(Layout::ColMajor, uplo, m, 1.0, A, m, vector_buf, 1, 0.0, &vector_buf[3 * m], 1);
+
+        // Compute w = (A * g / ||g|| - V * diag(eigvals) * V' * g / ||g||)
+        // Result is stored in the 4th column of vector_buf
+        blas::axpy(m, -1.0, &vector_buf[2 * m], 1, &vector_buf[3 * m], 1);
+        // Compute (g / ||g||)' * w - this is our measure for the error
+        err = blas::dot(m, vector_buf, 1, &vector_buf[3 * m], 1);	
+        // v_0 <- v
+        std::copy(&vector_buf[3 * m], &vector_buf[4 * m], vector_buf);
+    }
+    return err;
+}
+
+
+template <typename SYRF_t>
+class REVD2 {
     public:
+        using T   = typename SYRF_t::T;
+        using RNG = typename SYRF_t::RNG;
+        SYRF_t &SYRF_Obj;
+        int error_est_p;
+        bool verbose;
 
-        virtual ~REVD2alg() {}
-
-        virtual int call(
-            Uplo uplo,
-            int64_t m,
-            const T* A,
-            int64_t &k,
-            T tol,
-            std::vector<T> &V,
-            std::vector<T> &eigvals,
-            RandBLAS::RNGState<RNG> &state
-        ) = 0;
-
-        virtual int call(
-            linops::SymLinOp<T> &A,
-            int64_t &k,
-            T tol,
-            std::vector<T> &V,
-            std::vector<T> &eigvals,
-            RandBLAS::RNGState<RNG> &state
-        ) = 0;
-};
-
-template <typename T, typename RNG>
-class REVD2 : public REVD2alg<T, RNG> {
-    public:
+        std::vector<T> Y;
+        std::vector<T> Omega;
+        std::vector<T> R;
+        std::vector<T> S;
+        std::vector<T> symrf_work;
 
         // Constructor
         REVD2(
-            RandLAPACK::SymmetricRangeFinder<T, RNG> &syrf_obj,
+            SYRF_t &syrf_obj,
             int error_est_power_iters,
             bool verb = false
         ) : SYRF_Obj(syrf_obj) {
@@ -95,192 +136,106 @@ class REVD2 : public REVD2alg<T, RNG> {
             std::vector<T> &V,
             std::vector<T> &eigvals,
             RandBLAS::RNGState<RNG> &state
-        ) override;
+        ) {
+            linops::ExplicitSymLinOp<T> A_linop(m, uplo, A, m, Layout::ColMajor);
+            return this->call(A_linop, k, tol, V, eigvals, state);
+        }
 
+        template <linops::SymmetricLinearOperator SLO>
         int call(
-            linops::SymLinOp<T> &A,
+            SLO &A,
             int64_t &k,
             T tol,
             std::vector<T> &V,
             std::vector<T> &eigvals,
             RandBLAS::RNGState<RNG> &state
-        ) override;
+        ) {
+            int64_t m = A.m;
+            T err = 0;
+            RandBLAS::RNGState<RNG> error_est_state(state.counter, state.key);
+            error_est_state.key.incr(1);
+            while(true) {
+                util::upsize(k, eigvals);
+                T* V_dat = util::upsize(m * k, V);
+                T* Y_dat = util::upsize(m * k, this->Y);
+                T* Omega_dat = util::upsize(m * k, this->Omega);
+                T* R_dat = util::upsize(k * k, this->R);
+                T* S_dat = util::upsize(k * k, this->S);
+                T* symrf_work_dat = util::upsize(m * k, this->symrf_work);
 
-    public:
-        RandLAPACK::SymmetricRangeFinder<T, RNG> &SYRF_Obj;
-        int error_est_p;
-        bool verbose;
+                // Construnct a sketching operator
+                // If CholeskyQR is used for stab/orth here, RF can fail
+                this->SYRF_Obj.call(A, k, this->Omega, state, symrf_work_dat);
 
-        std::vector<T> Y;
-        std::vector<T> Omega;
-        std::vector<T> R;
-        std::vector<T> S;
-        std::vector<T> symrf_work;
+                // Y = A * Omega
+                A(Layout::ColMajor, k, 1.0, Omega_dat, m, 0.0, Y_dat, m);
+
+                T nu = std::numeric_limits<T>::epsilon() * lapack::lange(Norm::Fro, m, k, Y_dat, m);
+
+                // We need Y = Y + v Omega
+                // We further need R = chol(Omega' Y)
+                // Solve this as R = chol(Omega' Y + v Omega'Omega)
+                // Compute v Omega' Omega; syrk only computes the lower triangular part. Need full.
+                blas::syrk(Layout::ColMajor, Uplo::Lower, Op::Trans, k, m, nu, Omega_dat, m, 0.0, R_dat, k);
+                for(int i = 1; i < k; ++i)
+                    blas::copy(k - i, &R_dat[i + ((i-1) * k)], 1, &R_dat[(i - 1) + (i * k)], k);
+                // Compute Omega' Y + v Omega' Omega
+                blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, m, 1.0, Omega_dat, m, Y_dat, m, 1.0, R_dat, k);
+
+                // Compute R = chol(Omega' Y + v Omega' Omega)
+                // Looks like if POTRF gets passed a non-triangular matrix, it will also output a non-triangular one
+                if(lapack::potrf(Uplo::Upper, k, R_dat, k))
+                    throw std::runtime_error("Cholesky decomposition failed.");
+                RandLAPACK::util::get_U(k, k, R_dat, k);
+
+                // B = Y(R')^-1 - need to transpose R
+                blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, 1.0, R_dat, k, Y_dat, m);
+
+                //[V, S, ~] = SVD(B)
+                // Although we don't need the right singular vectors, we need to give space for those.
+                // Use R as a buffer for that.
+                lapack::gesdd(Job::SomeVec, m, k, Y_dat, m, S_dat, V_dat, m, R_dat, k);
+
+                // eigvals = diag(S^2)
+                T buf;
+                int64_t r = 0;
+                int i;
+                for(i = 0; i < k; ++i) {
+                    buf = std::pow(S[i], 2);
+                    eigvals[i] = buf;
+                    // r = number of entries in eigvals that are greater than v
+                    if(buf > nu)
+                        ++r;
+                }
+
+                // Undo regularlization
+                // Need to make sure no eigenvalue is negative
+                for(i = 0; i < r; ++i)
+                    (eigvals[i] - nu < 0) ? 0 : eigvals[i] -=nu;
+
+                std::fill(&V_dat[m * r], &V_dat[m * k], 0.0);
+
+                // Error estimation
+                // Using the first column of Omega as a buffer for a random vector
+                // To perform the following safely, need to make sure Omega has at least 4 columns
+                Omega_dat = util::upsize(m * 4, this->Omega);
+                RandBLAS::DenseDist  g(m, 1);
+                error_est_state = RandBLAS::fill_dense(g, Omega_dat, error_est_state);
+
+                err = power_error_est(A, k, this->error_est_p, Omega_dat, V_dat, Y_dat, eigvals.data()); 
+
+                if(err <= 5 * std::max(tol, nu) || k == m) {
+                    break;
+                } else if (2 * k > m) {
+                    k = m;
+                } else {
+                    k = 2 * k;
+                }
+            }
+            return 0;
+        }
+
 };
 
-// -----------------------------------------------------------------------------
-/// Power scheme for error estimation, based on Algorithm E.1 from https://arxiv.org/pdf/2110.02820.pdf.
-/// This routine is too specialized to be included into RandLAPACK::utils
-/// p - number of algorithm iterations
-/// vector_buf - buffer for vector operations
-/// Mat_buf - buffer for matrix operations
-/// All other parameters come from REVD2
-template <typename T>
-T power_error_est(
-    linops::SymLinOp<T> &A,
-    int64_t k,
-    int p,
-    T* vector_buf,
-    T* V,
-    T* Mat_buf,
-    T* eigvals
-) {
-    int64_t m = A.m;
-    T err = 0;
-    for(int i = 0; i < p; ++i) {
-        T g_norm = blas::nrm2(m, vector_buf, 1);
-        // Compute g = g / ||g|| - we need this because dot product does not take in an alpha
-        blas::scal(m, 1 / g_norm, vector_buf, 1);
-
-        // Compute V' * g / ||g||
-        // Using the second column of vector_buff as a buffer for matrix-vector product
-        gemv(Layout::ColMajor, Op::Trans, m, k, 1.0, V, m, vector_buf, 1, 0.0, &vector_buf[m], 1);
-
-        // Compute V*E, eigvals diag
-        // Using Mat_buf as a buffer for V * diag(eigvals).
-        for (int i = 0, j = 0; i < m * k; ++i) {
-            Mat_buf[i] = V[i] * eigvals[j];
-            if((i + 1) % m == 0 && i != 0)
-                ++j;
-        }
-
-        // Compute V * diag(eigvals) * V' * g / ||g||
-        // Using the third column of vector_buf as a buffer for matrix-vector product
-        gemv(Layout::ColMajor, Op::NoTrans, m, k, 1.0, Mat_buf, m, &vector_buf[m], 1, 0.0, &vector_buf[2 * m], 1);
-        // Compute A * g / ||g||
-        // Using the forth column of vector_buff as a buffer for matrix-vector product
-        A(Layout::ColMajor, 1, 1.0, vector_buf, m, 0.0, &vector_buf[3*m], m);
-        // symv(Layout::ColMajor, uplo, m, 1.0, A, m, vector_buf, 1, 0.0, &vector_buf[3 * m], 1);
-
-        // Compute w = (A * g / ||g|| - V * diag(eigvals) * V' * g / ||g||)
-        // Result is stored in the 4th column of vector_buf
-        blas::axpy(m, -1.0, &vector_buf[2 * m], 1, &vector_buf[3 * m], 1);
-        // Compute (g / ||g||)' * w - this is our measure for the error
-        err = blas::dot(m, vector_buf, 1, &vector_buf[3 * m], 1);	
-        // v_0 <- v
-        std::copy(&vector_buf[3 * m], &vector_buf[4 * m], vector_buf);
-    }
-    return err;
-}
-
-
-template <typename T, typename RNG>
-int REVD2<T, RNG>::call(
-        linops::SymLinOp<T> &A,
-        int64_t &k,
-        T tol,
-        std::vector<T> &V,
-        std::vector<T> &eigvals,
-        RandBLAS::RNGState<RNG> &state
-) {
-    int64_t m = A.m;
-    T err = 0;
-    RandBLAS::RNGState<RNG> error_est_state(state.counter, state.key);
-    error_est_state.key.incr(1);
-    while(true) {
-        util::upsize(k, eigvals);
-        T* V_dat = util::upsize(m * k, V);
-        T* Y_dat = util::upsize(m * k, this->Y);
-        T* Omega_dat = util::upsize(m * k, this->Omega);
-        T* R_dat = util::upsize(k * k, this->R);
-        T* S_dat = util::upsize(k * k, this->S);
-        T* symrf_work_dat = util::upsize(m * k, this->symrf_work);
-
-        // Construnct a sketching operator
-        // If CholeskyQR is used for stab/orth here, RF can fail
-        this->SYRF_Obj.call(A, k, this->Omega, state, symrf_work_dat);
-
-        // Y = A * Omega
-        A(Layout::ColMajor, k, 1.0, Omega_dat, m, 0.0, Y_dat, m);
-
-        T nu = std::numeric_limits<T>::epsilon() * lapack::lange(Norm::Fro, m, k, Y_dat, m);
-
-        // We need Y = Y + v Omega
-        // We further need R = chol(Omega' Y)
-        // Solve this as R = chol(Omega' Y + v Omega'Omega)
-        // Compute v Omega' Omega; syrk only computes the lower triangular part. Need full.
-        blas::syrk(Layout::ColMajor, Uplo::Lower, Op::Trans, k, m, nu, Omega_dat, m, 0.0, R_dat, k);
-        for(int i = 1; i < k; ++i)
-            blas::copy(k - i, &R_dat[i + ((i-1) * k)], 1, &R_dat[(i - 1) + (i * k)], k);
-        // Compute Omega' Y + v Omega' Omega
-        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, m, 1.0, Omega_dat, m, Y_dat, m, 1.0, R_dat, k);
-
-        // Compute R = chol(Omega' Y + v Omega' Omega)
-        // Looks like if POTRF gets passed a non-triangular matrix, it will also output a non-triangular one
-        if(lapack::potrf(Uplo::Upper, k, R_dat, k))
-            throw std::runtime_error("Cholesky decomposition failed.");
-        RandLAPACK::util::get_U(k, k, R_dat, k);
-
-        // B = Y(R')^-1 - need to transpose R
-        blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, 1.0, R_dat, k, Y_dat, m);
-
-        //[V, S, ~] = SVD(B)
-        // Although we don't need the right singular vectors, we need to give space for those.
-        // Use R as a buffer for that.
-        lapack::gesdd(Job::SomeVec, m, k, Y_dat, m, S_dat, V_dat, m, R_dat, k);
-
-        // eigvals = diag(S^2)
-        T buf;
-        int64_t r = 0;
-        int i;
-        for(i = 0; i < k; ++i) {
-            buf = std::pow(S[i], 2);
-            eigvals[i] = buf;
-            // r = number of entries in eigvals that are greater than v
-            if(buf > nu)
-                ++r;
-        }
-
-        // Undo regularlization
-        // Need to make sure no eigenvalue is negative
-        for(i = 0; i < r; ++i)
-            (eigvals[i] - nu < 0) ? 0 : eigvals[i] -=nu;
-
-        std::fill(&V_dat[m * r], &V_dat[m * k], 0.0);
-
-        // Error estimation
-        // Using the first column of Omega as a buffer for a random vector
-        // To perform the following safely, need to make sure Omega has at least 4 columns
-        Omega_dat = util::upsize(m * 4, this->Omega);
-        RandBLAS::DenseDist  g(m, 1);
-        error_est_state = RandBLAS::fill_dense(g, Omega_dat, error_est_state);
-
-        err = power_error_est(A, k, this->error_est_p, Omega_dat, V_dat, Y_dat, eigvals.data()); 
-
-        if(err <= 5 * std::max(tol, nu) || k == m) {
-            break;
-        } else if (2 * k > m) {
-            k = m;
-        } else {
-            k = 2 * k;
-        }
-    }
-    return 0;
-}
-
-template <typename T, typename RNG>
-int REVD2<T, RNG>::call(
-        Uplo uplo,
-        int64_t m,
-        const T* A,
-        int64_t &k,
-        T tol,
-        std::vector<T> &V,
-        std::vector<T> &eigvals,
-        RandBLAS::RNGState<RNG> &state
-) {
-    linops::ExplicitSymLinOp<T> A_linop(m, uplo, A, m, Layout::ColMajor);
-    return this->call(A_linop, k, tol, V, eigvals, state);
-}
 
 } // end namespace RandLAPACK

--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -31,7 +31,7 @@ class REVD2alg {
         ) = 0;
 
         virtual int call(
-            linops::SymmetricLinearOperator<T> &A,
+            linops::SymLinOp<T> &A,
             int64_t &k,
             T tol,
             std::vector<T> &V,
@@ -98,7 +98,7 @@ class REVD2 : public REVD2alg<T, RNG> {
         ) override;
 
         int call(
-            linops::SymmetricLinearOperator<T> &A,
+            linops::SymLinOp<T> &A,
             int64_t &k,
             T tol,
             std::vector<T> &V,
@@ -127,7 +127,7 @@ class REVD2 : public REVD2alg<T, RNG> {
 /// All other parameters come from REVD2
 template <typename T>
 T power_error_est(
-    linops::SymmetricLinearOperator<T> &A,
+    linops::SymLinOp<T> &A,
     int64_t k,
     int p,
     T* vector_buf,
@@ -176,7 +176,7 @@ T power_error_est(
 
 template <typename T, typename RNG>
 int REVD2<T, RNG>::call(
-        linops::SymmetricLinearOperator<T> &A,
+        linops::SymLinOp<T> &A,
         int64_t &k,
         T tol,
         std::vector<T> &V,

--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -75,7 +75,7 @@ class REVD2 {
     public:
         using T   = typename SYRF_t::T;
         using RNG = typename SYRF_t::RNG;
-        SYRF_t &SYRF_Obj;
+        SYRF_t &syrf;
         int error_est_p;
         bool verbose;
 
@@ -90,7 +90,7 @@ class REVD2 {
             SYRF_t &syrf_obj,
             int error_est_power_iters,
             bool verb = false
-        ) : SYRF_Obj(syrf_obj) {
+        ) : syrf(syrf_obj) {
             error_est_p = error_est_power_iters;
             verbose = verb;
         }
@@ -165,7 +165,7 @@ class REVD2 {
 
                 // Construnct a sketching operator
                 // If CholeskyQR is used for stab/orth here, RF can fail
-                this->SYRF_Obj.call(A, k, this->Omega, state, symrf_work_dat);
+                this->syrf.call(A, k, this->Omega, state, symrf_work_dat);
 
                 // Y = A * Omega
                 A(Layout::ColMajor, k, 1.0, Omega_dat, m, 0.0, Y_dat, m);

--- a/RandLAPACK/misc/rl_linops.hh
+++ b/RandLAPACK/misc/rl_linops.hh
@@ -71,17 +71,17 @@ struct SymLinOp {
 template <typename T>
 struct ExplicitSymLinOp : public SymLinOp<T> {
 
-    const blas::Uplo uplo;
+    const Uplo uplo;
     const T* A_buff;
     const int64_t lda;
-    const blas::Layout buff_layout;
+    const Layout buff_layout;
 
     ExplicitSymLinOp(
         int64_t m,
-        blas::Uplo uplo,
+        Uplo uplo,
         const T* A_buff,
         int64_t lda,
-        blas::Layout buff_layout
+        Layout buff_layout
     ) : SymLinOp<T>(m), uplo(uplo), A_buff(A_buff), lda(lda), buff_layout(buff_layout) {}
 
     // Note: the "layout" parameter here is interpreted for (B and C).
@@ -89,7 +89,7 @@ struct ExplicitSymLinOp : public SymLinOp<T> {
     // parameters to blas::symm to reconcile the different layouts of
     // A vs (B, C).
     void operator()(
-        blas::Layout layout,
+        Layout layout,
         int64_t n,
         T alpha,
         T* const B,
@@ -102,7 +102,7 @@ struct ExplicitSymLinOp : public SymLinOp<T> {
         randblas_require(ldc >= this->m);
         auto blas_call_uplo = this->uplo;
         if (layout != this->buff_layout)
-            blas_call_uplo = (this->uplo == blas::Uplo::Upper) ? blas::Uplo::Lower : blas::Uplo::Upper;
+            blas_call_uplo = (this->uplo == Uplo::Upper) ? Uplo::Lower : Uplo::Upper;
         // Reading the "blas_call_uplo" triangle of "this->A_buff" in "layout" order is the same
         // as reading the "this->uplo" triangle of "this->A_buff" in "this->buff_layout" order.
         blas::symm(
@@ -112,7 +112,7 @@ struct ExplicitSymLinOp : public SymLinOp<T> {
     }
 
     inline T operator()(int64_t i, int64_t j) {
-        randblas_require(this->uplo == blas::Uplo::Upper && this->buff_layout == blas::Layout::ColMajor);
+        randblas_require(this->uplo == Uplo::Upper && this->buff_layout == Layout::ColMajor);
         if (i > j) {
             return A_buff[j + i*lda];
         } else {
@@ -130,8 +130,8 @@ struct RegExplicitSymLinOp : public SymLinOp<T> {
     T* regs = nullptr;
     bool _eval_includes_reg;
 
-    static const blas::Uplo uplo = blas::Uplo::Upper;
-    static const blas::Layout buff_layout = blas::Layout::ColMajor;
+    static const Uplo uplo = Uplo::Upper;
+    static const Layout buff_layout = Layout::ColMajor;
     using scalar_t = T;
 
     RegExplicitSymLinOp(
@@ -157,7 +157,7 @@ struct RegExplicitSymLinOp : public SymLinOp<T> {
         _eval_includes_reg = eir;
     }
 
-    void operator()(blas::Layout layout, int64_t n, T alpha, T* const B, int64_t ldb, T beta, T* C, int64_t ldc) {
+    void operator()(Layout layout, int64_t n, T alpha, T* const B, int64_t ldb, T beta, T* C, int64_t ldc) {
         randblas_require(layout == this->buff_layout);
         randblas_require(ldb >= this->m);
         randblas_require(ldc >= this->m);
@@ -291,9 +291,9 @@ struct SpectralPrecond {
     }
 
     void operator()(
-        blas::Layout layout, int64_t n, T alpha, const T* B, int64_t ldb, T beta, T* C, int64_t ldc
+        Layout layout, int64_t n, T alpha, const T* B, int64_t ldb, T beta, T* C, int64_t ldc
     ) {
-        randblas_require(layout == blas::Layout::ColMajor);
+        randblas_require(layout == Layout::ColMajor);
         randblas_require(ldb >= this->m);
         randblas_require(ldc >= this->m);
         if (this->num_ops != 1) {

--- a/RandLAPACK/misc/rl_linops.hh
+++ b/RandLAPACK/misc/rl_linops.hh
@@ -10,11 +10,11 @@
 #include <algorithm>
 #include <vector>
 #include <cstdint>
+#include <concepts>
+
 
 namespace RandLAPACK::linops {
 
-#ifdef __cpp_concepts
-#include <concepts>
 
 template<typename LinOp, typename T = LinOp::scalar_t>
 concept SymmetricLinearOperator = requires(LinOp A) {
@@ -29,9 +29,7 @@ concept SymmetricLinearOperator = requires(LinOp A) {
     //
     { A(layout, n, alpha, B, ldb, beta, C, ldc) } -> std::same_as<void>;
 };
-#else
-#define SymmetricLinearOperator typename
-#endif
+
 
 using std::vector;
 

--- a/test/comps/test_syrf.cc
+++ b/test/comps/test_syrf.cc
@@ -47,7 +47,7 @@ class TestSYRF : public ::testing::Test
     struct algorithm_objects {
         RandLAPACK::SYPS<T, RNG> SYPS;
         RandLAPACK::HQRQ<T> Orth_RF; 
-        RandLAPACK::SYRF<T, RNG> SYRF;
+        RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>, T, RNG> SYRF;
 
         algorithm_objects(
             bool verbose, 

--- a/test/comps/test_syrf.cc
+++ b/test/comps/test_syrf.cc
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <gtest/gtest.h>
 
+
 class TestSYRF : public ::testing::Test
 {
     protected:
@@ -47,7 +48,7 @@ class TestSYRF : public ::testing::Test
     struct algorithm_objects {
         RandLAPACK::SYPS<T, RNG> SYPS;
         RandLAPACK::HQRQ<T> Orth_RF; 
-        RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>, T, RNG> SYRF;
+        RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>> SYRF;
 
         algorithm_objects(
             bool verbose, 

--- a/test/comps/test_syrf.cc
+++ b/test/comps/test_syrf.cc
@@ -46,9 +46,12 @@ class TestSYRF : public ::testing::Test
 
     template <typename T, typename RNG>
     struct algorithm_objects {
-        RandLAPACK::SYPS<T, RNG> SYPS;
-        RandLAPACK::HQRQ<T> Orth_RF; 
-        RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>> SYRF;
+        using SYPS_t = RandLAPACK::SYPS<T, RNG>;
+        using Orth_t = RandLAPACK::HQRQ<T>;
+        using SYRF_t = RandLAPACK::SYRF<SYPS_t, Orth_t>;
+        SYPS_t syps;
+        Orth_t orth; 
+        SYRF_t syrf;
 
         algorithm_objects(
             bool verbose, 
@@ -56,9 +59,9 @@ class TestSYRF : public ::testing::Test
             int64_t p, 
             int64_t passes_per_iteration
         ) :
-            SYPS(p, passes_per_iteration, verbose, cond_check),
-            Orth_RF(cond_check, verbose),
-            SYRF(SYPS, Orth_RF, verbose, cond_check)
+            syps(p, passes_per_iteration, verbose, cond_check),
+            orth(cond_check, verbose),
+            syrf(syps, orth, verbose, cond_check)
             {}
     };
 
@@ -96,7 +99,7 @@ class TestSYRF : public ::testing::Test
         auto m = all_data.row;
         auto k = all_data.rank;
 
-        all_algs.SYRF.call(Uplo::Upper, m, all_data.A.data(), k, all_data.Q, state, NULL);
+        all_algs.syrf.call(Uplo::Upper, m, all_data.A.data(), k, all_data.Q, state, NULL);
 
         // Reassing pointers because Q, B have been resized
         T* Q_dat = all_data.Q.data();

--- a/test/drivers/test_revd2.cc
+++ b/test/drivers/test_revd2.cc
@@ -77,12 +77,12 @@ class TestREVD2 : public ::testing::Test
     template <typename T, typename RNG>
     struct algorithm_objects {
         using SYPS_t = RandLAPACK::SYPS<T, RNG>;
-        using SYRF_t = RandLAPACK::SYRF<SYPS_t>;
         using Orth_t = RandLAPACK::HQRQ<T>;
-        SYPS_t SYPS;
-        Orth_t Orth; 
-        SYRF_t SYRF;
-        RandLAPACK::REVD2<SYRF_t> REVD2;
+        using SYRF_t = RandLAPACK::SYRF<SYPS_t, Orth_t>;
+        SYPS_t syps;
+        Orth_t orth; 
+        SYRF_t syrf;
+        RandLAPACK::REVD2<SYRF_t> revd2;
 
 
         algorithm_objects(
@@ -92,10 +92,10 @@ class TestREVD2 : public ::testing::Test
             int64_t passes_per_syps_stabilization, 
             int64_t num_steps_power_iter_error_est
         ) : 
-            SYPS(num_syps_passes, passes_per_syps_stabilization, verbose, cond_check),
-            Orth(cond_check, verbose),
-            SYRF(SYPS, Orth, verbose, cond_check),
-            REVD2(SYRF, num_steps_power_iter_error_est, verbose)
+            syps(num_syps_passes, passes_per_syps_stabilization, verbose, cond_check),
+            orth(cond_check, verbose),
+            syrf(syps, orth, verbose, cond_check),
+            revd2(syrf, num_steps_power_iter_error_est, verbose)
             {}
     };
 
@@ -152,7 +152,7 @@ class TestREVD2 : public ::testing::Test
         auto m = all_data.dim;
 
         int64_t k = k_start;
-        all_algs.REVD2.call(blas::Uplo::Upper, m, all_data.A.data(), k, tol, all_data.V, all_data.eigvals, state);
+        all_algs.revd2.call(blas::Uplo::Upper, m, all_data.A.data(), k, tol, all_data.V, all_data.eigvals, state);
 
         T* E_dat = RandLAPACK::util::upsize(k * k, all_data.E);
         T* Buf_dat = RandLAPACK::util::upsize(m * k, all_data.Buf);
@@ -190,8 +190,8 @@ class TestREVD2 : public ::testing::Test
         auto m = all_data.dim;
 
         int64_t k = k_start;
-        all_algs.REVD2.call(blas::Uplo::Upper, m, all_data.A_u.data(), k, tol, all_data.V_u, all_data.eigvals_u, state);
-        all_algs.REVD2.call(blas::Uplo::Lower, m, all_data.A_l.data(), k, tol, all_data.V_l, all_data.eigvals_l, state);
+        all_algs.revd2.call(blas::Uplo::Upper, m, all_data.A_u.data(), k, tol, all_data.V_u, all_data.eigvals_u, state);
+        all_algs.revd2.call(blas::Uplo::Lower, m, all_data.A_l.data(), k, tol, all_data.V_l, all_data.eigvals_l, state);
 
         T* E_u_dat = RandLAPACK::util::upsize(k * k, all_data.E_u);
         T* E_l_dat = RandLAPACK::util::upsize(k * k, all_data.E_l);

--- a/test/drivers/test_revd2.cc
+++ b/test/drivers/test_revd2.cc
@@ -77,7 +77,7 @@ class TestREVD2 : public ::testing::Test
     struct algorithm_objects {
         RandLAPACK::SYPS<T, RNG> SYPS;
         RandLAPACK::HQRQ<T> Orth_RF; 
-        RandLAPACK::SYRF<T, RNG> SYRF;
+        RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>, T, RNG> SYRF;
         //  ^ Needs a symmetric power skether and an orthogonalizer
         RandLAPACK::REVD2<T, RNG> REVD2;
         //  ^ Needs a symmetric rangefinder.

--- a/test/drivers/test_revd2.cc
+++ b/test/drivers/test_revd2.cc
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <gtest/gtest.h>
 
+
 class TestREVD2 : public ::testing::Test
 {
     protected:
@@ -75,12 +76,13 @@ class TestREVD2 : public ::testing::Test
 
     template <typename T, typename RNG>
     struct algorithm_objects {
-        RandLAPACK::SYPS<T, RNG> SYPS;
-        RandLAPACK::HQRQ<T> Orth_RF; 
-        RandLAPACK::SYRF<RandLAPACK::SYPS<T, RNG>, T, RNG> SYRF;
-        //  ^ Needs a symmetric power skether and an orthogonalizer
-        RandLAPACK::REVD2<T, RNG> REVD2;
-        //  ^ Needs a symmetric rangefinder.
+        using SYPS_t = RandLAPACK::SYPS<T, RNG>;
+        using SYRF_t = RandLAPACK::SYRF<SYPS_t>;
+        using Orth_t = RandLAPACK::HQRQ<T>;
+        SYPS_t SYPS;
+        Orth_t Orth; 
+        SYRF_t SYRF;
+        RandLAPACK::REVD2<SYRF_t> REVD2;
 
 
         algorithm_objects(
@@ -91,8 +93,8 @@ class TestREVD2 : public ::testing::Test
             int64_t num_steps_power_iter_error_est
         ) : 
             SYPS(num_syps_passes, passes_per_syps_stabilization, verbose, cond_check),
-            Orth_RF(cond_check, verbose),
-            SYRF(SYPS, Orth_RF, verbose, cond_check),
+            Orth(cond_check, verbose),
+            SYRF(SYPS, Orth, verbose, cond_check),
             REVD2(SYRF, num_steps_power_iter_error_est, verbose)
             {}
     };


### PR DESCRIPTION
Changes
* Defined a SymmetricLinearOperator C++20 concept. It only requires that conforming types have an int64_t "dim" member and that operator() is implemented with a certain signature. Removed the base classes for ``ExplicitSymLinOp`` and ``RegExplicitSymLinOp``.
* Remove base classes for SYPS, SYRF, and REVD2. The purposes of these base classes can be handled in a simpler way by changing how we template REVD2 and SYRF.
* Adopt a new naming convention for members of algorithm classes. This is best exemplified with SYRF. It takes two template parameters: ``SYPS_t`` and ``Orth_t``, which are the types of instance variables called ``syps`` and ``orth`` --- note the lower case. At present, the only valid choice for ``SYPS_t`` is ``RandLAPACK::SYPS<T,RNG>`` for some scalar type ``T`` and CBRNG type ``RNG``. The suffix "_t" in ``SYPS_t`` helps distinguish between the abstract template parameter with our available implementation in the templated ``RandLAPACK::SYPS`` type.
* I've moved some function implementations inside the original class definition. (Before the class definition only contained function signatures. That style is unnecessary given that RandLAPACK has implementations in the header files.)