### PR TITLE
Making sure RandLAPACK GPU functions arre in-line with RandBLAS 1.0.1

### DIFF
--- a/RandLAPACK/drivers/rl_cqrrpt_gpu.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt_gpu.hh
@@ -201,9 +201,10 @@ int CQRRPT_GPU<T, RNG>::call(
     // I will avoid performing skething on a GPU for now
 
     /// Generating a SASO
-    RandBLAS::SparseDist DS = {.n_rows = d, .n_cols = m, .vec_nnz = this->nnz};
+    RandBLAS::SparseDist DS(d, m, this->nnz);
     RandBLAS::SparseSkOp<T, RNG> S(DS, state);
-    state = RandBLAS::fill_sparse(S);
+    RandBLAS::fill_sparse(S);
+    state = S.next_state;
 
     /// Applying a SASO
     RandBLAS::sketch_general(

--- a/test/comps/test_util_gpu.cu
+++ b/test/comps/test_util_gpu.cu
@@ -517,9 +517,9 @@ TEST_F(TestUtil_GPU, test_ger_gpu) {
     m_info.exponent = 2.0;
     RandLAPACK::gen::mat_gen<double, r123::Philox4x32>(m_info, all_data.A.data(), state); 
     RandBLAS::DenseDist D1(n, n);
-    state = RandBLAS::fill_dense(D1, all_data.y.data(), state).second;
+    state = RandBLAS::fill_dense(D1, all_data.y.data(), state);
     RandBLAS::DenseDist D2(1, m);
-    state = RandBLAS::fill_dense(D2, all_data.x.data(), state).second;
+    state = RandBLAS::fill_dense(D2, all_data.x.data(), state);
     
     ger_gpu(alpha, all_data);
 }

--- a/test/drivers/bench_bqrrp_gpu.cu
+++ b/test/drivers/bench_bqrrp_gpu.cu
@@ -104,7 +104,7 @@ class BenchBQRRP : public ::testing::TestWithParam<int64_t>
         all_data.A_sk = ( T * ) calloc( d * n, sizeof( T ) );
         T* S          = ( T * ) calloc( d * m, sizeof( T ) );
         RandBLAS::DenseDist D(d, m);
-        RandBLAS::fill_dense(D, S, state_const).second;
+        RandBLAS::fill_dense(D, S, state_const);
         blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, d, n, m, 1.0, S, d, all_data.A.data(), m, 0.0, all_data.A_sk, d);
         cudaMemcpy(all_data.A_sk_device, all_data.A_sk, d * n * sizeof(double), cudaMemcpyHostToDevice);
         RandLAPACK::BQRRP_GPU<double, r123::Philox4x32> BQRRP_GPU_QRF(profile_runtime, block_size);

--- a/test/drivers/test_bqrrp_gpu.cu
+++ b/test/drivers/test_bqrrp_gpu.cu
@@ -97,7 +97,7 @@ class TestBQRRP : public ::testing::TestWithParam<int64_t>
         // Skethcing in an sampling regime
         T* S  = ( T * ) calloc( d * m, sizeof( T ) );
         RandBLAS::DenseDist D(d, m);
-        RandBLAS::fill_dense(D, S, state_const).second;
+        RandBLAS::fill_dense(D, S, state_const);
         blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, d, n, m, 1.0, S, d, all_data.A.data(), m, 0.0, all_data.A_sk.data(), d);
         free(S);
         cudaMemcpy(all_data.A_sk_device, all_data.A_sk.data(), d * n * sizeof(double), cudaMemcpyHostToDevice);


### PR DESCRIPTION
Quick fixes to a couple of places that were missed in PR #93.
This exposes the need for GPU integration in our CI and the need to move GPU benchmarks away from tests.