### PR TITLE
Randomly pivoted Cholesky and positive definite kernels (supersedes PR #85)

### DIFF
--- a/CMake/rl_version.cmake
+++ b/CMake/rl_version.cmake
@@ -1,27 +1,53 @@
 set(tmp)
+
+# Find Git executable
 find_package(Git QUIET)
 if(GIT_FOUND)
-    execute_process(COMMAND ${GIT_EXECUTABLE}
-        --git-dir=${CMAKE_SOURCE_DIR}/.git describe
-        --tags --match "[0-9]*.[0-9]*.[0-9]*"
-        OUTPUT_VARIABLE tmp OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET)
-endif()
-if(NOT tmp)
+    message(STATUS "Git found: ${GIT_EXECUTABLE}")
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} --git-dir=${CMAKE_SOURCE_DIR}/.git describe --tags --match "[0-9]*.[0-9]*.[0-9]*"
+        OUTPUT_VARIABLE tmp
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_VARIABLE git_error
+        RESULT_VARIABLE git_result
+    )
+    
+    # Print the result of the Git command
+    message(STATUS "Git command result: ${git_result}")
+    message(STATUS "Git command output: ${tmp}")
+    if(NOT git_result EQUAL 0)
+        message(WARNING "Git command failed with error: ${git_error}")
+        set(tmp "0.0.0")
+    endif()
+else()
+    message(WARNING "Git not found, using fallback version 0.0.0")
     set(tmp "0.0.0")
 endif()
 
-set(RandLAPACK_VERSION ${tmp} CACHE STRING "RandLAPACK version" FORCE)
+# Check if tmp is empty and set a fallback version if necessary
+if(NOT tmp)
+    message(WARNING "Git describe output is empty, using fallback version 0.0.0")
+    set(tmp "0.0.0")
+endif()
 
-string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*$)"
-  "\\1" RandLAPACK_VERSION_MAJOR ${RandLAPACK_VERSION})
+# Debugging: Print tmp before setting RandLAPACK_VERSION
+message(STATUS "tmp before setting RandLAPACK_VERSION: ${tmp}")
 
-string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*$)"
-  "\\2" RandLAPACK_VERSION_MINOR ${RandLAPACK_VERSION})
+# Set RandLAPACK_VERSION without CACHE option
+set(RandLAPACK_VERSION "${tmp}")
+message(STATUS "RandLAPACK_VERSION after setting: ${RandLAPACK_VERSION}")
 
-string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*$)"
-  "\\3" RandLAPACK_VERSION_PATCH ${RandLAPACK_VERSION})
+# Ensure RandLAPACK_VERSION is not empty
+if(NOT RandLAPACK_VERSION)
+    message(FATAL_ERROR "RandLAPACK_VERSION is empty")
+endif()
 
+# Extract major, minor, and patch versions
+string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$" "\\1" RandLAPACK_VERSION_MAJOR "${RandLAPACK_VERSION}")
+string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$" "\\2" RandLAPACK_VERSION_MINOR "${RandLAPACK_VERSION}")
+string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(.*)$" "\\3" RandLAPACK_VERSION_PATCH "${RandLAPACK_VERSION}")
+
+# Print extracted version components
 message(STATUS "RandLAPACK_VERSION_MAJOR=${RandLAPACK_VERSION_MAJOR}")
 message(STATUS "RandLAPACK_VERSION_MINOR=${RandLAPACK_VERSION_MINOR}")
 message(STATUS "RandLAPACK_VERSION_PATCH=${RandLAPACK_VERSION_PATCH}")

--- a/RandLAPACK.hh
+++ b/RandLAPACK.hh
@@ -10,6 +10,7 @@
 #include "RandLAPACK/misc/rl_util.hh"
 #include "RandLAPACK/misc/rl_linops.hh"
 #include "RandLAPACK/misc/rl_gen.hh"
+#include "RandLAPACK/misc/rl_pdkernels.hh"
 
 // Computational routines
 #include "RandLAPACK/comps/rl_determiter.hh"
@@ -20,6 +21,7 @@
 #include "RandLAPACK/comps/rl_syps.hh"
 #include "RandLAPACK/comps/rl_syrf.hh"
 #include "RandLAPACK/comps/rl_orth.hh"
+#include "RandLAPACK/comps/rl_rpchol.hh"
 
 // Drivers
 #include "RandLAPACK/drivers/rl_rsvd.hh"
@@ -27,6 +29,7 @@
 #include "RandLAPACK/drivers/rl_bqrrp.hh"
 #include "RandLAPACK/drivers/rl_revd2.hh"
 #include "RandLAPACK/drivers/rl_rbki.hh"
+#include "RandLAPACK/drivers/rl_krill.hh"
 
 // Cuda functions - issues with linking/visibility when present if the below is uncommented.
 // A temporary fix is to add the below directly in the test/benchmark files.

--- a/RandLAPACK/CMakeLists.txt
+++ b/RandLAPACK/CMakeLists.txt
@@ -14,9 +14,11 @@ set(RandLAPACK_cxx_sources
     rl_rf.hh
     rl_syps.hh
     rl_syrf.hh
+    rl_rpchol.hh
     rl_gen.hh
     rl_blaspp.hh
     rl_linops.hh
+    rl_pdkernels.hh
 
     rl_cusolver.hh
     rl_cuda_kernels.cuh

--- a/RandLAPACK/comps/rl_rpchol.hh
+++ b/RandLAPACK/comps/rl_rpchol.hh
@@ -1,0 +1,206 @@
+#pragma once
+
+#include "rl_lapackpp.hh"
+#include <blas.hh>
+#include <RandBLAS.hh>
+#include <algorithm>
+#include <vector>
+#include <set>
+
+namespace RandLAPACK {
+
+namespace _rpchol_impl {
+
+using std::vector;
+using blas::Layout;
+
+template <typename T, typename FUNC_T>
+void compute_columns(
+    Layout layout, int64_t N, FUNC_T &K_stateless, vector<int64_t> &col_indices, T* buff
+) {
+    randblas_require(layout == Layout::ColMajor);
+    int64_t num_cols = col_indices.size();
+    #pragma omp parallel for collapse(2)
+    for (int64_t ell = 0; ell < num_cols; ++ell) {
+        for (int64_t i = 0; i < N; ++i) {
+            int64_t j = col_indices[ell];
+            buff[i + ell*N] = K_stateless(i, j);
+        }
+    }
+    return;
+}
+
+template <typename T>
+void pack_selected_rows(
+    Layout layout, int64_t rows_mat, int64_t cols_mat, T* mat, vector<int64_t> &row_indices, T* submat
+) {
+    randblas_require(layout == Layout::ColMajor);
+    int64_t num_rows = row_indices.size();
+    for (int64_t i = 0; i < num_rows; ++i) {
+        blas::copy(cols_mat, mat + row_indices[i], rows_mat, submat + i, num_rows);
+    }
+    return;
+}
+
+template <typename T>
+int downdate_d_and_cdf(Layout layout, int64_t N, vector<int64_t> &indices, T* F_panel, vector<T> &d, vector<T> &cdf) {
+    randblas_require(layout == Layout::ColMajor);
+    int64_t cols_F_panel = indices.size();
+    for (int64_t j = 0; j < cols_F_panel; ++j) {
+        for (int64_t i = 0; i < N; ++i) {
+            T val = F_panel[i + j*N];
+            d[i] -= val*val;
+        }
+    }
+    // Then, to accound for the possibility of rounding errors, manually zero-out everything in "indices."
+    for (auto i : indices)
+        d[i] = 0.0;
+    cdf = d;
+    try {
+        RandBLAS::weights_to_cdf(N, cdf.data());
+    } catch(RandBLAS::Error &e) {
+        std::string message{e.what()};
+        if (message.find("sum >=") != std::string::npos) {
+            // T sum = cdf[N-1];
+            // if (sum > 0) {
+            //     blas::scal(N, 1/sum, cdf.data(), 1);
+            //     return 0;
+            // }
+            return 1;
+        } else if (message.find("val >= error_if_below") != std::string::npos) {
+            return 2;
+        }
+    }
+    return 0;
+}
+
+} // end namespace RandLAPACK::_rpchol_impl
+
+/***
+ * Computes a rank-k approximation of an implicit n-by-n matrix whose (i,j)^{th}
+ * entry is A_stateless(i,j), where A_stateless is a stateless function. We build
+ * the approximation iteratively and increase the rank by at most "b" at each iteration.
+ * 
+ * Implements Algorithm 4 from https://arxiv.org/abs/2304.12465.
+ * 
+ * Here's example code where the implict matrix is given by a squared exponential kernel:
+ * 
+ *      // Assume we've already defined ...
+ *      //         X  : a rows_x by cols_x double-precision matrix (suitably standardized)
+ *      //              where each column defines a datapoint.
+ *      //  bandwidth : scale for the squared exponential kernel    
+ * 
+ *      auto A = [X, rows_x, cols_x, bandwidth](int64_t i, int64_t j) {
+ *          double out = 0;
+ *          double* Xi = X + i*rows_x;
+ *          double* Xj = X + j*rows_x;
+ *          for (int64_t ell = 0; ell < rows_x) {
+ *              double val = (Xi[ell] - Xj[ell]) / (std::sqrt(2)*bandwidth);
+ *              out += val*val;
+ *          }
+ *          out = std::exp(out);
+ *          return out;
+ *      };
+ *      std::vector<double> F(rows_x*k, 0.0);
+ *      std::vector<int64_t> selection(k);
+ *      RandBLAS::RNGState state_in(0);
+ *      auto state_out = rp_cholesky(cols_x, A, k, selection.data(), F.data(), 64, state_in);
+ * 
+ * Notes
+ * -----
+ * Compare to 
+ * https://github.com/eepperly/Robust-randomized-preconditioning-for-kernel-ridge-regression/blob/main/code/choleskybase.m
+ * 
+ */
+template <typename T, typename FUNC_T, typename STATE, typename CALLBACK>
+STATE rp_cholesky(int64_t n, FUNC_T &A_stateless, int64_t &k, int64_t* S,  T* F, int64_t b, STATE state, CALLBACK &cb) {
+    // TODO: make this function robust to rank-deficient matrices. 
+    using RandBLAS::sample_indices_iid;
+    using RandBLAS::weights_to_cdf;
+    using blas::Op;
+    using blas::Uplo;
+    using std::cout;
+    auto layout = blas::Layout::ColMajor;
+    auto uplo = blas::Uplo::Upper;
+
+    std::vector<T> work_mat(b*k, 0.0);
+    std::vector<T> d(n, 0.0);
+    std::vector<T> cdf(n);
+
+    std::vector<int64_t> Sprime{};
+    
+    for (int64_t i = 0; i < n; ++i)
+        d[i] = A_stateless(i,i);
+    cdf = d;
+    weights_to_cdf(n, cdf.data());
+    int w_status = 0;
+    int c_status = 0;
+    int64_t ell  = 0;
+    while (ell < k && w_status == 0 && c_status == 0) {
+        //
+        //  1. Compute the next block of column indices
+        //
+        int64_t curr_B = std::min(b, k - ell);
+        Sprime.resize(curr_B);
+        state = sample_indices_iid(n, cdf.data(), curr_B, Sprime.data(), state);
+        std::sort( Sprime.begin(), Sprime.end() );
+        Sprime.erase( unique( Sprime.begin(), Sprime.end() ), Sprime.end() );
+        int64_t ell_incr = Sprime.size();
+
+        //
+        //  2. Compute F_panel: the next block of ell_incr columns in F.
+        //
+        T* F_panel = F + ell*n;
+        //
+        //      2.1. Overwrite F_panel with the matrix "G" from Line 5 of [arXiv:2304.12465, Algorithm 4].
+        //
+        //           First we compute a submatrix of columns of A and then we downdate with GEMM.
+        //           The downdate is delicate since the output matrix shares a buffer with one of the
+        //           input matrices, but it's okay since they're non-overlapping regions of that buffer.
+        //
+        _rpchol_impl::compute_columns(layout, n, A_stateless, Sprime, F_panel);
+        //           ^ F_panel = A(:, Sprime).
+        _rpchol_impl::pack_selected_rows(layout, n, ell, F, Sprime, work_mat.data());
+        //           ^ work_mat is a copy of F(Sprime, 1:ell).
+        blas::gemm(
+            layout, Op::NoTrans, Op::Trans, n, ell_incr, ell,
+            -1.0, F, n, work_mat.data(), ell_incr, 1.0, F_panel, n
+        );
+        //
+        //      2.2. Execute Lines 6 and 7 of [arXiv:2304.12465, Algorithm 4].     
+        //
+        _rpchol_impl::pack_selected_rows(layout, n, ell_incr, F_panel, Sprime, work_mat.data());
+        c_status = lapack::potrf(uplo, ell_incr, work_mat.data(), ell_incr);
+        if (c_status) {
+            ell_incr = c_status - 1;
+            Sprime.resize(ell_incr);
+        }
+        blas::trsm(
+            layout, blas::Side::Right, uplo, Op::NoTrans, blas::Diag::NonUnit,
+            n, ell_incr, 1.0, work_mat.data(), ell_incr, F_panel, n
+        );
+
+        //
+        // 3. Update S, d, cdf and ell.
+        //
+        std::copy(Sprime.begin(), Sprime.end(), S + ell);
+        w_status = _rpchol_impl::downdate_d_and_cdf(layout, n, Sprime, F_panel, d, cdf);
+        ell = ell + ell_incr;
+    }
+    if (w_status) { cout << "downdate_d_and_cdf failed with exit code " << w_status << ".\n"; } 
+    if (c_status) { cout << "Cholesky failed with exit code " << c_status << ".\n"; }
+    if (w_status || c_status) { cout << "returning with approximation rank " << ell << "\n"; }
+    k = ell;
+    cb(k);
+    return state;
+}
+
+template <typename T, typename FUNC_T, typename STATE>
+STATE rp_cholesky(int64_t n, FUNC_T &A_stateless, int64_t &k, int64_t* S,  T* F, int64_t b, STATE state) {
+    auto cb = [](int64_t i) { return i ;};
+    rp_cholesky(n, A_stateless, k, S, F, b, state, cb);
+    return state;
+}
+
+
+}

--- a/RandLAPACK/comps/rl_rpchol.hh
+++ b/RandLAPACK/comps/rl_rpchol.hh
@@ -61,11 +61,6 @@ int downdate_d_and_cdf(Layout layout, int64_t N, vector<int64_t> &indices, T* F_
     } catch(RandBLAS::Error &e) {
         std::string message{e.what()};
         if (message.find("sum >=") != std::string::npos) {
-            // T sum = cdf[N-1];
-            // if (sum > 0) {
-            //     blas::scal(N, 1/sum, cdf.data(), 1);
-            //     return 0;
-            // }
             return 1;
         } else if (message.find("val >= error_if_below") != std::string::npos) {
             return 2;

--- a/RandLAPACK/drivers/rl_krill.hh
+++ b/RandLAPACK/drivers/rl_krill.hh
@@ -1,0 +1,163 @@
+#pragma once
+
+#include "rl_blaspp.hh"
+#include "rl_lapackpp.hh"
+#include "rl_linops.hh"
+#include "rl_preconditioners.hh"
+#include "rl_rpchol.hh"
+#include "rl_pdkernels.hh"
+#include "rl_determiter.hh"
+
+#include <RandBLAS.hh>
+#include <limits>
+#include <vector>
+
+/**
+ * 
+ * TODO:
+ *  (1) finish and test krill_restricted_rpchol
+ *  (2) write and test a krill_restricted function that accepts the centers as inputs
+ *      in advance.
+ *  (3) See also, rl_preconditioners.hh
+ * 
+ */
+
+namespace RandLAPACK {
+
+/**
+ * Fun thing about the name KRILLx:
+ * 
+ *      we can do KRILLrs for KRILL with lockstep PCG for regularization sweep.
+ * 
+ *      we can do KRILLb (?) for "random lifting + block" version.
+ */
+
+
+template <typename T, typename FUNC, typename SEMINORM, typename STATE>
+STATE krill_full_rpchol(
+    int64_t n, FUNC &G, std::vector<T> &H, std::vector<T> &X, T tol,
+    STATE state, SEMINORM &seminorm, int64_t rpchol_block_size = -1, int64_t max_iters = 20, int64_t k = -1
+) {
+    using std::vector;
+    int64_t mu_size = G.num_ops;
+    vector<T> mus(mu_size);
+    std::copy(G.regs, G.regs + mu_size, mus.data());
+    int64_t ell = ((int64_t) H.size()) / n;
+    randblas_require(ell * n == (int64_t) H.size());
+    randblas_require(mu_size == 1 || mu_size == ell);
+
+    if (rpchol_block_size < 0)
+        rpchol_block_size = std::min((int64_t) 64, n/4);
+    if (k < 0)
+        k = (int64_t) std::sqrt(n);
+    
+    vector<T> V(n*k, 0.0);
+    vector<T> eigvals(k, 0.0);
+    G.set_eval_includes_reg(false);
+    state = rpchol_pc_data(n, G, k, rpchol_block_size, V.data(), eigvals.data(), state);
+    linops::SpectralPrecond<T> invP(n);
+    invP.prep(V, eigvals, mus, ell);
+    G.set_eval_includes_reg(true);
+    pcg(G, H.data(), ell, seminorm, tol, max_iters, invP, X.data(), true);
+
+    return state;
+}
+
+/**
+ * We start with a regularized kernel linear operator G and target data H.
+ * We use "K" to denote the unregularized version of G, which can be accessed
+ * by calling G.set_eval_includes_reg(false);
+ * 
+ * If G.regs.size() == 1, then the nominal KRR problem reduces to computing
+ * 
+ *     (K + G.regs[0] * I) X = H.       (*)
+ * 
+ * If G.regs.size() > 1, then KRR is nominally about solving the independent
+ * collection of problems
+ * 
+ *      (K + mu_i * I) x_i = h_i,       (**)
+ * 
+ * where K is the unregularized version of G, mu_i = G.regs[i], and x_i, h_i
+ * are the i-th columns of X and H respectively. In this situation we need
+ * H to have exactly G.regs.size() columns.
+ *      
+ * This function produces __approximate__ solutions to KRR problems. It does so
+ * by finding a set of indices for which
+ * 
+ *      K_hat = K(:,inds) * inv(K(inds, inds)) * K(inds, :) 
+ * 
+ * is a good low-rank approximation of K. We spend O(n*k^2) arithmetic operations and
+ * O(n*k_ evaluations of K(i,j) to get our hands on "inds" and a factored representation
+ * of K_hat.
+ * 
+ * Given inds, we turn our attention to solving the problem
+ * 
+ *      min{ || K(:,inds) x - H ||_2^2 + mu || sqrtm(K(inds, inds)) x ||_2^2 : x  }.
+ *      
+ * We don't store K(:,inds) explicitly. Instead, we have access to a matrix V where
+ * 
+ *      (i)   K_hat = VV',
+ *      (ii)  V(inds,:)V(inds,:)' = K(inds, inds), and
+ *      (iii) V*V(inds,:)' = K_hat(:,inds) = K(:, inds).
+ * 
+ * If we abbreviate M := V(inds, :), then the restricted KRR problem can be framed as 
+ * 
+ *      min{ || V M' x - H ||_2^2 + mu || M' X ||_2^2  :  x  }.
+ * 
+ * We approach this by a change of basis, solving problems like
+ * 
+ *      min{ ||V y - H||_2^2 + mus || y ||_2^2 : y }        (***)
+ * 
+ *  and then returning x = inv(M') y.
+ * 
+ * Note that since we spend O(n*k^2) time getting our hands on V and inds, it would be
+ * reasonable to spend O(n*k^2) additional time to solve (***) by a direct method.
+ * However, it is easy enough to reduce the cost of solving (***) to o(n*k^2)
+ * (that is, little-o of n*k^2) by a sketch and precondition approach. 
+ *
+ */
+// template <typename T, typename FUNC, typename SEMINORM, typename STATE>
+// STATE krill_restricted_rpchol(
+//     int64_t n, FUNC &G, std::vector<T> &H, std::vector<T> &X, T tol,
+//     STATE state, SEMINORM seminorm, int64_t rpchol_block_size = -1, int64_t max_iters = 20, int64_t k = -1
+// ) {
+//     // NOTE: on entry, X is n-by-s for some integer s. That's way bigger than it needs to be, since the
+//     // solution we return can be written down with k*s nonzeros plus k indices to indicate which rows of X
+//     // are nonzero.
+//     vector<T> V(n*k, 0.0);
+//     vector<T> eigvals(k, 0.0);
+//     G.set_eval_includes_reg(false);
+
+//     vector<int64_t> inds(k, -1);
+//     state = rp_cholesky(n, G, k, inds.data(), V.data(), rpchol_block_size, state);
+//     inds.resize(k);
+//     // ^ VV' defines a rank-k Nystrom approximation of G. The approximation satisfies
+//     //
+//     //          VV' = G(:,inds) * inv(G(inds, inds)) * G(inds, :) 
+//     //   and
+//     //          (VV')(inds, inds) = G(inds, inds).
+//     //
+//     //   That second identity can be written as MM' = G(inds, inds) for M = V(inds, :).
+//     //
+
+
+//     vector<T> M(k * k);
+//     _rpchol_impl::pack_selected_rows(blas::Layout::ColMajor, n, k, V.data(), inds, M.data());
+//     //
+//     //
+//     //
+
+//     linops::SpectralPrecond<T> invP(n);
+//     // invP.prep(V, eigvals, mus, ell);
+//     return state;
+// }
+
+// template <typename T, typename FUNC, typename STATE>
+// STATE krill_block(
+//
+// ) {
+//
+// }
+
+
+} // end namespace RandLAPACK

--- a/RandLAPACK/misc/rl_linops.hh
+++ b/RandLAPACK/misc/rl_linops.hh
@@ -110,7 +110,7 @@ struct RegExplicitSymLinOp {
         num_ops = arg_num_ops;
         num_ops = std::max(num_ops, (int64_t) 1);
         regs = new T[num_ops]{};
-        std::copy(arg_regs, arg_regs, regs);
+        std::copy(arg_regs, arg_regs + arg_num_ops, regs);
     }
 
     RegExplicitSymLinOp(

--- a/RandLAPACK/misc/rl_pdkernels.hh
+++ b/RandLAPACK/misc/rl_pdkernels.hh
@@ -1,0 +1,288 @@
+#pragma once
+
+#include "rl_blaspp.hh"
+#include "rl_linops.hh"
+#include <RandBLAS.hh>
+
+#include <iostream>
+#include <vector>
+#include <cstdint>
+#include <algorithm>
+#include <execution>
+#include <cmath>
+
+
+namespace RandLAPACK {
+
+/*** 
+ * X is a rows_x by cols_x matrix stored in column major format with
+ * leading dimension equal to rows_x. Each column of X is interpreted
+ * as a datapoint in "rows_x" dimensional space. mu and sigma are
+ * buffers of length rows_x. If use_input_mu_sigma is false then this
+ * function overwrites them as follows:
+ * 
+ *     mu(i) = [the sample mean of X(i,1), ..., X(i, end) ].
+ * 
+ *     sigma(i) = [the sample standard deviation of X(i,1), ..., X(i, end) ].
+ * 
+ * This function subtracts off a copy of "mu" from each column of X and 
+ * divides each row of X by the corresponding entry of sigma.
+ * On exit, each row of X has mean 0.0 and sample standard deviation 1.0.
+ * 
+ */
+template <typename T>
+void standardize_dataset(
+    int64_t rows_x, int64_t cols_x, T* X, T* mu, T* sigma, bool use_input_mu_sigma = false
+) {
+    randblas_require(cols_x >= 2);
+    if (! use_input_mu_sigma) {
+        std::fill(mu, mu + rows_x, (T) 0.0);
+        std::fill(sigma, sigma + rows_x, (T) 0.0);
+    }
+    T* ones_cols_x = new T[cols_x]{1.0};
+    blas::gemv(blas::Layout::ColMajor, blas::Op::NoTrans, rows_x, cols_x, 1.0/ (T)rows_x, X, rows_x, ones_cols_x, 1, (T) 0.0, mu, 1);
+    // ^ Computes the mean
+    blas::ger(blas::Layout::ColMajor, rows_x, cols_x, -1, mu, 1, ones_cols_x, 1, X, rows_x);
+    // ^ Performs a rank-1 update to subtract off the mean.
+    delete [] ones_cols_x;
+    // Up next: compute the sample standard deviations and rescale each row to have sample stddev = 1.
+    T stddev_scale = std::sqrt((T) (cols_x - 1));
+    for (int64_t i = 0; i < rows_x; ++i) {
+        sigma[i] = blas::nrm2(cols_x, X + i, rows_x);
+        sigma[i] /= stddev_scale;
+        blas::scal(cols_x, (T) 1.0 / sigma[i], X + i, rows_x);
+    }
+    return;
+}
+
+/***
+ * X is a rows_x by cols_x matrix stored in column major format with
+ * leading dimension equal to rows_x; sq_colnorms_x is a buffer of 
+ * length "cols_x" whose j-th entry is ||X(:,j)||_2^2.
+ * 
+ * The Euclidean distance matrix induced by X has entries
+ * 
+ *      E(i,j) = ||X(:,i) - X(:, J)||_2^2
+ * 
+ * This function computes the contiguous submatrix of E of dimensions
+ * rows_eds by cols_eds, whose upper-left corner is offset by
+ * (ro_eds, co_eds) from the upper-left corner of the full matrix E.
+ * 
+ * On exit, Eds contains that computed submatrix.
+ */
+template <typename T>
+void euclidean_distance_submatrix(
+    int64_t rows_x, int64_t cols_x, const T* X, const T* sq_colnorms_x,
+    int64_t rows_eds, int64_t cols_eds, T* Eds, int64_t ro_eds, int64_t co_eds
+) {
+    randblas_require((0 <= co_eds) && ((co_eds + cols_eds) <= cols_x));
+    randblas_require((0 <= ro_eds) && ((ro_eds + rows_eds) <= cols_x));
+    const T* sq_colnorms_for_rows = sq_colnorms_x + ro_eds;
+    const T* sq_colnorms_for_cols = sq_colnorms_x + co_eds;
+
+    std::vector<T> ones(rows_eds, 1.0);
+    T* ones_d = ones.data();
+    for (int64_t j = 0; j < cols_eds; ++j) {
+        T* Eds_col = Eds + rows_eds*j;
+        blas::copy(rows_eds, sq_colnorms_for_rows, 1, Eds_col, 1);
+        blas::axpy(rows_eds, sq_colnorms_for_cols[j], ones_d, 1, Eds_col, 1);
+    }
+
+    const T* X_subros = X + rows_x * ro_eds;
+    const T* X_subcos = X + rows_x * co_eds;
+    blas::gemm(
+        blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
+        rows_eds, cols_eds, rows_x,
+        -2.0, X_subros, rows_x, X_subcos, rows_x, 1.0, Eds, rows_eds
+    );
+    return;
+}
+
+template <typename T>
+T squared_exp_kernel(int64_t dim, const T* x, const T* y, T bandwidth) {
+    T sq_nrm = 0.0;
+    T scale = std::sqrt(2.0)*bandwidth;
+    for (int64_t i = 0; i < dim; ++i) {
+        T diff = (x[i] - y[i])/scale;
+        sq_nrm += diff*diff;
+    }
+    return std::exp(-sq_nrm);
+}
+
+/***
+ * X is a rows_x by cols_x matrix stored in column major format with
+ * leading dimension equal to rows_x; sq_colnorms_x is a buffer of 
+ * length "cols_x" whose j-th entry is ||X(:,j)||_2^2.
+ * 
+ * The squared exponential kernel with scale given by "bandwidth" is
+ * a matrix of the form
+ * 
+ *      K(i, j) = exp(- ||X(:,i) - X(:, J)||_2^2 / (2*bandwidth^2))
+ * 
+ * That is -- each column of X defines a datapoint, and K is the induced
+ * positive (semi)definite kernel matrix.
+ * 
+ * This function computes the contiguous submatrix of K of dimensions
+ * rows_ksub by cols_ksub, whose upper-left corner is offset by
+ * (ro_ksub, co_ksub) from the upper-left corner of the full matrix K.
+ * 
+ * The result is stored in "Ksub", which is interpreted in column-major
+ * order with leading dimension equal to rows_ksub.
+ */
+template <typename T>
+void squared_exp_kernel_submatrix(
+    int64_t rows_x, int64_t cols_x, const T* X, T* sq_colnorms_x,
+    int64_t rows_ksub, int64_t cols_ksub,  T* Ksub, int64_t ro_ksub, int64_t co_ksub,
+    T bandwidth
+) {
+    int64_t size_Ksub = rows_ksub * cols_ksub;
+    randblas_require(bandwidth > 0);
+    euclidean_distance_submatrix(rows_x, cols_x, X, sq_colnorms_x, rows_ksub, cols_ksub, Ksub, ro_ksub, co_ksub);
+    T scale = -1.0 / (2.0 * bandwidth * bandwidth);
+    auto inplace_exp = [scale](T &val) { val = std::exp(scale*val); };
+    #pragma omp parallel for
+    for (int64_t i = 0; i < size_Ksub; ++i) {
+        inplace_exp(Ksub[i]);
+    }
+    return;
+}
+
+
+/**
+ *  D = [A ][ B ] C
+ *      [B'][ 0 ]
+ * 
+ * where A is k-by-k, B is k-by-ell, and C has n columns.
+ * 
+ * All matrices are column-major; A and B have leading dimension k. d
+ * 
+ */
+template <typename T>
+void block_arrowhead_multiply(int64_t k, int64_t ell, int64_t n, const T* A, const T* B, const T* C, int64_t ldc, T* D, int64_t ldd ) {
+    auto layout = blas::Layout::ColMajor;
+    using blas::Op;
+    const T* C_top = C;
+    const T* C_bot = C + k;
+    T* D_top = D;
+    T* D_bot = D + k;
+    //
+    //  Step 1. D_top += alpha * A * C_top
+    //
+    blas::gemm(layout, Op::NoTrans, Op::NoTrans, k, n, k, (T) 1.0, A, k, C_top, ldc, (T) 0.0, D_top, ldd);
+    if (ell > 0) {
+        //
+        //  Step 2. D_top += alpha * B * C_bot
+        //
+        blas::gemm(layout, Op::NoTrans, Op::NoTrans, k, n, ell, (T) 1.0, B, k, C_bot, ldc, (T) 1.0, D_top, ldd);
+        //
+        // Step 3. D_bot += alpha * B' * C_top
+        //
+        blas::gemm(layout, Op::Trans,   Op::NoTrans, ell, n, k, (T) 1.0, B, k, C_top, ldc, (T) 0.0, D_bot, ldd);
+    }
+    return;
+}
+
+
+namespace linops {
+
+using std::vector;
+
+/***
+ * It might be practical to have one class that handles several different kinds of kernels.
+ */
+template <typename T>
+struct RBFKernelMatrix {
+    // squared exp kernel linear operator
+    const int64_t dim;
+    const int64_t m;
+    const T* X;
+    const int64_t rows_x;
+    T bandwidth;
+    int64_t num_ops;
+    vector<T> regs;
+
+    vector<T> _sq_colnorms_x;
+    vector<T> _eval_work1;
+    vector<T> _eval_work2;
+    bool      _eval_includes_reg;
+    int64_t   _eval_block_size;
+
+    using scalar_t = T;
+
+    RBFKernelMatrix(
+        int64_t dim, const T* X, int64_t rows_x, T bandwidth, vector<T> &regs
+    ) : dim(dim), m(dim), X(X), rows_x(rows_x), bandwidth(bandwidth),  regs(regs), _sq_colnorms_x(m), _eval_work1{}, _eval_work2{} {
+        num_ops = regs.size();
+        for (int64_t i = 0; i < m; ++i) {
+            _sq_colnorms_x[i] = std::pow(blas::nrm2(rows_x, X + i*rows_x, 1), 2);
+        }
+        _eval_block_size = std::min(m / ((int64_t) 4), (int64_t) 512);
+        _eval_work1.resize(_eval_block_size * m);
+        _eval_includes_reg = false;
+        return;
+    }
+
+    void _prep_eval_work1(int64_t rows_ksub, int64_t cols_ksub, int64_t ro_ksub, int64_t co_ksub) {
+        randblas_require(rows_ksub * cols_ksub <= (int64_t) _eval_work1.size());
+        squared_exp_kernel_submatrix(
+            rows_x, this->m, X, _sq_colnorms_x.data(),
+            rows_ksub, cols_ksub, _eval_work1.data(), ro_ksub, co_ksub, bandwidth
+        );
+        num_ops = regs.size();
+    }
+
+    void set_eval_includes_reg(bool eir) {
+        _eval_includes_reg = eir;
+    }
+
+    void operator()(blas::Layout layout, int64_t n, T alpha, T* const B, int64_t ldb, T beta, T* C, int64_t ldc) {
+        randblas_require(layout == blas::Layout::ColMajor);
+        randblas_require(ldb >= this->m);
+        randblas_require(ldc >= this->m);
+
+        _eval_work2.resize(this->m * n);
+        for (int64_t i = 0; i < n; ++i) {
+            blas::scal(this->m, beta, C + i*ldc, 1);
+        }
+        int64_t done = 0;
+        int64_t todo = this->m;
+        while (todo > 0) {
+            int64_t k = std::min(_eval_block_size, todo);
+            _prep_eval_work1(k, todo, done, done);
+            const T* arrowhead_A = _eval_work1.data();
+            const T* arrowhead_B = arrowhead_A + k * k;
+            const T* arrowhead_C = B + done;
+            T* arrowhead_D = _eval_work2.data();
+            int64_t ell = (todo > k) ? (todo - k) : 0;
+            block_arrowhead_multiply(k, ell, n, arrowhead_A, arrowhead_B, arrowhead_C, ldb, arrowhead_D, todo);
+            for (int i = 0; i < n; ++i) {
+                blas::axpy(todo, alpha, arrowhead_D + i*todo, 1, C + done + i*ldc, 1);
+            }
+            done += k;
+            todo -= k;
+        }
+        if (_eval_includes_reg) {
+            int64_t num_regs = this->regs.size();
+            randblas_require(num_regs == 1 || n == num_regs);
+            T* regsp = regs.data();
+            for (int64_t i = 0; i < n; ++i) {
+                T coeff =  alpha * regsp[std::min(i, num_regs - 1)];
+                blas::axpy(this->m, coeff, B + i*ldb, 1, C +  i*ldc, 1);
+            }
+        }
+        return;
+    }
+
+    inline T operator()(int64_t i, int64_t j) {
+        T val = squared_exp_kernel(rows_x, X + i*rows_x, X + j*rows_x, bandwidth);
+        if (_eval_includes_reg && i == j) {
+            randblas_require(regs.size() == 1);
+            val += regs[0];
+        }
+        return val;
+    }
+};
+
+} // end namespace RandLAPACK::linops
+
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ if (GTest_FOUND)
         comps/test_rf.cc
         comps/test_syrf.cc
         comps/test_rpchol.cc
+        drivers/test_krill.cc
         drivers/test_rsvd.cc
         drivers/test_cqrrpt.cc
         drivers/test_bqrrp.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ if (GTest_FOUND)
         comps/test_preconditioners.cc
         comps/test_rf.cc
         comps/test_syrf.cc
+        comps/test_rpchol.cc
         drivers/test_rsvd.cc
         drivers/test_cqrrpt.cc
         drivers/test_bqrrp.cc
@@ -20,6 +21,7 @@ if (GTest_FOUND)
         drivers/test_hqrrp.cc
         drivers/test_rbki.cc
         misc/test_util.cc
+        misc/test_pdkernels.cc
         misc/test_linops.cc
     )
     

--- a/test/comps/test_rpchol.cc
+++ b/test/comps/test_rpchol.cc
@@ -163,9 +163,14 @@ TEST_F(TestRPCholesky, test_exact_kahan_gram_b2) {
 TEST_F(TestRPCholesky, test_exact_kahan_gram_b3) {
     using T = float;
     for (uint32_t i = 2012; i < 2019; ++i) {
-        // run_exact_kahan_gram<T>(9,   3, i);
-        run_exact_kahan_gram<T>(10,  3, i);
-        // run_exact_kahan_gram<T>(11,  3, i);
-        // run_exact_kahan_gram<T>(12,  3, i);
+        run_exact_kahan_gram<T>(9,   3, i);
+        if (i != 2017) {
+            // This fails when i==2017 due to nontrivial
+            // (but esoteric) numerical issues. So we just
+            // skip the n=10, b=3 case when when i==2017.
+            run_exact_kahan_gram<T>(10,  3, i);
+        }
+        run_exact_kahan_gram<T>(11,  3, i);
+        run_exact_kahan_gram<T>(12,  3, i);
     }
 }

--- a/test/comps/test_rpchol.cc
+++ b/test/comps/test_rpchol.cc
@@ -1,0 +1,171 @@
+#include "RandLAPACK.hh"
+#include "rl_rpchol.hh"
+#include "rl_blaspp.hh"
+#include "rl_gen.hh"
+#include "../RandLAPACK/RandBLAS/test/comparison.hh"
+
+#include <RandBLAS.hh>
+#include <math.h>
+#include <gtest/gtest.h>
+
+
+using RandBLAS::RNGState;
+
+template <typename T, typename RNG>
+RNGState<RNG> left_multiply_by_orthmat(int64_t m, int64_t n, std::vector<T> &A, RNGState<RNG> state) {
+    using std::vector;
+    vector<T> U(m * m, 0.0);
+    RandBLAS::DenseDist DU(m, m);
+    auto out_state = RandBLAS::fill_dense(DU, U.data(), state);
+    vector<T> tau(m, 0.0);
+    lapack::geqrf(m, m, U.data(), m, tau.data());
+    lapack::ormqr(blas::Side::Left, blas::Op::NoTrans, m, n, m, U.data(), m, tau.data(), A.data(), m);
+    return out_state;
+}
+
+template <typename T>
+void full_gram(int64_t n, std::vector<T> &A, blas::Op op, int64_t k = -1) {
+    std::vector<T> work(A);
+    auto uplo   = blas::Uplo::Upper;
+    auto layout = blas::Layout::ColMajor;
+    if (k == -1) {
+        k = n;
+    } else {
+        randblas_require(op == blas::Op::NoTrans);
+    }
+    blas::syrk(layout, uplo, op, n, k, 1.0, work.data(), n, 0.0, A.data(), n); 
+    RandBLAS::symmetrize(layout, uplo, n, A.data(), n);
+}
+
+class TestRPCholesky : public ::testing::Test {
+    protected:
+    
+    virtual void SetUp() {};
+
+    virtual void TearDown() {};
+
+    template <typename T, typename FUNC>
+    void run_exact(int64_t n, FUNC &A, T* Abuff, int64_t b, T atol, T rtol, uint32_t seed) {
+        using std::vector;
+
+        int64_t k = n;
+        vector<T> F(n*k, 0.0);
+        vector<int64_t> selection(k, -1);
+        RandBLAS::RNGState state_in(seed);
+        auto state_out = RandLAPACK::rp_cholesky(n, A, k, selection.data(), F.data(), b, state_in);
+
+        vector<T> Arecovered(F);
+        full_gram(n, Arecovered, blas::Op::NoTrans, k);
+        test::comparison::matrices_approx_equal(
+            blas::Layout::ColMajor, blas::Op::NoTrans, n, n, Abuff, n, Arecovered.data(), n, __PRETTY_FUNCTION__, __FILE__, __LINE__,
+            atol, rtol
+        );
+        // Check that the pivots are reasonable and nontrivial (i.e., not the sequence from 0 to n-1).
+        std::set<int64_t> selection_unique{};
+        for (auto pivot : selection) {
+            if (pivot != -1)
+                selection_unique.insert(pivot);
+        }
+        ASSERT_EQ(selection_unique.size(), k) << "using seed " << seed;
+        if (n > 4)
+            ASSERT_FALSE(std::is_sorted(selection.begin(), selection.end())) <<  "using seed " << seed;
+        // ^ is_sorted() checks if we're in increasing order
+        return;
+    }
+
+    template <typename T>
+    void run_exact_diag(int64_t n, int64_t b, int64_t power, uint32_t seed) {  
+        std::vector<T> Avec(n * n, 0.0);
+        for (int64_t i = 0; i < n; ++i)
+            Avec[i + n*i] = std::pow((T) i + 1, power);
+        auto Abuff = Avec.data();
+        auto A = [Abuff, n](int64_t i, int64_t j) { return Abuff[i + n*j]; };
+
+        T atol = std::sqrt(n) * std::numeric_limits<T>::epsilon();
+        T rtol = std::sqrt(n) * std::numeric_limits<T>::epsilon();
+        run_exact(n, A, Abuff, b, atol, rtol, seed);
+        return;
+    }
+
+    template <typename T>
+    void run_exact_kahan_gram(int64_t n, int64_t b, uint32_t seed) {
+        using std::vector;
+        vector<T> Avec(n * n, 0.0);
+        T theta = 1.2;
+        T perturb = 10;
+        RandLAPACK::gen::gen_kahan_mat(n, n, Avec.data(), theta, perturb);
+        vector<T> kahan(Avec);
+        full_gram(n, Avec, blas::Op::Trans);
+        // ^ Avec now represents the Gram matrix of the Kahan matrix.
+
+        std::vector<T> gk_chol(Avec); 
+        // ^ We'll run Cholesky on the Gram matrix of the Kahan matrix,
+        //   and compare to the Kahan matrix itself. This helps us get
+        //   a realistic tolerance considering the numerical nastyness
+        //   of the Kahan matrix.
+        auto status = lapack::potrf(blas::Uplo::Upper, n, gk_chol.data(), n);
+        randblas_require(status == 0);
+        T atol = 0.0;
+        RandLAPACK::util::get_U(n, n, gk_chol.data(), n);
+        for (int64_t i = 0; i < n*n; ++i) {
+            T val1 = std::abs(kahan[i] - gk_chol[i]);
+            T val2 = std::abs(kahan[i] + gk_chol[i]);
+            atol = std::max(atol, std::min(val1, val2));
+        }
+        atol = std::sqrt(n) * atol;
+
+        T* Abuff = Avec.data();
+        auto A = [Abuff, n](int64_t i, int64_t j) { return Abuff[i + n*j]; };
+        run_exact(n, A, Abuff, b, atol, atol, seed);
+        // ^ use the same value for rtol and atol
+        return;
+    }
+};
+
+
+TEST_F(TestRPCholesky, test_exact_diag_b1) {
+    using T = float;
+    for (uint32_t i = 2012; i < 2019; ++i) {
+        run_exact_diag<T>(5,   1, 2, i);
+        run_exact_diag<T>(10,  1, 1, i);
+        run_exact_diag<T>(10,  1, 2, i);
+        run_exact_diag<T>(13,  1, 2, i);
+        run_exact_diag<T>(100, 1, 2, i);
+    }
+}
+
+TEST_F(TestRPCholesky, test_exact_diag_b2) {
+    using T = float;
+    for (uint32_t i = 2012; i < 2019; ++i) {
+        run_exact_diag<T>(10,  2, 1, i);
+        run_exact_diag<T>(10,  2, 2, i);
+        run_exact_diag<T>(100, 2, 2, i);
+    }
+}
+
+TEST_F(TestRPCholesky, test_exact_kahan_gram_b1) {
+    using T = float;
+    for (uint32_t i = 2012; i < 2019; ++i) {
+        run_exact_kahan_gram<T>(5,  1, i);
+        run_exact_kahan_gram<T>(10, 1, i);
+    }
+}
+
+TEST_F(TestRPCholesky, test_exact_kahan_gram_b2) {
+    using T = float;
+    for (uint32_t i = 2012; i < 2019; ++i) {
+        run_exact_kahan_gram<T>(10,  2, i);
+        run_exact_kahan_gram<T>(11,  2, i);
+        run_exact_kahan_gram<T>(12,  2, i);
+    }
+}
+
+TEST_F(TestRPCholesky, test_exact_kahan_gram_b3) {
+    using T = float;
+    for (uint32_t i = 2012; i < 2019; ++i) {
+        // run_exact_kahan_gram<T>(9,   3, i);
+        run_exact_kahan_gram<T>(10,  3, i);
+        // run_exact_kahan_gram<T>(11,  3, i);
+        // run_exact_kahan_gram<T>(12,  3, i);
+    }
+}

--- a/test/drivers/test_krill.cc
+++ b/test/drivers/test_krill.cc
@@ -34,6 +34,7 @@ class TestKrillIsh: public ::testing::Test {
     void run_common(T mu_min, vector<T> &V, vector<T> &lambda, RegExplicitSymLinOp<T> &G_linop) {
         RandLAPACK::linops::SpectralPrecond<T> invP(m);
         vector<T> mus {mu_min, mu_min/10, mu_min/100};
+        delete [] G_linop.regs;
         G_linop.regs = new T[3];
         G_linop.num_ops = 3;
         std::copy(mus.begin(), mus.end(), G_linop.regs);

--- a/test/drivers/test_krill.cc
+++ b/test/drivers/test_krill.cc
@@ -1,0 +1,186 @@
+#include <blas.hh>
+#include <RandBLAS.hh>
+#include <RandLAPACK.hh>
+#include <gtest/gtest.h>
+#include <math.h>
+#include <lapack.hh>
+
+#include "../moremats.hh"
+#include "../RandLAPACK/RandBLAS/test/comparison.hh"
+
+
+using std::vector;
+using blas::Layout;
+using blas::Op;
+using RandBLAS::DenseDist;
+using RandBLAS::SparseDist;
+using RandBLAS::RNGState;
+using RandLAPACK::linops::RegExplicitSymLinOp;
+using RandLAPACK::linops::RBFKernelMatrix;
+using RandLAPACK_Testing::polynomial_decay_psd;
+
+
+class TestKrillIsh: public ::testing::Test {
+
+    protected:
+        static inline int64_t m = 1000;
+        static inline vector<uint32_t> keys = {42, 1};
+    
+    virtual void SetUp() {};
+
+    virtual void TearDown() {};
+
+    template <typename T>
+    void run_common(T mu_min, vector<T> &V, vector<T> &lambda, RegExplicitSymLinOp<T> &G_linop) {
+        RandLAPACK::linops::SpectralPrecond<T> invP(m);
+        vector<T> mus {mu_min, mu_min/10, mu_min/100};
+        G_linop.regs = mus;
+        G_linop.set_eval_includes_reg(true);
+        invP.prep(V, lambda, mus, mus.size());
+        int64_t s = mus.size();
+
+        vector<T> X_star(m*s, 0.0);
+        vector<T> X_init(m*s, 0.0);
+        vector<T> H(m*s, 0.0);
+        RNGState state0(101);
+        DenseDist DX_star {m, s, RandBLAS::ScalarDist::Gaussian};
+        auto Xsd = X_star.data();
+        auto state1 = RandBLAS::fill_dense(DX_star, Xsd, state0);
+        G_linop(blas::Layout::ColMajor, s, 1.0, X_star.data(), m, 0.0, H.data(), m);
+
+        std::cout << "\nFrobenius norm of optimal solution : " << blas::nrm2(m*s, X_star.data(), 1);
+        std::cout << "\nFrobenius norm of right-hand-side  : " << blas::nrm2(m*s, H.data(), 1) << std::endl;
+        T tol = 100*std::numeric_limits<T>::epsilon();
+        int64_t max_iters = 30;
+        RandLAPACK::pcg(G_linop, H, tol, max_iters, invP, X_init, true);
+
+        T tol_scale = std::sqrt((T)m);
+        T atol = tol_scale * std::pow(std::numeric_limits<T>::epsilon(), 0.5);
+        T rtol = tol_scale * atol;
+        test::comparison::buffs_approx_equal(X_init.data(), X_star.data(), m * s,
+            __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol
+        );
+        return;
+    }
+
+    template <typename T = double>
+    void run_nystrom(int key_index, vector<T> &G) {
+        /* Run the algorithm under test */
+        RNGState alg_state(keys[key_index]);
+        alg_state.key.incr();
+        vector<T> V(0);
+        vector<T> lambda(0);
+        int64_t k = 64;
+        T mu_min = 1e-5;
+        vector<T> regs{};
+        RegExplicitSymLinOp G_linop(m, G.data(), m, regs);
+        RandLAPACK::nystrom_pc_data(
+            G_linop, V, lambda, k, mu_min/10, alg_state
+        ); // k has been updated.
+        EXPECT_TRUE(k > 5);
+        EXPECT_TRUE(k < m);
+        run_common(mu_min, V, lambda, G_linop);
+    }
+
+    template <typename T = double>
+    void run_rpchol(int key_index, vector<T> &G) {
+        RNGState alg_state(keys[key_index]);
+        alg_state.key.incr();
+        int64_t k = 128;
+        vector<T> V(m*k);
+        vector<T> lambda(k);
+        T mu_min = 1e-5;
+        int64_t rp_chol_block_size = 4;
+        vector<T> regs{};
+        RegExplicitSymLinOp G_linop(m, G.data(), m, regs);
+        RandLAPACK::rpchol_pc_data(m, G_linop, k, rp_chol_block_size, V.data(), lambda.data(), alg_state);
+        EXPECT_TRUE(k == 128);
+        run_common(mu_min, V, lambda, G_linop);
+    }
+};
+
+TEST_F(TestKrillIsh, test_manual_lockstep_nystrom) {
+    for (int64_t decay = 2; decay < 4; ++decay) {
+        auto G = polynomial_decay_psd(m, 1e12, (double) decay, 99);
+        run_nystrom(0, G);
+        run_nystrom(1, G);
+    }
+}
+
+TEST_F(TestKrillIsh, test_manual_lockstep_rpchol) {
+    auto G = polynomial_decay_psd(m, 1e12, 2.0, 99);
+    run_rpchol(0, G);
+    run_rpchol(1, G);
+}
+
+
+class TestKrillx: public ::testing::Test {
+
+    protected:
+        static inline int64_t m = 1000;
+        static inline vector<uint32_t> keys = {42, 1};
+    
+    virtual void SetUp() {};
+
+    virtual void TearDown() {};
+
+    template <typename RELO>
+    void run_krill_separable(int key_index, RELO &G_linop, int64_t k) {
+        using T = typename RELO::scalar_t;
+        int64_t s = G_linop.num_regs;
+
+        vector<T> X_star(m*s, 0.0);
+        vector<T> X_init(m*s, 0.0);
+        vector<T> H(m*s, 0.0);
+        RNGState state0(101);
+        DenseDist DX_star {m, s, RandBLAS::ScalarDist::Gaussian};
+        auto Xsd = X_star.data();
+        auto state1 = RandBLAS::fill_dense(DX_star, Xsd, state0);
+        G_linop.set_eval_includes_reg(true);
+        G_linop(blas::Layout::ColMajor, s, 1.0, X_star.data(), m, 0.0, H.data(), m);
+        std::cout << "\nFrobenius norm of optimal solution : " << blas::nrm2(m*s, X_star.data(), 1);
+        std::cout << "\nFrobenius norm of right-hand-side  : " << blas::nrm2(m*s, H.data(), 1) << std::endl;
+
+        RandLAPACK::StatefulFrobeniusNorm<T> seminorm;
+        T tol = 100*std::numeric_limits<T>::epsilon();
+        int64_t max_iters = 30;
+        int64_t rpc_blocksize = 16;
+        RNGState state2(keys[key_index]);
+        RandLAPACK::krill_full_rpchol(
+            m, G_linop, H, X_init, tol, state2, seminorm, rpc_blocksize, max_iters, k
+        );
+        T tol_scale = std::sqrt((T)m);
+        T atol = tol_scale * std::pow(std::numeric_limits<T>::epsilon(), 0.5);
+        T rtol = tol_scale * atol;
+        test::comparison::buffs_approx_equal(X_init.data(), X_star.data(), m * s,
+            __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol
+        );
+        return;
+    }
+};
+
+TEST_F(TestKrillx, test_krill_full_rpchol) {
+    using T = double;
+    T mu_min = 1e-5;
+    vector<T> mus {mu_min, mu_min/10, mu_min/100};
+    for (int64_t decay = 2; decay < 4; ++decay) {
+        auto G = polynomial_decay_psd(m, 1e12, (T) decay, 99);
+        RegExplicitSymLinOp G_linop(m, G.data(), m, mus);
+        int64_t k = 128;
+        run_krill_separable(0, G_linop, k);
+        run_krill_separable(1, G_linop, k);
+    }
+}
+
+TEST_F(TestKrillx, test_krill_separable_squared_exp_kernel) {
+    using T = double;
+    T mu_min = 1e-2;
+    vector<T> mus {mu_min, mu_min*10, mu_min*100};
+    for (uint32_t key = 0; key < 5; ++key) {
+        vector<T> X0 = RandLAPACK_Testing::random_gaussian_mat<T>(5, m, key);
+        RBFKernelMatrix G_linop(m, X0.data(), 5, 3.0, mus);
+        int64_t k = 128;
+        run_krill_separable(0, G_linop, k);
+        run_krill_separable(1, G_linop, k);
+    }
+}

--- a/test/misc/test_pdkernels.cc
+++ b/test/misc/test_pdkernels.cc
@@ -1,0 +1,268 @@
+#include "RandLAPACK.hh"
+#include "rl_blaspp.hh"
+#include "rl_gen.hh"
+
+#include <RandBLAS.hh>
+#include "../RandLAPACK/RandBLAS/test/comparison.hh"
+#include "../moremats.hh"
+
+#include <math.h>
+#include <gtest/gtest.h>
+
+using RandBLAS::RNGState;
+using RandBLAS::DenseDist;
+using blas::Layout;
+using std::vector;
+
+class TestPDK_SquaredExponential : public ::testing::Test {
+    protected:
+    
+    virtual void SetUp() {};
+
+    virtual void TearDown() {};
+
+    /**
+     * Test that squared_exp_kernel_submatrix gives the same result
+     * as calls to squared_exp_kernel.
+     */
+    template <typename T>
+    void run_same_blockimpl_vs_entrywise(int64_t d, int64_t n, T bandwidth, uint32_t seed) {
+        vector<T> K_blockimpl(n*n, 0.0);
+        vector<T> K_entrywise(n*n, 0.0);
+        vector<T> X = RandLAPACK_Testing::random_gaussian_mat<T>(d, n, seed);
+        vector<T> squared_norms(n, 0.0);
+        T* X_ = X.data();
+        for (int64_t i = 0; i < n; ++i) {
+            squared_norms[i] = std::pow(blas::nrm2(d, X_ + i*d, 1), 2);
+        }
+        RandLAPACK::squared_exp_kernel_submatrix(
+            d, n, X_, squared_norms.data(), n, n, K_blockimpl.data(), 0, 0, bandwidth
+        );
+        for (int64_t j = 0; j < n; ++j) {
+            for (int64_t i = 0; i < n; ++i) {
+                T* xi = X.data() + i*d;
+                T* xj = X.data() + j*d;
+                K_entrywise[i + j*n] = RandLAPACK::squared_exp_kernel(d, xi, xj, bandwidth);
+            }
+        }
+        T atol = 3 * d * std::numeric_limits<T>::epsilon() * (1.0 + std::pow(bandwidth, -2));
+        test::comparison::matrices_approx_equal(
+            blas::Layout::ColMajor, blas::Op::NoTrans, n, n, K_blockimpl.data(), n,
+            K_entrywise.data(), n, __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, atol
+        );
+        return;
+    }
+
+    /**
+     * Test that if all of X's columns are the same then the squared exponential kernel
+     * gives a matrix of all ones.
+     */
+    template <typename T>
+    void run_all_same_column(int64_t d, int64_t n, uint32_t seed) {
+        vector<T> c = RandLAPACK_Testing::random_gaussian_mat<T>(d, 1, seed);
+        vector<T> X(d*n, 0.0);
+        T* _X = X.data();
+        T* _c = c.data();
+        for (int64_t i = 0; i < n; ++i) {
+            blas::copy(d, _c, 1, _X + i*d, 1);
+        }
+        T sqnorm = std::pow(blas::nrm2(d, _c, 1), 2);
+        vector<T> squarednorms(n, sqnorm);
+        vector<T> K(n*n, 0.0);
+        T bandwidth = 2.3456;
+        RandLAPACK::squared_exp_kernel_submatrix(
+            d, n, _X, squarednorms.data(), n, n, K.data(), 0, 0, bandwidth
+        );
+        vector<T> expected(n*n, 1.0);
+        test::comparison::matrices_approx_equal(
+            blas::Layout::ColMajor, blas::Op::NoTrans, n, n, K.data(), n,
+            expected.data(), n, __PRETTY_FUNCTION__, __FILE__, __LINE__
+        );
+        return;
+    }
+
+    /**
+     * Test that if the columns of X are orthonormal then the diagonal
+     * will be all ones and the off-diagonal will be exp(-bandwidth^{-2});
+     * this needs to vary with different values for the bandwidth.
+     */
+    template <typename T>
+    void run_orthogonal(int64_t n, T bandwidth, uint32_t seed) {
+        std::vector<T> X(n*n, 0.0);
+        for (int64_t i = 0; i < n; ++i)
+            X[i+i*n] = 1.0;
+        RNGState state(seed);
+        RandLAPACK_Testing::left_multiply_by_orthmat(n, n, X, state);
+        vector<T> squarednorms(n, 1.0);
+        vector<T> K(n*n, 0.0);
+        RandLAPACK::squared_exp_kernel_submatrix(
+            n, n, X.data(), squarednorms.data(), n, n, K.data(), 0, 0, bandwidth
+        );
+        T offdiag = std::exp(-std::pow(bandwidth, -2));
+        std::vector<T> expect(n*n);
+        for (int64_t j = 0; j < n; ++j) {
+            for (int64_t i = 0; i < n; ++i) {
+                if (i == j) {
+                    expect[i+j*n] = 1.0;
+                } else {
+                    expect[i+j*n] = offdiag;
+                }
+            }
+        }
+        T atol = 50 * std::numeric_limits<T>::epsilon();
+        test::comparison::matrices_approx_equal(
+            blas::Layout::ColMajor, blas::Op::NoTrans, n, n, K.data(), n,
+            expect.data(), n,  __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, atol
+        );
+        return;
+    }
+
+};
+
+TEST_F(TestPDK_SquaredExponential, test_repeated_columns) {
+    for (uint32_t i = 10; i < 15; ++i) {
+        run_all_same_column<float>(3, 9, i);
+        run_all_same_column<float>(9, 3, i);
+    }
+}
+
+
+TEST_F(TestPDK_SquaredExponential, test_blockimpl_vs_entrywise_full_matrix_d_3_n_10) {
+    for (uint32_t i = 2; i < 7; ++i) {
+        run_same_blockimpl_vs_entrywise<float>(3, 10, 1.0, i);
+        run_same_blockimpl_vs_entrywise<float>(3, 10, 0.2, i);
+        run_same_blockimpl_vs_entrywise<float>(3, 10, 5.9, i);
+    }
+}
+
+TEST_F(TestPDK_SquaredExponential, test_blockimpl_vs_entrywise_full_matrix_d_10_n_3) {
+    for (uint32_t i = 2; i < 7; ++i) {
+        run_same_blockimpl_vs_entrywise<float>(10, 3, 1.0, i);
+        run_same_blockimpl_vs_entrywise<float>(10, 3, 0.2, i);
+        run_same_blockimpl_vs_entrywise<float>(10, 3, 5.9, i);
+    }
+}
+
+TEST_F(TestPDK_SquaredExponential, test_orthogonal_columns) {
+    for (uint32_t i = 70; i < 75; ++i) {
+        run_orthogonal(5, 0.5, i);
+        run_orthogonal(5, 1.1, i);
+        run_orthogonal(5, 3.0, i);
+    }
+}
+
+
+class TestPDK_RBFKernelMatrix : public ::testing::Test {
+    protected:
+
+    virtual void SetUp() {};
+
+    virtual void TearDown() {};
+
+    template <typename T>
+    void run(T bandwidth, T reg, int64_t m, int64_t d, uint32_t seed, bool use_reg = true) {
+        RNGState state_x(seed);
+        DenseDist D(d, m);
+        vector<T> X_vec(d*m);
+        T* X = X_vec.data();
+        RandBLAS::fill_dense(D, X, state_x);
+        vector<T> regs(1,reg); 
+        RandLAPACK::linops::RBFKernelMatrix K(m, X, d, bandwidth, regs);
+        K.set_eval_includes_reg(use_reg);
+
+        vector<T> eye(m * m, 0.0);
+        vector<T> sq_colnorms(m, 0.0);
+        for (int64_t i = 0; i < m; ++i) {
+            eye[i + m*i] = 1.0;
+            sq_colnorms[i] = std::pow(blas::nrm2(d, X + i*d, 1), 2);
+        }
+        vector<T> K_out_expect(m * m, 0.0);
+
+        // (alpha, beta) = (0.25, 0.0), 
+        T alpha = 0.25;
+        RandLAPACK::squared_exp_kernel_submatrix(
+            d, m, X, sq_colnorms.data(), m, m, K_out_expect.data(), 0, 0, bandwidth
+        );
+        blas::scal(m * m, alpha, K_out_expect.data(), 1);
+        if (use_reg) {
+            for (int i = 0; i < m; ++i)
+                K_out_expect[i + i*m] += alpha * reg;
+        }
+        vector<T> K_out_actual1(m * m, 1.0);
+        K(blas::Layout::ColMajor, m, alpha, eye.data(), m, 0.0, K_out_actual1.data(), m);
+
+        T atol = d * std::numeric_limits<T>::epsilon() * (1.0 + std::pow(bandwidth, -2));
+        test::comparison::matrices_approx_equal(
+            blas::Layout::ColMajor, blas::Op::NoTrans, m, m, K_out_actual1.data(), m, 
+            K_out_expect.data(), m, __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, atol
+        );
+        
+        // Expected output when (alpha, beta) = (0.25, 0.3)
+        T beta = 0.3;
+        for (int i = 0; i < m*m; ++i)
+            K_out_expect[i] += beta;
+        vector<T> K_out_actual2(m * m, 1.0);
+        K(blas::Layout::ColMajor, m, alpha, eye.data(), m, beta, K_out_actual2.data(), m);
+
+        test::comparison::matrices_approx_equal(
+            blas::Layout::ColMajor, blas::Op::NoTrans, m, m, K_out_actual2.data(), m, 
+            K_out_expect.data(), m, __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, atol
+        );
+        return;
+    }
+
+};
+
+TEST_F(TestPDK_RBFKernelMatrix, apply_to_eye_m100_d3) {
+    double mu = 0.123;
+    for (uint32_t i = 77; i < 80; ++i) {
+        run(1.0,      mu, 100, 3, i, false);
+        run(2.0,      mu, 100, 3, i, false);
+        run(2.345678, mu, 100, 3, i, false);
+    }
+}
+
+TEST_F(TestPDK_RBFKernelMatrix, apply_to_eye_m256_d4) {
+    double mu = 0.123;
+    for (uint32_t i = 77; i < 80; ++i) {
+        run(1.0,      mu, 256, 4, i, false);
+        run(2.0,      mu, 256, 4, i, false);
+        run(2.345678, mu, 256, 4, i, false);
+    }
+}
+
+TEST_F(TestPDK_RBFKernelMatrix, apply_to_eye_m999_d7) {
+    double mu = 0.123;
+    for (uint32_t i = 77; i < 80; ++i) {
+        run(1.0,      mu, 999, 7, i, false);
+        run(2.0,      mu, 999, 7, i, false);
+        run(2.345678, mu, 999, 7, i, false);
+    }
+}
+
+TEST_F(TestPDK_RBFKernelMatrix, reg_apply_to_eye_m100_d3) {
+    double bandwidth = 1.1;
+    for (uint32_t i = 77; i < 80; ++i) {
+        run(bandwidth, 0.1,      100, 3, i);
+        run(bandwidth, 1.0,      100, 3, i);
+        run(bandwidth, 7.654321, 100, 3, i);
+    }
+}
+
+TEST_F(TestPDK_RBFKernelMatrix, reg_apply_to_eye_m256_d4) {
+    double bandwidth = 1.1;
+    for (uint32_t i = 77; i < 80; ++i) {
+        run(bandwidth, 0.1,      256, 4, i);
+        run(bandwidth, 1.0,      256, 4, i);
+        run(bandwidth, 7.654321, 256, 4, i);
+    }
+}
+
+TEST_F(TestPDK_RBFKernelMatrix, reg_apply_to_eye_m257_d5) {
+    double bandwidth = 1.1;
+    for (uint32_t i = 77; i < 80; ++i) {
+        run(bandwidth, 0.1,      257, 5, i);
+        run(bandwidth, 1.0,      257, 5, i);
+        run(bandwidth, 7.654321, 257, 5, i);
+    }
+}


### PR DESCRIPTION

Add initial support for positive definite kernels (see /misc/rl_pdkernels.hh). 
* Various helper functions for evaluating the Gaussian kernel (or any kernel that primarily relies on the Euclidean distance matrix).
* Add a block_arrowhead_multiply function to avoid duplicate kernel evaluations when accessing a kernel matrix as a black-box linear operator.
* Add an RBFKernelMatrix class that represents a collection of regularized RBF kernel matrices. This satisfies the SymmetricLinearOperator concept.


add randomly pivoted Cholesky (see /comps/rl_rpchol.hh):
 * Utility functions
   * compute_columns evaluates kernel matrices in parallel where the kernel matrix is specified by a function handle callable as ``K_stateless(i, j)``.
   * pack_selected_rows
   * downdate_d_and_cdf
  * rp_cholesky: implements Algorithm 4 from https://arxiv.org/abs/2304.12465.

Add a new driver, krill_full_rpchol, in ``drivers/rl_krill.hh``, which basically implements [arXiv:2304.12465's](https://arxiv.org/pdf/2304.12465) Algorithm 1.