### PR TITLE
fix compiler warnings under -Wall -Wextra

### DIFF
--- a/RandLAPACK/comps/rl_determiter.hh
+++ b/RandLAPACK/comps/rl_determiter.hh
@@ -401,7 +401,7 @@ void pcg(
     T* scratch = beta    + ss;
     T* ableft  = scratch + ss; 
 
-    T normNR = INFINITY, prevnormNR = INFINITY;
+    T normNR = INFINITY;
 
     auto layout = blas::Layout::ColMajor;
     using blas::Op;
@@ -460,7 +460,6 @@ void pcg(
 
         N(layout, s, 1.0, R, n, 0.0, NR, n
         ); // NR <- N R
-        prevnormNR = normNR;
         normNR = seminorm(n, s, NR);
         if (verbose)
             std::cout << "normNR : " << normNR << "\tnormR : " << normR << "\tk: " << k << "\tdim : " << subspace_dim << '\n';

--- a/RandLAPACK/drivers/rl_abrik.hh
+++ b/RandLAPACK/drivers/rl_abrik.hh
@@ -139,7 +139,7 @@ class ABRIK {
             int64_t m,
             int64_t n,
             SpMat &A,
-            int64_t lda,
+            [[maybe_unused]] int64_t lda,
             int64_t k,
             T* &U,
             T* &V,

--- a/RandLAPACK/drivers/rl_abrik.hh
+++ b/RandLAPACK/drivers/rl_abrik.hh
@@ -139,7 +139,6 @@ class ABRIK {
             int64_t m,
             int64_t n,
             SpMat &A,
-            [[maybe_unused]] int64_t lda,
             int64_t k,
             T* &U,
             T* &V,

--- a/RandLAPACK/linops/rl_composite_linop.hh
+++ b/RandLAPACK/linops/rl_composite_linop.hh
@@ -298,7 +298,6 @@ public:
             // Left multiplication: C := alpha * (LinOp1 * LinOp2) * op(B_sp) + beta * C
 
             // Validate input dimensions
-            auto [rows_B, cols_B] = RandBLAS::dims_before_op(k, n, trans_B);
             auto [rows_comp, cols_comp] = RandBLAS::dims_before_op(m, k, trans_comp);
             randblas_require(rows_comp <= n_rows);
             randblas_require(cols_comp <= n_cols);
@@ -332,7 +331,6 @@ public:
         } else {  // side == Side::Right
             // Right multiplication: C := alpha * op(B_sp) * (LinOp1 * LinOp2) + beta * C
 
-            auto [rows_B, cols_B] = RandBLAS::dims_before_op(m, k, trans_B);
             auto [rows_comp, cols_comp] = RandBLAS::dims_before_op(k, n, trans_comp);
             randblas_require(rows_comp <= n_rows);
             randblas_require(cols_comp <= n_cols);

--- a/RandLAPACK/linops/rl_dense_linop.hh
+++ b/RandLAPACK/linops/rl_dense_linop.hh
@@ -185,7 +185,6 @@ struct DenseLinOp {
 
         if (side == Side::Left) {
             // C = alpha * op(A) * op(B_sp) + beta * C
-            auto [rows_B, cols_B] = RandBLAS::dims_before_op(k, n, trans_B);
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
             randblas_require(rows_A == n_rows);
             randblas_require(cols_A == n_cols);
@@ -199,7 +198,6 @@ struct DenseLinOp {
             RandBLAS::sparse_data::right_spmm(layout, trans_A, trans_B, m, n, k, alpha, A_buff, lda, B_sp, 0, 0, beta, C, ldc);
         } else {  // Side::Right
             // C = alpha * op(B_sp) * op(A) + beta * C
-            auto [rows_B, cols_B] = RandBLAS::dims_before_op(m, k, trans_B);
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
             randblas_require(rows_A == n_rows);
             randblas_require(cols_A == n_cols);

--- a/benchmark/bench_ABRIK/ABRIK_runtime_breakdown_sparse.cc
+++ b/benchmark/bench_ABRIK/ABRIK_runtime_breakdown_sparse.cc
@@ -153,7 +153,7 @@ static void call_all_algs(
 
     for (int i = 0; i < num_runs; ++i) {
         printf("\nBlock size %ld, num matmuls %ld. Iteration %d start.\n", k, num_matmuls, i);
-        ABRIK.call(m, n, *all_data.A_input, m, k, all_data.U, all_data.V, all_data.Sigma, state_alg);
+        ABRIK.call(m, n, *all_data.A_input, k, all_data.U, all_data.V, all_data.Sigma, state_alg);
         
         // Update timing vector
         inner_timing = ABRIK.times;

--- a/benchmark/bench_ABRIK/ABRIK_speed_comparisons_sparse.cc
+++ b/benchmark/bench_ABRIK/ABRIK_speed_comparisons_sparse.cc
@@ -289,7 +289,7 @@ static void call_all_algs(
 
         // Running ABRIK
         auto start_ABRIK = steady_clock::now();
-        all_algs.ABRIK.call(m, n, *all_data.A_input, m, b_sz, all_data.U, all_data.V, all_data.Sigma, state_alg);
+        all_algs.ABRIK.call(m, n, *all_data.A_input, b_sz, all_data.U, all_data.V, all_data.Sigma, state_alg);
         auto stop_ABRIK = steady_clock::now();
         dur_ABRIK = duration_cast<microseconds>(stop_ABRIK - start_ABRIK).count();
         printf("TOTAL TIME FOR ABRIK %ld\n", dur_ABRIK);

--- a/test/comps/test_rpchol.cc
+++ b/test/comps/test_rpchol.cc
@@ -56,8 +56,9 @@ class TestRPCholesky : public ::testing::Test {
                 selection_unique.insert(pivot);
         }
         ASSERT_EQ(selection_unique.size(), k) << "using seed " << seed;
-        if (n > 4)
+        if (n > 4) {
             ASSERT_FALSE(std::is_sorted(selection.begin(), selection.end())) <<  "using seed " << seed;
+        }
         // ^ is_sorted() checks if we're in increasing order
         return;
     }

--- a/test/drivers/test_abrik.cc
+++ b/test/drivers/test_abrik.cc
@@ -138,7 +138,11 @@ class TestABRIK : public ::testing::Test
         auto n = all_data.col;
         ABRIK.max_krylov_iters = (int) ((target_rank * 2) / b_sz);
 
-        ABRIK.call(m, n, all_data.A, m, b_sz, all_data.U, all_data.V, all_data.Sigma, state);
+        if constexpr (std::is_pointer_v<decltype(all_data.A)>) {
+            ABRIK.call(m, n, all_data.A, m, b_sz, all_data.U, all_data.V, all_data.Sigma, state);
+        } else {
+            ABRIK.call(m, n, all_data.A, b_sz, all_data.U, all_data.V, all_data.Sigma, state);
+        }
         
         T residual_err_custom = residual_error_comp<T>(all_data, custom_rank);
         printf("residual_err_custom %e\n", residual_err_custom);

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -135,7 +135,6 @@ class TestCQRRPT : public ::testing::Test
     template <typename T, typename RNG, typename alg_type>
     static void test_CQRRPT_orthogonalization(
         T d_factor,
-        [[maybe_unused]] T norm_A,
         CQRRPTTestData<T> &all_data,
         alg_type &CQRRPT,
         RandBLAS::RNGState<RNG> &state) {
@@ -301,5 +300,5 @@ TEST_F(TestCQRRPT, CQRRPT_orthogonalization_mode_low_rank) {
     RandLAPACK::gen::mat_gen(m_info, all_data.A.data(), state);
 
     norm_and_copy_computational_helper(norm_A, all_data);
-    test_CQRRPT_orthogonalization(d_factor, norm_A, all_data, CQRRPT, state);
+    test_CQRRPT_orthogonalization(d_factor, all_data, CQRRPT, state);
 }

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -135,7 +135,7 @@ class TestCQRRPT : public ::testing::Test
     template <typename T, typename RNG, typename alg_type>
     static void test_CQRRPT_orthogonalization(
         T d_factor,
-        T norm_A,
+        [[maybe_unused]] T norm_A,
         CQRRPTTestData<T> &all_data,
         alg_type &CQRRPT,
         RandBLAS::RNGState<RNG> &state) {

--- a/test/linops/test_linop_block_views.cc
+++ b/test/linops/test_linop_block_views.cc
@@ -786,7 +786,7 @@ protected:
 
     /// Test csr_split_col_blocks: split and verify all blocks are correct.
     template <typename T>
-    void test_csr_col_split(int64_t m, int64_t n, [[maybe_unused]] int64_t k, T density, int64_t num_blocks) {
+    void test_csr_col_split(int64_t m, int64_t n, T density, int64_t num_blocks) {
         RNGState state(42);
         auto A = generate_csr_matrix<T>(m, n, density, state);
 
@@ -860,11 +860,11 @@ TEST_F(TestCSRColBlocks, spmm_last_cols) {
 
 // CSR col-block split tests
 TEST_F(TestCSRColBlocks, split_3_blocks) {
-    test_csr_col_split<double>(20, 15, 10, 0.3, 3);
+    test_csr_col_split<double>(20, 15, 0.3, 3);
 }
 
 TEST_F(TestCSRColBlocks, split_5_blocks) {
-    test_csr_col_split<double>(20, 15, 10, 0.3, 5);
+    test_csr_col_split<double>(20, 15, 0.3, 5);
 }
 
 

--- a/test/linops/test_linop_block_views.cc
+++ b/test/linops/test_linop_block_views.cc
@@ -786,7 +786,7 @@ protected:
 
     /// Test csr_split_col_blocks: split and verify all blocks are correct.
     template <typename T>
-    void test_csr_col_split(int64_t m, int64_t n, int64_t k, T density, int64_t num_blocks) {
+    void test_csr_col_split(int64_t m, int64_t n, [[maybe_unused]] int64_t k, T density, int64_t num_blocks) {
         RNGState state(42);
         auto A = generate_csr_matrix<T>(m, n, density, state);
 

--- a/test/linops/test_linop_unified.cc
+++ b/test/linops/test_linop_unified.cc
@@ -120,9 +120,14 @@ RandLAPACK::linops::DenseLinOp<T> make_operator(
     int64_t rows,
     int64_t cols,
     Layout layout,
-    [[maybe_unused]] T density,  // unused for dense
+    T density,
     RNGState<r123::Philox4x32_R<10>>& state
 ) {
+    // density is required by the templated callers (which dispatch by
+    // OperatorData<TAG> across dense and sparse overloads), but a dense
+    // matrix has no notion of density.
+    UNUSED(density);
+
     data.rows = rows;
     data.cols = cols;
     data.layout = layout;
@@ -140,10 +145,15 @@ RandLAPACK::linops::SparseLinOp<RandBLAS::sparse_data::csc::CSCMatrix<T>> make_o
     OperatorData<SparseCSCOpTag<T>>& data,
     int64_t rows,
     int64_t cols,
-    [[maybe_unused]] Layout layout,  // layout doesn't affect CSC storage
+    Layout layout,
     T density,
     RNGState<r123::Philox4x32_R<10>>& state
 ) {
+    // layout is required by the templated callers (which dispatch by
+    // OperatorData<TAG> across dense and sparse overloads), but CSC
+    // storage is layout-agnostic.
+    UNUSED(layout);
+
     data.rows = rows;
     data.cols = cols;
     // Generate COO then convert to CSC (owned) for SparseLinOp

--- a/test/linops/test_linop_unified.cc
+++ b/test/linops/test_linop_unified.cc
@@ -120,7 +120,7 @@ RandLAPACK::linops::DenseLinOp<T> make_operator(
     int64_t rows,
     int64_t cols,
     Layout layout,
-    T density,  // unused for dense
+    [[maybe_unused]] T density,  // unused for dense
     RNGState<r123::Philox4x32_R<10>>& state
 ) {
     data.rows = rows;
@@ -140,7 +140,7 @@ RandLAPACK::linops::SparseLinOp<RandBLAS::sparse_data::csc::CSCMatrix<T>> make_o
     OperatorData<SparseCSCOpTag<T>>& data,
     int64_t rows,
     int64_t cols,
-    Layout layout,  // layout doesn't affect CSC storage
+    [[maybe_unused]] Layout layout,  // layout doesn't affect CSC storage
     T density,
     RNGState<r123::Philox4x32_R<10>>& state
 ) {

--- a/test/misc/test_memory_tracker.cc
+++ b/test/misc/test_memory_tracker.cc
@@ -55,7 +55,7 @@ TEST_F(TestMemoryTracker, NoAllocationReportsSmall) {
     // Do trivial work — no large allocations.
     volatile int x = 0;
     for (int i = 0; i < 1000; ++i)
-        x += i;
+        x = x + i;
     long increase = tracker.stop();
     EXPECT_LT(increase, 4096)
         << "Expected small RSS increase with no allocation, got " << increase << " KB";


### PR DESCRIPTION
**Silence all RandLAPACK compiler warnings under `-Wall -Wextra`**

Resolves all 22 warnings emitted when building the workshop docker image (`ghcr.io/rileyjmurray/randlapack-python-workshop:latest`).

**Categories fixed** (-Wunused-but-set-variable, -Wunused-parameter, -Wsign-compare, -Wvolatile, -Wdangling-else):
- Removed dead code: `prevnormNR` in `rl_determiter.hh`; unused `[rows_B, cols_B]` structured bindings in `rl_dense_linop.hh` / `rl_composite_linop.hh`.
- Removed genuinely vestigial parameters: `lda` from sparse `ABRIK::call` (LDA is meaningless for sparse — `test_ABRIK_general` uses `if constexpr` to dispatch dense vs. sparse), `k` from `test_csr_col_split`, `norm_A` from `test_CQRRPT_orthogonalization`. All callers updated.
- For parameters that are unused only in one specialization but required by template-overload symmetry (`density`/`layout` in `make_operator`), used the existing `UNUSED(x)` macro from `RandBLAS/exceptions.hh` with explanatory comments.
- Misc: braced `ASSERT_FALSE` in `test_rpchol.cc` for `-Wdangling-else`; rewrote `x += i` on `volatile int` as `x = x + i` to avoid C++20 deprecation in `test_memory_tracker.cc`.

Added issue #137 to deal with clang warnings/errors (will involve updating RandBLAS submodule).