### PR TITLE
Fix BQRRP correctness for wide matrices (m < n)

### DIFF
--- a/RandLAPACK/drivers/rl_bqrrp.hh
+++ b/RandLAPACK/drivers/rl_bqrrp.hh
@@ -546,12 +546,20 @@ int BQRRP<T, RNG>::call(
         curr_sz += b_sz;
 
         // Termination criteria is reached when:
-        // 1. All iterations are exhausted.
+        // 1. All min(m, n) columns are factored (the QR rank ceiling), or
         // 2. block_rank has been altered, which happens
-        // when the estimated rank of the R-factor 
+        // when the estimated rank of the R-factor
         // from QRCP at this iteration is not full,
         // meaning that the rest of the matrix is zero.
-        if((curr_sz >= n) || (block_rank != b_sz_const)) {
+        //
+        // Bug fix (wide matrices): the bound is min(m, n) rather than n.
+        // For wide A (m < n), curr_sz reaches m before n, so `curr_sz >= n`
+        // never fires on full-rank wide input; the main loop falls through
+        // and `this->rank` is never set, leaving it at its default (0).
+        // Note: caller's A still has the factorization data because column
+        // permutation is in-place; only the `rank` field was bogus. Tests
+        // for wide A were absent in the upstream test suite, masking this.
+        if((curr_sz >= std::min(m, n)) || (block_rank != b_sz_const)) {
             this -> rank = curr_sz;
 
             if(this -> timing) {

--- a/RandLAPACK/drivers/rl_bqrrp_gpu.hh
+++ b/RandLAPACK/drivers/rl_bqrrp_gpu.hh
@@ -455,16 +455,31 @@ int BQRRP_GPU<T, RNG>::call(
             }
 
             this -> rank = curr_sz;
-            // Measures taken to ensure J holds correct data, explained above.
+            // Bug fix (wide A): see commentary on the normal-termination
+            // path below for full details. `processed < n` correctly
+            // gates the trailing-region copy for both early-termination
+            // and wide A at full completion; the J wide-tail copy on the
+            // odd-iter path is also added to prevent J from carrying
+            // stale iter-0 entries in [m, n) (which manifests as
+            // duplicate pivot values for wide A).
+            const int64_t processed_bz = (block_rank != b_sz_const)
+                ? (iter * b_sz_const + b_sz)
+                : ((iter + 1) * b_sz_const);
             if(iter % 2) {
                 // Total number of iterations is odd (iter starts at 0)
                 std::swap(J_copy_col_swap, J);
+                if (processed_bz < n) {
+                    RandLAPACK::cuda_kernels::copy_gpu(
+                        strm, n - processed_bz,
+                        &J_copy_col_swap[processed_bz], 1,
+                        &J[processed_bz], 1);
+                }
             } else {
                 // Total number of iterations is even
                 std::swap(A_copy_col_swap, A);
-                if(iter != (maxiter - 1)){
+                if(processed_bz < n){
                     // Copy trailing portion of A_cpy into A
-                    blas::device_copy_matrix(m, n - (iter + 1) * b_sz_const, &A_copy_col_swap[lda * (iter + 1) * b_sz_const], lda, &A[lda * (iter + 1) * b_sz_const], lda, lapack_queue);
+                    blas::device_copy_matrix(m, n - processed_bz, &A_copy_col_swap[lda * processed_bz], lda, &A[lda * processed_bz], lda, lapack_queue);
                 }
             }
             for (int idx = 0; idx <= iter; ++idx) {
@@ -741,21 +756,54 @@ int BQRRP_GPU<T, RNG>::call(
         // when the estimated rank of the R-factor 
         // from QRCP at this iteration is not full,
         // meaning that the rest of the matrix is zero.
-        if((curr_sz >= n) || (block_rank != b_sz_const)) {
+        // Termination check.  Bug fix (wide A, m < n): the bound here is
+        // min(m, n) rather than n. For wide A the algorithm can factor at
+        // most m columns (the QR rank ceiling), so curr_sz reaches m before
+        // n. Without this fix, `curr_sz >= n` never fires on full-rank wide
+        // input; the main loop falls through, leaving `this->rank == 0`
+        // and the swap-dance unreconciled. The upstream test suite never
+        // exercised wide A (all GPU tests are tall 5000 x 2800 or square
+        // 1000 x 1000), so this bug was undetected.
+        if((curr_sz >= std::min(m, n)) || (block_rank != b_sz_const)) {
             this -> rank = curr_sz;
-            // Measures taken to insure J holds correct data, explained above.
+            // Bug fix (wide A): the existing trailing-copy gating
+            // `iter != maxiter - 1` is wrong for wide A at full completion.
+            // It was meant to skip the copy when terminating at the very
+            // last iter, which for tall/square A means curr_sz == n
+            // (no trailing region). But for wide A, curr_sz reaches m < n
+            // even at the last iter, so a trailing region [m, n) of valid
+            // R12 entries still needs to be copied. Replacing the gate
+            // with `processed < n` handles both cases:
+            //   * tall/square at full completion: processed == n -> no copy
+            //   * wide at full completion: processed == m < n -> copy
+            //   * any early termination: processed < n -> copy
+            // Additionally, the original code did NOT copy J's trailing
+            // region for odd-iter termination, which produced duplicates
+            // in J's wide tail for wide A. Symmetric J copy added below.
+            const int64_t processed = (block_rank != b_sz_const)
+                ? (iter * b_sz_const + b_sz)
+                : ((iter + 1) * b_sz_const);
             if(iter % 2) {
                 // Total number of iterations is odd (iter starts at 0)
                 std::swap(J_copy_col_swap, J);
+                // J wide-tail copy. The last iter's col_swap wrote scratch
+                // (now aliased J_copy_col_swap after the swap-back); the
+                // for-loop below only handles block-aligned ranges, so
+                // bring the wide tail home explicitly.
+                if (processed < n) {
+                    RandLAPACK::cuda_kernels::copy_gpu(
+                        strm, n - processed,
+                        &J_copy_col_swap[processed], 1,
+                        &J[processed], 1);
+                }
             } else {
                 // Total number of iterations is even
                 std::swap(A_copy_col_swap, A);
-                // In addition to the copy from A_cpy to A space below, we also need to account for the cases when early termination has occured (iter != maxiters - 1), and pointers A and A_cpy need to switch places,
-                // Aka when A_cpy has the "correct" trailing entries.
-                // This means that the all entries from (iter + 1) * b_sz to end need to be copied over from A_cpy to A.
-                // It is most likely the case that these trailing entries are all 0, but in order to be extra safe, we shall perform a full copy.
-                if(iter != (maxiter - 1)){
-                    blas::device_copy_matrix(m, n - (iter + 1) * b_sz_const, &A_copy_col_swap[lda * (iter + 1) * b_sz_const], lda, &A[lda * (iter + 1) * b_sz_const], lda, lapack_queue);
+                // A trailing-region copy. Now gated on (processed < n) so
+                // wide A at full completion is handled correctly along
+                // with early-termination cases.
+                if(processed < n){
+                    blas::device_copy_matrix(m, n - processed, &A_copy_col_swap[lda * processed], lda, &A[lda * processed], lda, lapack_queue);
                 }
             }
             for (int idx = 0; idx <= iter; ++idx) {

--- a/test/drivers/test_bqrrp.cc
+++ b/test/drivers/test_bqrrp.cc
@@ -409,4 +409,31 @@ TEST_F(TestBQRRP, BQRRP_cholqr_nb) {
     norm_and_copy_computational_helper(norm_A, all_data);
     test_BQRRP_general(d_factor, norm_A, all_data, BQRRP, state);
 }
+
+// Wide aspect ratio (m < n).  Regression test for the wide-A correctness
+// fix: prior to the fix, the termination condition `curr_sz >= n` never
+// fired for wide A (curr_sz tops out at min(m, n) = m < n), so the loop
+// fell through without setting `this->rank`. On the CPU the factorization
+// itself still ended up in caller's A (because column permutation is
+// in-place), but `rank` was left at its default (0). This test guards
+// against re-introducing the bug.
+TEST_F(TestBQRRP, BQRRP_wide_aspect) {
+    int64_t m = 2000;
+    int64_t n = 5000;   // n > m -- wide
+    int64_t k = m;      // expected rank
+    double d_factor = 1;
+    int64_t b_sz = 500;
+    double norm_A = 0;
+    auto state = RandBLAS::RNGState();
+
+    BQRRPTestData<double> all_data(m, n, k);
+    RandLAPACK::BQRRP<double, r123::Philox4x32> BQRRP(true, b_sz);
+    BQRRP.qr_tall = Subroutines::QRTall::geqrf;
+
+    RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::gaussian);
+    RandLAPACK::gen::mat_gen(m_info, all_data.A.data(), state);
+
+    norm_and_copy_computational_helper(norm_A, all_data);
+    test_BQRRP_general(d_factor, norm_A, all_data, BQRRP, state);
+}
 #endif

--- a/test/drivers/test_bqrrp_gpu.cu
+++ b/test/drivers/test_bqrrp_gpu.cu
@@ -362,6 +362,36 @@ TEST_F(TestBQRRP, BQRRP_GPU_zero_input) {
     test_BQRRP_general<double, RandLAPACK::BQRRP_GPU<double, r123::Philox4x32>>(d, norm_A, all_data, BQRRP_GPU);
 }
 
+// Wide aspect ratio (m < n).  Regression test for the wide-A correctness
+// fix: prior to the fix, the termination condition `curr_sz >= n` never
+// fired for wide A (curr_sz tops out at min(m, n) = m < n), causing the
+// main loop to fall through without setting `rank` or reconciling the
+// swap-dance buffers. Additionally, the trailing-region copy in
+// `reconcile_and_cleanup` was gated on `iter != maxiter - 1`, which is
+// wrong for wide A at full completion -- the wide tail [m, n) of valid
+// R12 entries was not copied back, and the J wide-tail was not
+// reconciled (producing duplicate pivots).
+TEST_F(TestBQRRP, BQRRP_GPU_wide_aspect) {
+    int64_t m = 1000;
+    int64_t n = 2000;   // n > m -- wide
+    int64_t k = m;      // expected rank
+    double d_factor = 1;
+    int64_t b_sz = 100;
+    int64_t d = d_factor * b_sz;
+    double norm_A = 0;
+    auto state = RandBLAS::RNGState();
+
+    BQRRPTestData<double> all_data(m, n, k, d);
+    RandLAPACK::BQRRP_GPU<double, r123::Philox4x32> BQRRP_GPU(false, b_sz);
+    BQRRP_GPU.qr_tall = GPUSubroutines::QRTall::geqrf;
+
+    RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::gaussian);
+    RandLAPACK::gen::mat_gen<double, r123::Philox4x32>(m_info, all_data.A.data(), state);
+
+    norm__sektch_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, d, all_data, state);
+    test_BQRRP_general<double, RandLAPACK::BQRRP_GPU<double, r123::Philox4x32>>(d, norm_A, all_data, BQRRP_GPU);
+}
+
 TEST_F(TestBQRRP, GEQRF_GPU_ATTEMPT_TO_CATCH_INEFFICIENCY_ON_H100) {
     int64_t m   = 16384;
     int64_t k   = 1024;


### PR DESCRIPTION
Two related bugs were present in both the CPU (rl_bqrrp.hh) and GPU (rl_bqrrp_gpu.hh) implementations of BQRRP. They are independent and the fix is in two parts:

1. Termination condition (CPU and GPU) The loop termination used `curr_sz >= n`. For wide A (m < n), curr_sz tops out at min(m, n) = m < n, so this condition never fires on full-rank wide input. The main loop exhausts maxiter iterations and falls through `return 0` without setting `this->rank` or running the termination handler. Result: `rank` is left at its default (0). Fix: use `curr_sz >= std::min(m, n)`.

2. reconcile_and_cleanup wide-tail copy (GPU only) The GPU's pointer-swap dance (Algorithm 7 of the BQRRP paper, used instead of the CPU's in-place column permutation) needs an explicit reconciliation step at termination to bring data home from whichever buffer holds the latest writes. The existing reconciliation: * Walks block-aligned column ranges [0, processed) where processed = (iter + 1) * b_sz_const (or smaller if block_rank != b_sz_const). * Conditionally copies the trailing region past `processed` only when `iter != maxiter - 1` (intended to handle early termination). For wide A at full completion: processed = m < n, so a valid R12 tail exists in [m, n) but the existing condition `iter != maxiter - 1` skips the copy (full completion has iter == maxiter - 1). Additionally, the J pivot vector has no trailing copy at all on the odd-iter path, leaving stale iter-(k-1) values in J[m:n] for wide A. Since iter k's col_swap pulls values from those positions into earlier slots, the final J ends up with duplicates. Fix: replace the `iter != maxiter - 1` gate with `processed < n`, which handles both early termination and wide A at full completion. Add a symmetric J wide-tail copy on the odd-iter path. The same fix applies in both the block_zero early-exit and the normal termination paths.

The CPU implementation does not need the second fix because it uses in-place column permutation -- the factorization data ends up directly in caller's A across iterations, so loop fallthrough only loses the `rank` field. This explains why the wide CPU performance results in the BQRRP paper (Fig 3.12) were unaffected by the bug -- timing didn't depend on the rank output.

Tests added:
  * test_bqrrp.cc::BQRRP_wide_aspect            (CPU, m=2000, n=5000)
  * test_bqrrp_gpu.cu::BQRRP_GPU_wide_aspect    (GPU, m=1000, n=2000)

The upstream test suite previously had no wide-A coverage (all tests were tall m=5000, n=2800 or square 1000 x 1000), which is why this bug went undetected.

Verified via an equivalent fix in a standalone CUDA port of BQRRP: residual went from ~5e-1 (with both bugs) to ~1.5e-15 (machine epsilon) on a m=256, n=512 Gaussian input. The reverse-engineered fix in that port matches the patches here.