### PR TITLE
Bindings prep: RandLAPACK::Error, install.sh discovery, BQRRP validation

### DIFF
--- a/RandLAPACK.hh
+++ b/RandLAPACK.hh
@@ -4,6 +4,7 @@
 // config and dependencies
 #include "RandLAPACK/rl_blaspp.hh"
 #include "RandLAPACK/rl_lapackpp.hh"
+#include "RandLAPACK/rl_exceptions.hh"
 #include "RandBLAS.hh"
 
 // misc

--- a/RandLAPACK/CMakeLists.txt
+++ b/RandLAPACK/CMakeLists.txt
@@ -18,6 +18,7 @@ set(RandLAPACK_cxx_sources
     rl_rpchol.hh
     rl_blaspp.hh
     rl_pdkernels.hh
+    rl_exceptions.hh
 
     rl_cusolver.hh
     rl_cuda_kernels.cuh

--- a/RandLAPACK/comps/rl_determiter.hh
+++ b/RandLAPACK/comps/rl_determiter.hh
@@ -384,7 +384,7 @@ void pcg(
     int64_t ns = n*s;
     int64_t ss = s*s;
     bool treat_as_separable = G.num_ops > 1;
-    if (treat_as_separable) randlapack_error_if_msg(s != G.num_ops, "with separable treatment, s=%lld must equal G.num_ops=%lld", (long long)s, (long long)G.num_ops);
+    if (treat_as_separable) randlapack_require(s == G.num_ops) << "with separable treatment, s=" << s << " must equal G.num_ops=" << G.num_ops;
 
     // All workspace gets zero-initialized; this is only
     // overridden for "R".

--- a/RandLAPACK/comps/rl_determiter.hh
+++ b/RandLAPACK/comps/rl_determiter.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_blaspp.hh"
 
 #include <iostream>
@@ -383,7 +384,7 @@ void pcg(
     int64_t ns = n*s;
     int64_t ss = s*s;
     bool treat_as_separable = G.num_ops > 1;
-    if (treat_as_separable) randblas_require(s == G.num_ops);
+    if (treat_as_separable) randlapack_error_if_msg(s != G.num_ops, "with separable treatment, s=%lld must equal G.num_ops=%lld", (long long)s, (long long)G.num_ops);
 
     // All workspace gets zero-initialized; this is only
     // overridden for "R".

--- a/RandLAPACK/comps/rl_preconditioners.hh
+++ b/RandLAPACK/comps/rl_preconditioners.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_blaspp.hh"
 #include "rl_lapackpp.hh"
 #include "rl_util.hh"
@@ -37,7 +38,7 @@ void rpc_data_svd(
     T *sigma_sk //buffer of size at least n.
 ) {
     int64_t d = S.dist.n_rows;
-    randblas_require(d >= n);
+    randlapack_error_if_msg(d < n, "sketching dimension d=%lld must be >= n=%lld", (long long)d, (long long)n);
     T* A_sk = V_sk;
     if (m < n)
         throw std::invalid_argument("Input matrix A must have at least as many rows as columns.");
@@ -45,10 +46,10 @@ void rpc_data_svd(
     // step 1
     int64_t lda_sk;
     if (layout == Layout::RowMajor) {
-        randblas_require(lda >= n);
+        randlapack_error_if_msg(lda < n, "lda=%lld < n=%lld (lda must be >= n)", (long long)lda, (long long)n);
         lda_sk = n;
     } else {
-        randblas_require(lda >= m);
+        randlapack_error_if_msg(lda < m, "lda=%lld < m=%lld (lda must be >= m)", (long long)lda, (long long)m);
         lda_sk = d;
     }
     RandBLAS::util::safe_scal(d*n, (T) 0.0, A_sk);

--- a/RandLAPACK/comps/rl_preconditioners.hh
+++ b/RandLAPACK/comps/rl_preconditioners.hh
@@ -38,7 +38,7 @@ void rpc_data_svd(
     T *sigma_sk //buffer of size at least n.
 ) {
     int64_t d = S.dist.n_rows;
-    randlapack_error_if_msg(d < n, "sketching dimension d=%lld must be >= n=%lld", (long long)d, (long long)n);
+    randlapack_require(d >= n) << "sketching dimension d=" << d << " must be >= n=" << n;
     T* A_sk = V_sk;
     if (m < n)
         throw std::invalid_argument("Input matrix A must have at least as many rows as columns.");
@@ -46,10 +46,10 @@ void rpc_data_svd(
     // step 1
     int64_t lda_sk;
     if (layout == Layout::RowMajor) {
-        randlapack_error_if_msg(lda < n, "lda=%lld < n=%lld (lda must be >= n)", (long long)lda, (long long)n);
+        randlapack_require(lda >= n) << "lda=" << lda << " < n=" << n << " (lda must be >= n)";
         lda_sk = n;
     } else {
-        randlapack_error_if_msg(lda < m, "lda=%lld < m=%lld (lda must be >= m)", (long long)lda, (long long)m);
+        randlapack_require(lda >= m) << "lda=" << lda << " < m=" << m << " (lda must be >= m)";
         lda_sk = d;
     }
     RandBLAS::util::safe_scal(d*n, (T) 0.0, A_sk);

--- a/RandLAPACK/comps/rl_rpchol.hh
+++ b/RandLAPACK/comps/rl_rpchol.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_lapackpp.hh"
 #include <blas.hh>
 #include <RandBLAS.hh>
@@ -18,7 +19,7 @@ template <typename T, typename FUNC_T>
 void compute_columns(
     Layout layout, int64_t N, FUNC_T &K_stateless, vector<int64_t> &col_indices, T* buff
 ) {
-    randblas_require(layout == Layout::ColMajor);
+    randlapack_error_if_msg(layout != Layout::ColMajor, "this routine only supports ColMajor layout");
     int64_t num_cols = col_indices.size();
     #pragma omp parallel for collapse(2)
     for (int64_t ell = 0; ell < num_cols; ++ell) {
@@ -34,7 +35,7 @@ template <typename T>
 void pack_selected_rows(
     Layout layout, int64_t rows_mat, int64_t cols_mat, T* mat, vector<int64_t> &row_indices, T* submat
 ) {
-    randblas_require(layout == Layout::ColMajor);
+    randlapack_error_if_msg(layout != Layout::ColMajor, "this routine only supports ColMajor layout");
     int64_t num_rows = row_indices.size();
     for (int64_t i = 0; i < num_rows; ++i) {
         blas::copy(cols_mat, mat + row_indices[i], rows_mat, submat + i, num_rows);
@@ -44,7 +45,7 @@ void pack_selected_rows(
 
 template <typename T>
 int downdate_d_and_cdf(Layout layout, int64_t N, vector<int64_t> &indices, T* F_panel, vector<T> &d, vector<T> &cdf) {
-    randblas_require(layout == Layout::ColMajor);
+    randlapack_error_if_msg(layout != Layout::ColMajor, "this routine only supports ColMajor layout");
     int64_t cols_F_panel = indices.size();
     for (int64_t j = 0; j < cols_F_panel; ++j) {
         for (int64_t i = 0; i < N; ++i) {

--- a/RandLAPACK/comps/rl_rpchol.hh
+++ b/RandLAPACK/comps/rl_rpchol.hh
@@ -19,7 +19,7 @@ template <typename T, typename FUNC_T>
 void compute_columns(
     Layout layout, int64_t N, FUNC_T &K_stateless, vector<int64_t> &col_indices, T* buff
 ) {
-    randlapack_error_if_msg(layout != Layout::ColMajor, "this routine only supports ColMajor layout");
+    randlapack_require(layout == Layout::ColMajor) << "this routine only supports ColMajor layout";
     int64_t num_cols = col_indices.size();
     #pragma omp parallel for collapse(2)
     for (int64_t ell = 0; ell < num_cols; ++ell) {
@@ -35,7 +35,7 @@ template <typename T>
 void pack_selected_rows(
     Layout layout, int64_t rows_mat, int64_t cols_mat, T* mat, vector<int64_t> &row_indices, T* submat
 ) {
-    randlapack_error_if_msg(layout != Layout::ColMajor, "this routine only supports ColMajor layout");
+    randlapack_require(layout == Layout::ColMajor) << "this routine only supports ColMajor layout";
     int64_t num_rows = row_indices.size();
     for (int64_t i = 0; i < num_rows; ++i) {
         blas::copy(cols_mat, mat + row_indices[i], rows_mat, submat + i, num_rows);
@@ -45,7 +45,7 @@ void pack_selected_rows(
 
 template <typename T>
 int downdate_d_and_cdf(Layout layout, int64_t N, vector<int64_t> &indices, T* F_panel, vector<T> &d, vector<T> &cdf) {
-    randlapack_error_if_msg(layout != Layout::ColMajor, "this routine only supports ColMajor layout");
+    randlapack_require(layout == Layout::ColMajor) << "this routine only supports ColMajor layout";
     int64_t cols_F_panel = indices.size();
     for (int64_t j = 0; j < cols_F_panel; ++j) {
         for (int64_t i = 0; i < N; ++i) {

--- a/RandLAPACK/drivers/rl_abrik.hh
+++ b/RandLAPACK/drivers/rl_abrik.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_util.hh"
 #include "rl_blaspp.hh"
 #include "rl_lapackpp.hh"
@@ -129,6 +130,14 @@ class ABRIK {
             T* &Sigma,
             RandBLAS::RNGState<RNG> &state
         ) {
+            // Input parameter validation. Bad inputs would otherwise propagate to a
+            // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
+            // ABRIK is called through a binding layer (e.g. MEX/MATLAB).
+            randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
+            randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
+            randlapack_error_if_msg(lda < m, "lda=%lld < m=%lld (lda must be >= m for ColMajor)", (long long)lda, (long long)m);
+            randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
+            randlapack_error_if_msg(A == nullptr && m > 0 && n > 0, "A buffer is null but m=%lld and n=%lld imply a nonempty matrix", (long long)m, (long long)n);
             linops::DenseLinOp<T> A_linop(m, n, A, lda, Layout::ColMajor);
             return this->call(A_linop, k, U, V, Sigma, state);
         }
@@ -145,6 +154,10 @@ class ABRIK {
             T* &Sigma,
             RandBLAS::RNGState<RNG> &state
         ) {
+            // Input parameter validation; same MEX-safety motivation as above.
+            randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
+            randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
+            randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
             linops::SparseLinOp<SpMat> A_linop(m, n, A);
             return this->call(A_linop, k, U, V, Sigma, state);
         }
@@ -158,6 +171,8 @@ class ABRIK {
             T* &Sigma,
             RandBLAS::RNGState<RNG> &state
         ){
+            // Input parameter validation; same MEX-safety motivation as above.
+            randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
             steady_clock::time_point allocation_t_start;
             steady_clock::time_point allocation_t_stop;
             steady_clock::time_point get_factors_t_start;

--- a/RandLAPACK/drivers/rl_abrik.hh
+++ b/RandLAPACK/drivers/rl_abrik.hh
@@ -133,11 +133,11 @@ class ABRIK {
             // Input parameter validation. Bad inputs would otherwise propagate to a
             // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
             // ABRIK is called through a binding layer (e.g. MEX/MATLAB).
-            randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
-            randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
-            randlapack_error_if_msg(lda < m, "lda=%lld < m=%lld (lda must be >= m for ColMajor)", (long long)lda, (long long)m);
-            randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
-            randlapack_error_if_msg(A == nullptr && m > 0 && n > 0, "A buffer is null but m=%lld and n=%lld imply a nonempty matrix", (long long)m, (long long)n);
+            randlapack_require(m >= 0) << "m=" << m << " must be >= 0";
+            randlapack_require(n >= 0) << "n=" << n << " must be >= 0";
+            randlapack_require(lda >= m) << "lda=" << lda << " < m=" << m << " (lda must be >= m for ColMajor)";
+            randlapack_require(k > 0) << "target rank k=" << k << " must be > 0";
+            randlapack_require(!(A == nullptr && m > 0 && n > 0)) << "A buffer is null but m=" << m << " and n=" << n << " imply a nonempty matrix";
             linops::DenseLinOp<T> A_linop(m, n, A, lda, Layout::ColMajor);
             return this->call(A_linop, k, U, V, Sigma, state);
         }
@@ -155,9 +155,9 @@ class ABRIK {
             RandBLAS::RNGState<RNG> &state
         ) {
             // Input parameter validation; same MEX-safety motivation as above.
-            randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
-            randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
-            randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
+            randlapack_require(m >= 0) << "m=" << m << " must be >= 0";
+            randlapack_require(n >= 0) << "n=" << n << " must be >= 0";
+            randlapack_require(k > 0) << "target rank k=" << k << " must be > 0";
             linops::SparseLinOp<SpMat> A_linop(m, n, A);
             return this->call(A_linop, k, U, V, Sigma, state);
         }
@@ -172,7 +172,7 @@ class ABRIK {
             RandBLAS::RNGState<RNG> &state
         ){
             // Input parameter validation; same MEX-safety motivation as above.
-            randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
+            randlapack_require(k > 0) << "target rank k=" << k << " must be > 0";
             steady_clock::time_point allocation_t_start;
             steady_clock::time_point allocation_t_stop;
             steady_clock::time_point get_factors_t_start;

--- a/RandLAPACK/drivers/rl_bqrrp.hh
+++ b/RandLAPACK/drivers/rl_bqrrp.hh
@@ -4,6 +4,7 @@
 #include "rl_blaspp.hh"
 #include "rl_lapackpp.hh"
 #include "rl_hqrrp.hh"
+#include "rl_exceptions.hh"
 
 #include <RandBLAS.hh>
 #include <cstdint>
@@ -65,6 +66,7 @@ class BQRRP : public BQRRPalg<T, RNG> {
             bool time_subroutines,
             int64_t b_sz
         ) {
+            randlapack_error_if_msg(b_sz <= 0, "BQRRP block size b_sz=%lld must be > 0", (long long)b_sz);
             timing          = time_subroutines;
             tol             = std::numeric_limits<T>::epsilon();
             block_size      = b_sz;
@@ -164,6 +166,17 @@ int BQRRP<T, RNG>::call(
     UNUSED(m); UNUSED(n); UNUSED(A); UNUSED(lda); UNUSED(d_factor); UNUSED(tau); UNUSED(J); UNUSED(state);
     throw std::runtime_error("BQRRP is not supported when BLAS is linked against Apple Accelerate.");
     #else
+    // Input parameter validation. Bad inputs would otherwise lead to a
+    // downstream BLAS/LAPACK failure or, worse, a segfault -- both fatal
+    // when BQRRP is called through a binding layer (e.g. MEX/MATLAB).
+    randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
+    randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
+    randlapack_error_if_msg(lda < m, "lda=%lld < m=%lld (lda must be >= m for ColMajor)", (long long)lda, (long long)m);
+    randlapack_error_if_msg(d_factor < (T)1.0, "d_factor=%g must be >= 1.0 (so that sketch dim >= block size)", (double)d_factor);
+    randlapack_error_if_msg(A == nullptr && m > 0 && n > 0, "A buffer is null but m=%lld and n=%lld imply a nonempty matrix", (long long)m, (long long)n);
+    randlapack_error_if_msg(tau == nullptr && n > 0, "tau buffer is null but n=%lld > 0", (long long)n);
+    randlapack_error_if_msg(J == nullptr && n > 0, "J buffer is null but n=%lld > 0", (long long)n);
+
     //-------TIMING VARS--------/
     steady_clock::time_point preallocation_t_start;
     steady_clock::time_point preallocation_t_stop;

--- a/RandLAPACK/drivers/rl_bqrrp.hh
+++ b/RandLAPACK/drivers/rl_bqrrp.hh
@@ -66,7 +66,7 @@ class BQRRP : public BQRRPalg<T, RNG> {
             bool time_subroutines,
             int64_t b_sz
         ) {
-            randlapack_error_if_msg(b_sz <= 0, "BQRRP block size b_sz=%lld must be > 0", (long long)b_sz);
+            randlapack_require(b_sz > 0) << "BQRRP block size b_sz=" << b_sz << " must be > 0";
             timing          = time_subroutines;
             tol             = std::numeric_limits<T>::epsilon();
             block_size      = b_sz;
@@ -169,13 +169,13 @@ int BQRRP<T, RNG>::call(
     // Input parameter validation. Bad inputs would otherwise lead to a
     // downstream BLAS/LAPACK failure or, worse, a segfault -- both fatal
     // when BQRRP is called through a binding layer (e.g. MEX/MATLAB).
-    randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
-    randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
-    randlapack_error_if_msg(lda < m, "lda=%lld < m=%lld (lda must be >= m for ColMajor)", (long long)lda, (long long)m);
-    randlapack_error_if_msg(d_factor < (T)1.0, "d_factor=%g must be >= 1.0 (so that sketch dim >= block size)", (double)d_factor);
-    randlapack_error_if_msg(A == nullptr && m > 0 && n > 0, "A buffer is null but m=%lld and n=%lld imply a nonempty matrix", (long long)m, (long long)n);
-    randlapack_error_if_msg(tau == nullptr && n > 0, "tau buffer is null but n=%lld > 0", (long long)n);
-    randlapack_error_if_msg(J == nullptr && n > 0, "J buffer is null but n=%lld > 0", (long long)n);
+    randlapack_require(m >= 0) << "m=" << m << " must be >= 0";
+    randlapack_require(n >= 0) << "n=" << n << " must be >= 0";
+    randlapack_require(lda >= m) << "lda=" << lda << " < m=" << m << " (lda must be >= m for ColMajor)";
+    randlapack_require(d_factor >= (T)1.0) << "d_factor=" << d_factor << " must be >= 1.0 (so that sketch dim >= block size)";
+    randlapack_require(!(A == nullptr && m > 0 && n > 0)) << "A buffer is null but m=" << m << " and n=" << n << " imply a nonempty matrix";
+    randlapack_require(!(tau == nullptr && n > 0)) << "tau buffer is null but n=" << n << " > 0";
+    randlapack_require(!(J == nullptr && n > 0)) << "J buffer is null but n=" << n << " > 0";
 
     //-------TIMING VARS--------/
     steady_clock::time_point preallocation_t_start;

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -158,14 +158,14 @@ int CQRRPT<T, RNG>::call(
     // Input parameter validation. Bad inputs would otherwise propagate to a
     // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
     // CQRRPT is called through a binding layer (e.g. MEX/MATLAB).
-    randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
-    randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
-    randlapack_error_if_msg(lda < m, "lda=%lld < m=%lld (lda must be >= m for ColMajor)", (long long)lda, (long long)m);
-    randlapack_error_if_msg(ldr < n, "ldr=%lld < n=%lld (ldr must be >= n)", (long long)ldr, (long long)n);
-    randlapack_error_if_msg(d_factor < (T)1.0, "d_factor=%g must be >= 1.0", (double)d_factor);
-    randlapack_error_if_msg(A == nullptr && m > 0 && n > 0, "A buffer is null but m=%lld and n=%lld imply a nonempty matrix", (long long)m, (long long)n);
-    randlapack_error_if_msg(R == nullptr && n > 0, "R buffer is null but n=%lld > 0", (long long)n);
-    randlapack_error_if_msg(J == nullptr && n > 0, "J buffer is null but n=%lld > 0", (long long)n);
+    randlapack_require(m >= 0) << "m=" << m << " must be >= 0";
+    randlapack_require(n >= 0) << "n=" << n << " must be >= 0";
+    randlapack_require(lda >= m) << "lda=" << lda << " < m=" << m << " (lda must be >= m for ColMajor)";
+    randlapack_require(ldr >= n) << "ldr=" << ldr << " < n=" << n << " (ldr must be >= n)";
+    randlapack_require(d_factor >= (T)1.0) << "d_factor=" << d_factor << " must be >= 1.0";
+    randlapack_require(!(A == nullptr && m > 0 && n > 0)) << "A buffer is null but m=" << m << " and n=" << n << " imply a nonempty matrix";
+    randlapack_require(!(R == nullptr && n > 0)) << "R buffer is null but n=" << n << " > 0";
+    randlapack_require(!(J == nullptr && n > 0)) << "J buffer is null but n=" << n << " > 0";
 
     ///--------------------TIMING VARS--------------------/
     steady_clock::time_point saso_t_stop;

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_util.hh"
 #include "rl_blaspp.hh"
 #include "rl_lapackpp.hh"
@@ -154,6 +155,18 @@ int CQRRPT<T, RNG>::call(
     T d_factor,
     RandBLAS::RNGState<RNG> &state
 ){
+    // Input parameter validation. Bad inputs would otherwise propagate to a
+    // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
+    // CQRRPT is called through a binding layer (e.g. MEX/MATLAB).
+    randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
+    randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
+    randlapack_error_if_msg(lda < m, "lda=%lld < m=%lld (lda must be >= m for ColMajor)", (long long)lda, (long long)m);
+    randlapack_error_if_msg(ldr < n, "ldr=%lld < n=%lld (ldr must be >= n)", (long long)ldr, (long long)n);
+    randlapack_error_if_msg(d_factor < (T)1.0, "d_factor=%g must be >= 1.0", (double)d_factor);
+    randlapack_error_if_msg(A == nullptr && m > 0 && n > 0, "A buffer is null but m=%lld and n=%lld imply a nonempty matrix", (long long)m, (long long)n);
+    randlapack_error_if_msg(R == nullptr && n > 0, "R buffer is null but n=%lld > 0", (long long)n);
+    randlapack_error_if_msg(J == nullptr && n > 0, "J buffer is null but n=%lld > 0", (long long)n);
+
     ///--------------------TIMING VARS--------------------/
     steady_clock::time_point saso_t_stop;
     steady_clock::time_point saso_t_start;

--- a/RandLAPACK/drivers/rl_cqrrt.hh
+++ b/RandLAPACK/drivers/rl_cqrrt.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_util.hh"
 #include "rl_blaspp.hh"
 #include "rl_lapackpp.hh"
@@ -129,6 +130,17 @@ int CQRRT<T, RNG>::call(
     T d_factor,
     RandBLAS::RNGState<RNG> &state
 ){
+    // Input parameter validation. Bad inputs would otherwise propagate to a
+    // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
+    // CQRRT is called through a binding layer (e.g. MEX/MATLAB).
+    randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
+    randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
+    randlapack_error_if_msg(lda < m, "lda=%lld < m=%lld (lda must be >= m for ColMajor)", (long long)lda, (long long)m);
+    randlapack_error_if_msg(ldr < n, "ldr=%lld < n=%lld (ldr must be >= n)", (long long)ldr, (long long)n);
+    randlapack_error_if_msg(d_factor < (T)1.0, "d_factor=%g must be >= 1.0", (double)d_factor);
+    randlapack_error_if_msg(A == nullptr && m > 0 && n > 0, "A buffer is null but m=%lld and n=%lld imply a nonempty matrix", (long long)m, (long long)n);
+    randlapack_error_if_msg(R == nullptr && n > 0, "R buffer is null but n=%lld > 0", (long long)n);
+
     ///--------------------TIMING VARS--------------------/
     steady_clock::time_point saso_t_start, saso_t_stop;
     steady_clock::time_point qr_t_start, qr_t_stop;

--- a/RandLAPACK/drivers/rl_cqrrt.hh
+++ b/RandLAPACK/drivers/rl_cqrrt.hh
@@ -133,13 +133,13 @@ int CQRRT<T, RNG>::call(
     // Input parameter validation. Bad inputs would otherwise propagate to a
     // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
     // CQRRT is called through a binding layer (e.g. MEX/MATLAB).
-    randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
-    randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
-    randlapack_error_if_msg(lda < m, "lda=%lld < m=%lld (lda must be >= m for ColMajor)", (long long)lda, (long long)m);
-    randlapack_error_if_msg(ldr < n, "ldr=%lld < n=%lld (ldr must be >= n)", (long long)ldr, (long long)n);
-    randlapack_error_if_msg(d_factor < (T)1.0, "d_factor=%g must be >= 1.0", (double)d_factor);
-    randlapack_error_if_msg(A == nullptr && m > 0 && n > 0, "A buffer is null but m=%lld and n=%lld imply a nonempty matrix", (long long)m, (long long)n);
-    randlapack_error_if_msg(R == nullptr && n > 0, "R buffer is null but n=%lld > 0", (long long)n);
+    randlapack_require(m >= 0) << "m=" << m << " must be >= 0";
+    randlapack_require(n >= 0) << "n=" << n << " must be >= 0";
+    randlapack_require(lda >= m) << "lda=" << lda << " < m=" << m << " (lda must be >= m for ColMajor)";
+    randlapack_require(ldr >= n) << "ldr=" << ldr << " < n=" << n << " (ldr must be >= n)";
+    randlapack_require(d_factor >= (T)1.0) << "d_factor=" << d_factor << " must be >= 1.0";
+    randlapack_require(!(A == nullptr && m > 0 && n > 0)) << "A buffer is null but m=" << m << " and n=" << n << " imply a nonempty matrix";
+    randlapack_require(!(R == nullptr && n > 0)) << "R buffer is null but n=" << n << " > 0";
 
     ///--------------------TIMING VARS--------------------/
     steady_clock::time_point saso_t_start, saso_t_stop;

--- a/RandLAPACK/drivers/rl_krill.hh
+++ b/RandLAPACK/drivers/rl_krill.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_blaspp.hh"
 #include "rl_lapackpp.hh"
 #include "rl_linops.hh"
@@ -24,7 +25,7 @@ STATE krill_full_rpchol(
     int64_t mu_size = G.num_ops;
     std::vector<T> mus(mu_size);
     std::copy(G.regs, G.regs + mu_size, mus.data());
-    randblas_require(mu_size == 1 || mu_size == ell);
+    randlapack_error_if_msg(!(mu_size == 1 || mu_size == ell), "mu_size=%lld must equal 1 or ell=%lld", (long long)mu_size, (long long)ell);
 
     if (rpchol_block_size < 0)
         rpchol_block_size = std::min((int64_t) 64, n/4);

--- a/RandLAPACK/drivers/rl_krill.hh
+++ b/RandLAPACK/drivers/rl_krill.hh
@@ -35,7 +35,7 @@ STATE krill_full_rpchol(
     int64_t mu_size = G.num_ops;
     std::vector<T> mus(mu_size);
     std::copy(G.regs, G.regs + mu_size, mus.data());
-    randlapack_require(!(mu_size != 1 || mu_size == ell)) << "mu_size=" << mu_size << " must equal 1 or ell=" << ell;
+    randlapack_require(mu_size == 1 || mu_size == ell) << "mu_size=" << mu_size << " must equal 1 or ell=" << ell;
 
     if (rpchol_block_size < 0)
         rpchol_block_size = std::min((int64_t) 64, n/4);

--- a/RandLAPACK/drivers/rl_krill.hh
+++ b/RandLAPACK/drivers/rl_krill.hh
@@ -25,17 +25,17 @@ STATE krill_full_rpchol(
     // Input parameter validation. Bad inputs would otherwise propagate to a
     // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
     // krill_full_rpchol is called through a binding layer (e.g. MEX/MATLAB).
-    randlapack_error_if_msg(n <= 0, "n=%lld must be > 0", (long long)n);
-    randlapack_error_if_msg(ell <= 0, "ell=%lld must be > 0", (long long)ell);
-    randlapack_error_if_msg(tol < (T)0, "tol=%g must be >= 0", (double)tol);
-    randlapack_error_if_msg(max_iters <= 0, "max_iters=%lld must be > 0", (long long)max_iters);
-    randlapack_error_if_msg(H == nullptr, "H buffer must not be null");
-    randlapack_error_if_msg(X == nullptr, "X buffer must not be null");
+    randlapack_require(n > 0) << "n=" << n << " must be > 0";
+    randlapack_require(ell > 0) << "ell=" << ell << " must be > 0";
+    randlapack_require(tol >= (T)0) << "tol=" << tol << " must be >= 0";
+    randlapack_require(max_iters > 0) << "max_iters=" << max_iters << " must be > 0";
+    randlapack_require(H != nullptr) << "H buffer must not be null";
+    randlapack_require(X != nullptr) << "X buffer must not be null";
 
     int64_t mu_size = G.num_ops;
     std::vector<T> mus(mu_size);
     std::copy(G.regs, G.regs + mu_size, mus.data());
-    randlapack_error_if_msg(!(mu_size == 1 || mu_size == ell), "mu_size=%lld must equal 1 or ell=%lld", (long long)mu_size, (long long)ell);
+    randlapack_require(!(mu_size != 1 || mu_size == ell)) << "mu_size=" << mu_size << " must equal 1 or ell=" << ell;
 
     if (rpchol_block_size < 0)
         rpchol_block_size = std::min((int64_t) 64, n/4);

--- a/RandLAPACK/drivers/rl_krill.hh
+++ b/RandLAPACK/drivers/rl_krill.hh
@@ -22,6 +22,16 @@ STATE krill_full_rpchol(
     int64_t n, FUNC &G, int64_t ell, const T* H, T* X, T tol,
     STATE state, SEMINORM &seminorm, int64_t rpchol_block_size = -1, int64_t max_iters = 20, int64_t k = -1
 ) {
+    // Input parameter validation. Bad inputs would otherwise propagate to a
+    // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
+    // krill_full_rpchol is called through a binding layer (e.g. MEX/MATLAB).
+    randlapack_error_if_msg(n <= 0, "n=%lld must be > 0", (long long)n);
+    randlapack_error_if_msg(ell <= 0, "ell=%lld must be > 0", (long long)ell);
+    randlapack_error_if_msg(tol < (T)0, "tol=%g must be >= 0", (double)tol);
+    randlapack_error_if_msg(max_iters <= 0, "max_iters=%lld must be > 0", (long long)max_iters);
+    randlapack_error_if_msg(H == nullptr, "H buffer must not be null");
+    randlapack_error_if_msg(X == nullptr, "X buffer must not be null");
+
     int64_t mu_size = G.num_ops;
     std::vector<T> mus(mu_size);
     std::copy(G.regs, G.regs + mu_size, mus.data());

--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_syps.hh"
 #include "rl_syrf.hh"
 #include "rl_blaspp.hh"
@@ -137,6 +138,13 @@ class REVD2 {
             std::vector<T> &eigvals,
             RandBLAS::RNGState<RNG> &state
         ) {
+            // Input parameter validation. Bad inputs would otherwise propagate to a
+            // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
+            // REVD2 is called through a binding layer (e.g. MEX/MATLAB).
+            randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
+            randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
+            randlapack_error_if_msg(tol < (T)0, "tol=%g must be >= 0", (double)tol);
+            randlapack_error_if_msg(A == nullptr && m > 0, "A buffer is null but m=%lld > 0", (long long)m);
             linops::ExplicitSymLinOp<T> A_linop(m, uplo, A, m, Layout::ColMajor);
             return this->call(A_linop, k, tol, V, eigvals, state);
         }
@@ -150,6 +158,9 @@ class REVD2 {
             std::vector<T> &eigvals,
             RandBLAS::RNGState<RNG> &state
         ) {
+            // Input parameter validation; same MEX-safety motivation as above.
+            randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
+            randlapack_error_if_msg(tol < (T)0, "tol=%g must be >= 0", (double)tol);
             int64_t m = A.dim;
             T err = 0;
             RandBLAS::RNGState<RNG> error_est_state(state.counter, state.key);

--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -141,10 +141,10 @@ class REVD2 {
             // Input parameter validation. Bad inputs would otherwise propagate to a
             // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
             // REVD2 is called through a binding layer (e.g. MEX/MATLAB).
-            randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
-            randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
-            randlapack_error_if_msg(tol < (T)0, "tol=%g must be >= 0", (double)tol);
-            randlapack_error_if_msg(A == nullptr && m > 0, "A buffer is null but m=%lld > 0", (long long)m);
+            randlapack_require(m >= 0) << "m=" << m << " must be >= 0";
+            randlapack_require(k > 0) << "target rank k=" << k << " must be > 0";
+            randlapack_require(tol >= (T)0) << "tol=" << tol << " must be >= 0";
+            randlapack_require(!(A == nullptr && m > 0)) << "A buffer is null but m=" << m << " > 0";
             linops::ExplicitSymLinOp<T> A_linop(m, uplo, A, m, Layout::ColMajor);
             return this->call(A_linop, k, tol, V, eigvals, state);
         }
@@ -159,8 +159,8 @@ class REVD2 {
             RandBLAS::RNGState<RNG> &state
         ) {
             // Input parameter validation; same MEX-safety motivation as above.
-            randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
-            randlapack_error_if_msg(tol < (T)0, "tol=%g must be >= 0", (double)tol);
+            randlapack_require(k > 0) << "target rank k=" << k << " must be > 0";
+            randlapack_require(tol >= (T)0) << "tol=" << tol << " must be >= 0";
             int64_t m = A.dim;
             T err = 0;
             RandBLAS::RNGState<RNG> error_est_state(state.counter, state.key);

--- a/RandLAPACK/drivers/rl_rsvd.hh
+++ b/RandLAPACK/drivers/rl_rsvd.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_qb.hh"
 #include "rl_blaspp.hh"
 #include "rl_lapackpp.hh"
@@ -121,6 +122,15 @@ int RSVD<T, RNG>::call(
     T* &V,
     RandBLAS::RNGState<RNG> &state
 ){
+    // Input parameter validation. Bad inputs would otherwise propagate to a
+    // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
+    // RSVD is called through a binding layer (e.g. MEX/MATLAB).
+    randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
+    randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
+    randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
+    randlapack_error_if_msg(tol < (T)0, "tol=%g must be >= 0", (double)tol);
+    randlapack_error_if_msg(A == nullptr && m > 0 && n > 0, "A buffer is null but m=%lld and n=%lld imply a nonempty matrix", (long long)m, (long long)n);
+
     T* Q = nullptr;
     T* BT = nullptr; 
     // Q and B sizes will be adjusted automatically

--- a/RandLAPACK/drivers/rl_rsvd.hh
+++ b/RandLAPACK/drivers/rl_rsvd.hh
@@ -125,11 +125,11 @@ int RSVD<T, RNG>::call(
     // Input parameter validation. Bad inputs would otherwise propagate to a
     // downstream BLAS/LAPACK failure or a segfault, the latter fatal when
     // RSVD is called through a binding layer (e.g. MEX/MATLAB).
-    randlapack_error_if_msg(m < 0, "m=%lld must be >= 0", (long long)m);
-    randlapack_error_if_msg(n < 0, "n=%lld must be >= 0", (long long)n);
-    randlapack_error_if_msg(k <= 0, "target rank k=%lld must be > 0", (long long)k);
-    randlapack_error_if_msg(tol < (T)0, "tol=%g must be >= 0", (double)tol);
-    randlapack_error_if_msg(A == nullptr && m > 0 && n > 0, "A buffer is null but m=%lld and n=%lld imply a nonempty matrix", (long long)m, (long long)n);
+    randlapack_require(m >= 0) << "m=" << m << " must be >= 0";
+    randlapack_require(n >= 0) << "n=" << n << " must be >= 0";
+    randlapack_require(k > 0) << "target rank k=" << k << " must be > 0";
+    randlapack_require(tol >= (T)0) << "tol=" << tol << " must be >= 0";
+    randlapack_require(!(A == nullptr && m > 0 && n > 0)) << "A buffer is null but m=" << m << " and n=" << n << " imply a nonempty matrix";
 
     T* Q = nullptr;
     T* BT = nullptr; 

--- a/RandLAPACK/linops/rl_composite_linop.hh
+++ b/RandLAPACK/linops/rl_composite_linop.hh
@@ -2,6 +2,7 @@
 
 // Public API: CompositeOperator — implicit product of two linear operators.
 
+#include "rl_exceptions.hh"
 #include "rl_concepts.hh"
 #include "rl_blaspp.hh"
 
@@ -121,8 +122,8 @@ public:
         owned_left_(), owned_right_(),
         left_op(left_op), right_op(right_op) {
         // Validate dimensions: left_op is (n_rows x right_op.n_rows), right_op is (right_op.n_rows x n_cols)
-        randblas_require(left_op.n_cols == right_op.n_rows);
-        randblas_require(right_op.n_cols == n_cols);
+        randlapack_error_if_msg(left_op.n_cols != right_op.n_rows, "left_op.n_cols=%lld must match right_op.n_rows=%lld for composite operator", (long long)left_op.n_cols, (long long)right_op.n_rows);
+        randlapack_error_if_msg(right_op.n_cols != n_cols, "right_op.n_cols=%lld must match composite operator n_cols=%lld", (long long)right_op.n_cols, (long long)n_cols);
     }
 
     // Non-sided dense matrix multiplication operator (required by LinearOperator concept).
@@ -185,16 +186,16 @@ public:
             // Validate input dimensions
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(k, n, trans_B);
             auto [rows_comp, cols_comp] = RandBLAS::dims_before_op(m, k, trans_comp);
-            randblas_require(rows_comp <= n_rows);
-            randblas_require(cols_comp <= n_cols);
+            randlapack_error_if_msg(rows_comp > n_rows, "op(comp) submatrix row dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_rows=%lld", (long long)rows_comp, (long long)n_rows);
+            randlapack_error_if_msg(cols_comp > n_cols, "op(comp) submatrix col dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_cols=%lld", (long long)cols_comp, (long long)n_cols);
 
             // Layout-aware dimension checks
             if (layout == Layout::ColMajor) {
-                randblas_require(ldb >= rows_B);
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {  // RowMajor
-                randblas_require(ldb >= cols_B);
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             if (trans_comp == Op::NoTrans) {
@@ -231,16 +232,16 @@ public:
 
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(m, k, trans_B);
             auto [rows_comp, cols_comp] = RandBLAS::dims_before_op(k, n, trans_comp);
-            randblas_require(rows_comp <= n_rows);
-            randblas_require(cols_comp <= n_cols);
+            randlapack_error_if_msg(rows_comp > n_rows, "op(comp) submatrix row dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_rows=%lld", (long long)rows_comp, (long long)n_rows);
+            randlapack_error_if_msg(cols_comp > n_cols, "op(comp) submatrix col dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_cols=%lld", (long long)cols_comp, (long long)n_cols);
 
             // Layout-aware dimension checks
             if (layout == Layout::ColMajor) {
-                randblas_require(ldb >= rows_B);
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {  // RowMajor
-                randblas_require(ldb >= cols_B);
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             if (trans_comp == Op::NoTrans) {
@@ -299,12 +300,12 @@ public:
 
             // Validate input dimensions
             auto [rows_comp, cols_comp] = RandBLAS::dims_before_op(m, k, trans_comp);
-            randblas_require(rows_comp <= n_rows);
-            randblas_require(cols_comp <= n_cols);
+            randlapack_error_if_msg(rows_comp > n_rows, "op(comp) submatrix row dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_rows=%lld", (long long)rows_comp, (long long)n_rows);
+            randlapack_error_if_msg(cols_comp > n_cols, "op(comp) submatrix col dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_cols=%lld", (long long)cols_comp, (long long)n_cols);
             if (layout == Layout::ColMajor) {
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {  // RowMajor
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             if (trans_comp == Op::NoTrans) {
@@ -332,12 +333,12 @@ public:
             // Right multiplication: C := alpha * op(B_sp) * (LinOp1 * LinOp2) + beta * C
 
             auto [rows_comp, cols_comp] = RandBLAS::dims_before_op(k, n, trans_comp);
-            randblas_require(rows_comp <= n_rows);
-            randblas_require(cols_comp <= n_cols);
+            randlapack_error_if_msg(rows_comp > n_rows, "op(comp) submatrix row dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_rows=%lld", (long long)rows_comp, (long long)n_rows);
+            randlapack_error_if_msg(cols_comp > n_cols, "op(comp) submatrix col dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_cols=%lld", (long long)cols_comp, (long long)n_cols);
             if (layout == Layout::ColMajor) {
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {  // RowMajor
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             if (trans_comp == Op::NoTrans) {

--- a/RandLAPACK/linops/rl_composite_linop.hh
+++ b/RandLAPACK/linops/rl_composite_linop.hh
@@ -122,8 +122,8 @@ public:
         owned_left_(), owned_right_(),
         left_op(left_op), right_op(right_op) {
         // Validate dimensions: left_op is (n_rows x right_op.n_rows), right_op is (right_op.n_rows x n_cols)
-        randlapack_error_if_msg(left_op.n_cols != right_op.n_rows, "left_op.n_cols=%lld must match right_op.n_rows=%lld for composite operator", (long long)left_op.n_cols, (long long)right_op.n_rows);
-        randlapack_error_if_msg(right_op.n_cols != n_cols, "right_op.n_cols=%lld must match composite operator n_cols=%lld", (long long)right_op.n_cols, (long long)n_cols);
+        randlapack_require(left_op.n_cols == right_op.n_rows) << "left_op.n_cols=" << left_op.n_cols << " must match right_op.n_rows=" << right_op.n_rows << " for composite operator";
+        randlapack_require(right_op.n_cols == n_cols) << "right_op.n_cols=" << right_op.n_cols << " must match composite operator n_cols=" << n_cols;
     }
 
     // Non-sided dense matrix multiplication operator (required by LinearOperator concept).
@@ -186,16 +186,16 @@ public:
             // Validate input dimensions
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(k, n, trans_B);
             auto [rows_comp, cols_comp] = RandBLAS::dims_before_op(m, k, trans_comp);
-            randlapack_error_if_msg(rows_comp > n_rows, "op(comp) submatrix row dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_rows=%lld", (long long)rows_comp, (long long)n_rows);
-            randlapack_error_if_msg(cols_comp > n_cols, "op(comp) submatrix col dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_cols=%lld", (long long)cols_comp, (long long)n_cols);
+            randlapack_require(rows_comp <= n_rows) << "op(comp) submatrix row dim inferred from (m, k, trans_comp) is " << rows_comp << " but exceeds composite operator n_rows=" << n_rows;
+            randlapack_require(cols_comp <= n_cols) << "op(comp) submatrix col dim inferred from (m, k, trans_comp) is " << cols_comp << " but exceeds composite operator n_cols=" << n_cols;
 
             // Layout-aware dimension checks
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldb >= rows_B) << "ldb=" << ldb << " < rows_B=" << rows_B << " (ldb must be >= rows of op(B) under ColMajor)";
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {  // RowMajor
-                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldb >= cols_B) << "ldb=" << ldb << " < cols_B=" << cols_B << " (ldb must be >= cols of op(B) under RowMajor)";
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             if (trans_comp == Op::NoTrans) {
@@ -232,16 +232,16 @@ public:
 
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(m, k, trans_B);
             auto [rows_comp, cols_comp] = RandBLAS::dims_before_op(k, n, trans_comp);
-            randlapack_error_if_msg(rows_comp > n_rows, "op(comp) submatrix row dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_rows=%lld", (long long)rows_comp, (long long)n_rows);
-            randlapack_error_if_msg(cols_comp > n_cols, "op(comp) submatrix col dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_cols=%lld", (long long)cols_comp, (long long)n_cols);
+            randlapack_require(rows_comp <= n_rows) << "op(comp) submatrix row dim inferred from (m, k, trans_comp) is " << rows_comp << " but exceeds composite operator n_rows=" << n_rows;
+            randlapack_require(cols_comp <= n_cols) << "op(comp) submatrix col dim inferred from (m, k, trans_comp) is " << cols_comp << " but exceeds composite operator n_cols=" << n_cols;
 
             // Layout-aware dimension checks
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldb >= rows_B) << "ldb=" << ldb << " < rows_B=" << rows_B << " (ldb must be >= rows of op(B) under ColMajor)";
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {  // RowMajor
-                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldb >= cols_B) << "ldb=" << ldb << " < cols_B=" << cols_B << " (ldb must be >= cols of op(B) under RowMajor)";
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             if (trans_comp == Op::NoTrans) {
@@ -300,12 +300,12 @@ public:
 
             // Validate input dimensions
             auto [rows_comp, cols_comp] = RandBLAS::dims_before_op(m, k, trans_comp);
-            randlapack_error_if_msg(rows_comp > n_rows, "op(comp) submatrix row dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_rows=%lld", (long long)rows_comp, (long long)n_rows);
-            randlapack_error_if_msg(cols_comp > n_cols, "op(comp) submatrix col dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_cols=%lld", (long long)cols_comp, (long long)n_cols);
+            randlapack_require(rows_comp <= n_rows) << "op(comp) submatrix row dim inferred from (m, k, trans_comp) is " << rows_comp << " but exceeds composite operator n_rows=" << n_rows;
+            randlapack_require(cols_comp <= n_cols) << "op(comp) submatrix col dim inferred from (m, k, trans_comp) is " << cols_comp << " but exceeds composite operator n_cols=" << n_cols;
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {  // RowMajor
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             if (trans_comp == Op::NoTrans) {
@@ -333,12 +333,12 @@ public:
             // Right multiplication: C := alpha * op(B_sp) * (LinOp1 * LinOp2) + beta * C
 
             auto [rows_comp, cols_comp] = RandBLAS::dims_before_op(k, n, trans_comp);
-            randlapack_error_if_msg(rows_comp > n_rows, "op(comp) submatrix row dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_rows=%lld", (long long)rows_comp, (long long)n_rows);
-            randlapack_error_if_msg(cols_comp > n_cols, "op(comp) submatrix col dim inferred from (m, k, trans_comp) is %lld but exceeds composite operator n_cols=%lld", (long long)cols_comp, (long long)n_cols);
+            randlapack_require(rows_comp <= n_rows) << "op(comp) submatrix row dim inferred from (m, k, trans_comp) is " << rows_comp << " but exceeds composite operator n_rows=" << n_rows;
+            randlapack_require(cols_comp <= n_cols) << "op(comp) submatrix col dim inferred from (m, k, trans_comp) is " << cols_comp << " but exceeds composite operator n_cols=" << n_cols;
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {  // RowMajor
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             if (trans_comp == Op::NoTrans) {

--- a/RandLAPACK/linops/rl_dense_linop.hh
+++ b/RandLAPACK/linops/rl_dense_linop.hh
@@ -2,6 +2,7 @@
 
 // Public API: DenseLinOp — linear operator backed by a dense matrix buffer.
 
+#include "rl_exceptions.hh"
 #include "rl_concepts.hh"
 #include "rl_blaspp.hh"
 #include "rl_lapackpp.hh"
@@ -55,9 +56,9 @@ struct DenseLinOp {
     ) : n_rows(n_rows), n_cols(n_cols), A_buff(A_buff), lda(lda), buff_layout(buff_layout) {
         // Validate leading dimension based on layout
         if (buff_layout == Layout::ColMajor) {
-            randblas_require(lda >= n_rows);
+            randlapack_error_if_msg(lda < n_rows, "lda=%lld < n_rows=%lld (lda must be >= n_rows under ColMajor)", (long long)lda, (long long)n_rows);
         } else {  // RowMajor
-            randblas_require(lda >= n_cols);
+            randlapack_error_if_msg(lda < n_cols, "lda=%lld < n_cols=%lld (lda must be >= n_cols under RowMajor)", (long long)lda, (long long)n_cols);
         }
     }
 
@@ -105,22 +106,22 @@ struct DenseLinOp {
         T* C,
         int64_t ldc
     ) {
-        randblas_require(layout == buff_layout);
+        randlapack_error_if_msg(layout != buff_layout, "operation layout must match the operator storage layout (buff_layout)");
 
         if (side == Side::Left) {
             // C := alpha * op(A) * op(B) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(k, n, trans_B);
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
-            randblas_require(rows_A == n_rows);
-            randblas_require(cols_A == n_cols);
+            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
+            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
 
             // Layout-aware dimension checks
             if (layout == Layout::ColMajor) {
-                randblas_require(ldb >= rows_B);
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {  // RowMajor
-                randblas_require(ldb >= cols_B);
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             blas::gemm(layout, trans_A, trans_B, m, n, k, alpha, A_buff, lda, B, ldb, beta, C, ldc);
@@ -128,16 +129,16 @@ struct DenseLinOp {
             // C := alpha * op(B) * op(A) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(m, k, trans_B);
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
-            randblas_require(rows_A == n_rows);
-            randblas_require(cols_A == n_cols);
+            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
+            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
 
             // Layout-aware dimension checks
             if (layout == Layout::ColMajor) {
-                randblas_require(ldb >= rows_B);
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {  // RowMajor
-                randblas_require(ldb >= cols_B);
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             blas::gemm(layout, trans_B, trans_A, m, n, k, alpha, B, ldb, A_buff, lda, beta, C, ldc);
@@ -181,31 +182,31 @@ struct DenseLinOp {
         T* C,
         int64_t ldc
     ) {
-        randblas_require(layout == buff_layout);
+        randlapack_error_if_msg(layout != buff_layout, "operation layout must match the operator storage layout (buff_layout)");
 
         if (side == Side::Left) {
             // C = alpha * op(A) * op(B_sp) + beta * C
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
-            randblas_require(rows_A == n_rows);
-            randblas_require(cols_A == n_cols);
+            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
+            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
 
             if (layout == Layout::ColMajor) {
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             RandBLAS::sparse_data::right_spmm(layout, trans_A, trans_B, m, n, k, alpha, A_buff, lda, B_sp, 0, 0, beta, C, ldc);
         } else {  // Side::Right
             // C = alpha * op(B_sp) * op(A) + beta * C
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
-            randblas_require(rows_A == n_rows);
-            randblas_require(cols_A == n_cols);
+            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
+            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
 
             if (layout == Layout::ColMajor) {
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             RandBLAS::sparse_data::left_spmm(layout, trans_B, trans_A, m, n, k, alpha, B_sp, 0, 0, A_buff, lda, beta, C, ldc);
@@ -250,19 +251,19 @@ struct DenseLinOp {
         T* C,
         int64_t ldc
     ) {
-        randblas_require(layout == buff_layout);
+        randlapack_error_if_msg(layout != buff_layout, "operation layout must match the operator storage layout (buff_layout)");
 
         if (side == Side::Left) {
             // C = alpha * op(A) * op(S) + beta * C
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
-            randblas_require(rows_A == n_rows);
-            randblas_require(cols_A == n_cols);
+            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
+            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
 
             // Layout-aware ldc check
             if (layout == Layout::ColMajor) {
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             // Right sketch in RandBLAS terms: B = alpha * op(A) * op(S) + beta * B
@@ -271,14 +272,14 @@ struct DenseLinOp {
         } else {  // Side::Right
             // C = alpha * op(S) * op(A) + beta * C
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
-            randblas_require(rows_A == n_rows);
-            randblas_require(cols_A == n_cols);
+            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
+            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
 
             // Layout-aware ldc check
             if (layout == Layout::ColMajor) {
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             // Left sketch in RandBLAS terms: B = alpha * op(S) * op(A) + beta * B
@@ -292,9 +293,9 @@ struct DenseLinOp {
 
     /// @brief Create a view of a contiguous row range [row_start, row_start + row_count).
     DenseLinOp<T> row_block(int64_t row_start, int64_t row_count) const {
-        randblas_require(row_start >= 0);
-        randblas_require(row_count > 0);
-        randblas_require(row_start + row_count <= n_rows);
+        randlapack_error_if_msg(row_start < 0, "row_start=%lld must be >= 0", (long long)row_start);
+        randlapack_error_if_msg(row_count <= 0, "row_count=%lld must be > 0", (long long)row_count);
+        randlapack_error_if_msg(row_start + row_count > n_rows, "row_start=%lld + row_count=%lld exceeds n_rows=%lld", (long long)row_start, (long long)row_count, (long long)n_rows);
         const T* offset = (buff_layout == Layout::ColMajor)
             ? A_buff + row_start
             : A_buff + row_start * lda;
@@ -303,9 +304,9 @@ struct DenseLinOp {
 
     /// @brief Create a view of a contiguous column range [col_start, col_start + col_count).
     DenseLinOp<T> col_block(int64_t col_start, int64_t col_count) const {
-        randblas_require(col_start >= 0);
-        randblas_require(col_count > 0);
-        randblas_require(col_start + col_count <= n_cols);
+        randlapack_error_if_msg(col_start < 0, "col_start=%lld must be >= 0", (long long)col_start);
+        randlapack_error_if_msg(col_count <= 0, "col_count=%lld must be > 0", (long long)col_count);
+        randlapack_error_if_msg(col_start + col_count > n_cols, "col_start=%lld + col_count=%lld exceeds n_cols=%lld", (long long)col_start, (long long)col_count, (long long)n_cols);
         const T* offset = (buff_layout == Layout::ColMajor)
             ? A_buff + col_start * lda
             : A_buff + col_start;
@@ -315,12 +316,12 @@ struct DenseLinOp {
     /// @brief Create a view of a submatrix starting at (row_start, col_start).
     DenseLinOp<T> submatrix(int64_t row_start, int64_t col_start,
                             int64_t row_count, int64_t col_count) const {
-        randblas_require(row_start >= 0);
-        randblas_require(col_start >= 0);
-        randblas_require(row_count > 0);
-        randblas_require(col_count > 0);
-        randblas_require(row_start + row_count <= n_rows);
-        randblas_require(col_start + col_count <= n_cols);
+        randlapack_error_if_msg(row_start < 0, "row_start=%lld must be >= 0", (long long)row_start);
+        randlapack_error_if_msg(col_start < 0, "col_start=%lld must be >= 0", (long long)col_start);
+        randlapack_error_if_msg(row_count <= 0, "row_count=%lld must be > 0", (long long)row_count);
+        randlapack_error_if_msg(col_count <= 0, "col_count=%lld must be > 0", (long long)col_count);
+        randlapack_error_if_msg(row_start + row_count > n_rows, "row_start=%lld + row_count=%lld exceeds n_rows=%lld", (long long)row_start, (long long)row_count, (long long)n_rows);
+        randlapack_error_if_msg(col_start + col_count > n_cols, "col_start=%lld + col_count=%lld exceeds n_cols=%lld", (long long)col_start, (long long)col_count, (long long)n_cols);
         const T* offset = (buff_layout == Layout::ColMajor)
             ? A_buff + row_start + col_start * lda
             : A_buff + row_start * lda + col_start;

--- a/RandLAPACK/linops/rl_dense_linop.hh
+++ b/RandLAPACK/linops/rl_dense_linop.hh
@@ -56,9 +56,9 @@ struct DenseLinOp {
     ) : n_rows(n_rows), n_cols(n_cols), A_buff(A_buff), lda(lda), buff_layout(buff_layout) {
         // Validate leading dimension based on layout
         if (buff_layout == Layout::ColMajor) {
-            randlapack_error_if_msg(lda < n_rows, "lda=%lld < n_rows=%lld (lda must be >= n_rows under ColMajor)", (long long)lda, (long long)n_rows);
+            randlapack_require(lda >= n_rows) << "lda=" << lda << " < n_rows=" << n_rows << " (lda must be >= n_rows under ColMajor)";
         } else {  // RowMajor
-            randlapack_error_if_msg(lda < n_cols, "lda=%lld < n_cols=%lld (lda must be >= n_cols under RowMajor)", (long long)lda, (long long)n_cols);
+            randlapack_require(lda >= n_cols) << "lda=" << lda << " < n_cols=" << n_cols << " (lda must be >= n_cols under RowMajor)";
         }
     }
 
@@ -106,22 +106,22 @@ struct DenseLinOp {
         T* C,
         int64_t ldc
     ) {
-        randlapack_error_if_msg(layout != buff_layout, "operation layout must match the operator storage layout (buff_layout)");
+        randlapack_require(layout == buff_layout) << "operation layout must match the operator storage layout (buff_layout)";
 
         if (side == Side::Left) {
             // C := alpha * op(A) * op(B) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(k, n, trans_B);
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
-            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
-            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
+            randlapack_require(rows_A == n_rows) << "op(A) row dim inferred from (m, k, trans_A) is " << rows_A << " but operator n_rows=" << n_rows;
+            randlapack_require(cols_A == n_cols) << "op(A) col dim inferred from (m, k, trans_A) is " << cols_A << " but operator n_cols=" << n_cols;
 
             // Layout-aware dimension checks
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldb >= rows_B) << "ldb=" << ldb << " < rows_B=" << rows_B << " (ldb must be >= rows of op(B) under ColMajor)";
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {  // RowMajor
-                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldb >= cols_B) << "ldb=" << ldb << " < cols_B=" << cols_B << " (ldb must be >= cols of op(B) under RowMajor)";
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             blas::gemm(layout, trans_A, trans_B, m, n, k, alpha, A_buff, lda, B, ldb, beta, C, ldc);
@@ -129,16 +129,16 @@ struct DenseLinOp {
             // C := alpha * op(B) * op(A) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(m, k, trans_B);
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
-            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
-            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
+            randlapack_require(rows_A == n_rows) << "op(A) row dim inferred from (m, k, trans_A) is " << rows_A << " but operator n_rows=" << n_rows;
+            randlapack_require(cols_A == n_cols) << "op(A) col dim inferred from (m, k, trans_A) is " << cols_A << " but operator n_cols=" << n_cols;
 
             // Layout-aware dimension checks
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldb >= rows_B) << "ldb=" << ldb << " < rows_B=" << rows_B << " (ldb must be >= rows of op(B) under ColMajor)";
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {  // RowMajor
-                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldb >= cols_B) << "ldb=" << ldb << " < cols_B=" << cols_B << " (ldb must be >= cols of op(B) under RowMajor)";
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             blas::gemm(layout, trans_B, trans_A, m, n, k, alpha, B, ldb, A_buff, lda, beta, C, ldc);
@@ -182,31 +182,31 @@ struct DenseLinOp {
         T* C,
         int64_t ldc
     ) {
-        randlapack_error_if_msg(layout != buff_layout, "operation layout must match the operator storage layout (buff_layout)");
+        randlapack_require(layout == buff_layout) << "operation layout must match the operator storage layout (buff_layout)";
 
         if (side == Side::Left) {
             // C = alpha * op(A) * op(B_sp) + beta * C
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
-            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
-            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
+            randlapack_require(rows_A == n_rows) << "op(A) row dim inferred from (m, k, trans_A) is " << rows_A << " but operator n_rows=" << n_rows;
+            randlapack_require(cols_A == n_cols) << "op(A) col dim inferred from (m, k, trans_A) is " << cols_A << " but operator n_cols=" << n_cols;
 
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             RandBLAS::sparse_data::right_spmm(layout, trans_A, trans_B, m, n, k, alpha, A_buff, lda, B_sp, 0, 0, beta, C, ldc);
         } else {  // Side::Right
             // C = alpha * op(B_sp) * op(A) + beta * C
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
-            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
-            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
+            randlapack_require(rows_A == n_rows) << "op(A) row dim inferred from (m, k, trans_A) is " << rows_A << " but operator n_rows=" << n_rows;
+            randlapack_require(cols_A == n_cols) << "op(A) col dim inferred from (m, k, trans_A) is " << cols_A << " but operator n_cols=" << n_cols;
 
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             RandBLAS::sparse_data::left_spmm(layout, trans_B, trans_A, m, n, k, alpha, B_sp, 0, 0, A_buff, lda, beta, C, ldc);
@@ -251,19 +251,19 @@ struct DenseLinOp {
         T* C,
         int64_t ldc
     ) {
-        randlapack_error_if_msg(layout != buff_layout, "operation layout must match the operator storage layout (buff_layout)");
+        randlapack_require(layout == buff_layout) << "operation layout must match the operator storage layout (buff_layout)";
 
         if (side == Side::Left) {
             // C = alpha * op(A) * op(S) + beta * C
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
-            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
-            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
+            randlapack_require(rows_A == n_rows) << "op(A) row dim inferred from (m, k, trans_A) is " << rows_A << " but operator n_rows=" << n_rows;
+            randlapack_require(cols_A == n_cols) << "op(A) col dim inferred from (m, k, trans_A) is " << cols_A << " but operator n_cols=" << n_cols;
 
             // Layout-aware ldc check
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             // Right sketch in RandBLAS terms: B = alpha * op(A) * op(S) + beta * B
@@ -272,14 +272,14 @@ struct DenseLinOp {
         } else {  // Side::Right
             // C = alpha * op(S) * op(A) + beta * C
             auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
-            randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
-            randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
+            randlapack_require(rows_A == n_rows) << "op(A) row dim inferred from (m, k, trans_A) is " << rows_A << " but operator n_rows=" << n_rows;
+            randlapack_require(cols_A == n_cols) << "op(A) col dim inferred from (m, k, trans_A) is " << cols_A << " but operator n_cols=" << n_cols;
 
             // Layout-aware ldc check
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             // Left sketch in RandBLAS terms: B = alpha * op(S) * op(A) + beta * B
@@ -293,9 +293,9 @@ struct DenseLinOp {
 
     /// @brief Create a view of a contiguous row range [row_start, row_start + row_count).
     DenseLinOp<T> row_block(int64_t row_start, int64_t row_count) const {
-        randlapack_error_if_msg(row_start < 0, "row_start=%lld must be >= 0", (long long)row_start);
-        randlapack_error_if_msg(row_count <= 0, "row_count=%lld must be > 0", (long long)row_count);
-        randlapack_error_if_msg(row_start + row_count > n_rows, "row_start=%lld + row_count=%lld exceeds n_rows=%lld", (long long)row_start, (long long)row_count, (long long)n_rows);
+        randlapack_require(row_start >= 0) << "row_start=" << row_start << " must be >= 0";
+        randlapack_require(row_count > 0) << "row_count=" << row_count << " must be > 0";
+        randlapack_require(row_start + row_count <= n_rows) << "row_start=" << row_start << " + row_count=" << row_count << " exceeds n_rows=" << n_rows;
         const T* offset = (buff_layout == Layout::ColMajor)
             ? A_buff + row_start
             : A_buff + row_start * lda;
@@ -304,9 +304,9 @@ struct DenseLinOp {
 
     /// @brief Create a view of a contiguous column range [col_start, col_start + col_count).
     DenseLinOp<T> col_block(int64_t col_start, int64_t col_count) const {
-        randlapack_error_if_msg(col_start < 0, "col_start=%lld must be >= 0", (long long)col_start);
-        randlapack_error_if_msg(col_count <= 0, "col_count=%lld must be > 0", (long long)col_count);
-        randlapack_error_if_msg(col_start + col_count > n_cols, "col_start=%lld + col_count=%lld exceeds n_cols=%lld", (long long)col_start, (long long)col_count, (long long)n_cols);
+        randlapack_require(col_start >= 0) << "col_start=" << col_start << " must be >= 0";
+        randlapack_require(col_count > 0) << "col_count=" << col_count << " must be > 0";
+        randlapack_require(col_start + col_count <= n_cols) << "col_start=" << col_start << " + col_count=" << col_count << " exceeds n_cols=" << n_cols;
         const T* offset = (buff_layout == Layout::ColMajor)
             ? A_buff + col_start * lda
             : A_buff + col_start;
@@ -316,12 +316,12 @@ struct DenseLinOp {
     /// @brief Create a view of a submatrix starting at (row_start, col_start).
     DenseLinOp<T> submatrix(int64_t row_start, int64_t col_start,
                             int64_t row_count, int64_t col_count) const {
-        randlapack_error_if_msg(row_start < 0, "row_start=%lld must be >= 0", (long long)row_start);
-        randlapack_error_if_msg(col_start < 0, "col_start=%lld must be >= 0", (long long)col_start);
-        randlapack_error_if_msg(row_count <= 0, "row_count=%lld must be > 0", (long long)row_count);
-        randlapack_error_if_msg(col_count <= 0, "col_count=%lld must be > 0", (long long)col_count);
-        randlapack_error_if_msg(row_start + row_count > n_rows, "row_start=%lld + row_count=%lld exceeds n_rows=%lld", (long long)row_start, (long long)row_count, (long long)n_rows);
-        randlapack_error_if_msg(col_start + col_count > n_cols, "col_start=%lld + col_count=%lld exceeds n_cols=%lld", (long long)col_start, (long long)col_count, (long long)n_cols);
+        randlapack_require(row_start >= 0) << "row_start=" << row_start << " must be >= 0";
+        randlapack_require(col_start >= 0) << "col_start=" << col_start << " must be >= 0";
+        randlapack_require(row_count > 0) << "row_count=" << row_count << " must be > 0";
+        randlapack_require(col_count > 0) << "col_count=" << col_count << " must be > 0";
+        randlapack_require(row_start + row_count <= n_rows) << "row_start=" << row_start << " + row_count=" << row_count << " exceeds n_rows=" << n_rows;
+        randlapack_require(col_start + col_count <= n_cols) << "col_start=" << col_start << " + col_count=" << col_count << " exceeds n_cols=" << n_cols;
         const T* offset = (buff_layout == Layout::ColMajor)
             ? A_buff + row_start + col_start * lda
             : A_buff + row_start * lda + col_start;

--- a/RandLAPACK/linops/rl_materialize.hh
+++ b/RandLAPACK/linops/rl_materialize.hh
@@ -7,6 +7,7 @@
 // Overloaded specializations avoid that cost when the underlying storage is
 // directly accessible (DenseLinOp, SparseLinOp).
 
+#include "rl_exceptions.hh"
 #include "rl_concepts.hh"
 #include "rl_dense_linop.hh"
 #include "rl_sparse_linop.hh"
@@ -32,7 +33,7 @@ namespace RandLAPACK {
 template <typename LinOp>
 void materialize(LinOp& A, int64_t m, int64_t n, typename LinOp::scalar_t* buf, int64_t ldb) {
     using T = typename LinOp::scalar_t;
-    randblas_require(ldb >= m);
+    randlapack_error_if_msg(ldb < m, "ldb=%lld < m=%lld (ldb must be >= m)", (long long)ldb, (long long)m);
     // Zero the output buffer.
     for (int64_t j = 0; j < n; ++j)
         for (int64_t i = 0; i < m; ++i)
@@ -50,9 +51,9 @@ void materialize(LinOp& A, int64_t m, int64_t n, typename LinOp::scalar_t* buf, 
 /// fall back to the generic path (RowMajor).
 template <typename T>
 void materialize(linops::DenseLinOp<T>& A, int64_t m, int64_t n, T* buf, int64_t ldb) {
-    randblas_require(m == A.n_rows);
-    randblas_require(n == A.n_cols);
-    randblas_require(ldb >= m);
+    randlapack_error_if_msg(m != A.n_rows, "m=%lld must equal A.n_rows=%lld for materialize specialization", (long long)m, (long long)A.n_rows);
+    randlapack_error_if_msg(n != A.n_cols, "n=%lld must equal A.n_cols=%lld for materialize specialization", (long long)n, (long long)A.n_cols);
+    randlapack_error_if_msg(ldb < m, "ldb=%lld < m=%lld (ldb must be >= m)", (long long)ldb, (long long)m);
     if (A.buff_layout == blas::Layout::ColMajor) {
         lapack::lacpy(lapack::MatrixType::General, m, n, A.A_buff, A.lda, buf, ldb);
     } else {
@@ -68,9 +69,9 @@ template <RandBLAS::sparse_data::SparseMatrix SpMat>
 void materialize(linops::SparseLinOp<SpMat>& A, int64_t m, int64_t n,
                  typename SpMat::scalar_t* buf, int64_t ldb) {
     using T = typename SpMat::scalar_t;
-    randblas_require(m == A.n_rows);
-    randblas_require(n == A.n_cols);
-    randblas_require(ldb >= m);
+    randlapack_error_if_msg(m != A.n_rows, "m=%lld must equal A.n_rows=%lld for materialize specialization", (long long)m, (long long)A.n_rows);
+    randlapack_error_if_msg(n != A.n_cols, "n=%lld must equal A.n_cols=%lld for materialize specialization", (long long)n, (long long)A.n_cols);
+    randlapack_error_if_msg(ldb < m, "ldb=%lld < m=%lld (ldb must be >= m)", (long long)ldb, (long long)m);
     // Zero the output buffer.
     for (int64_t j = 0; j < n; ++j)
         for (int64_t i = 0; i < m; ++i)

--- a/RandLAPACK/linops/rl_materialize.hh
+++ b/RandLAPACK/linops/rl_materialize.hh
@@ -33,7 +33,7 @@ namespace RandLAPACK {
 template <typename LinOp>
 void materialize(LinOp& A, int64_t m, int64_t n, typename LinOp::scalar_t* buf, int64_t ldb) {
     using T = typename LinOp::scalar_t;
-    randlapack_error_if_msg(ldb < m, "ldb=%lld < m=%lld (ldb must be >= m)", (long long)ldb, (long long)m);
+    randlapack_require(ldb >= m) << "ldb=" << ldb << " < m=" << m << " (ldb must be >= m)";
     // Zero the output buffer.
     for (int64_t j = 0; j < n; ++j)
         for (int64_t i = 0; i < m; ++i)
@@ -51,9 +51,9 @@ void materialize(LinOp& A, int64_t m, int64_t n, typename LinOp::scalar_t* buf, 
 /// fall back to the generic path (RowMajor).
 template <typename T>
 void materialize(linops::DenseLinOp<T>& A, int64_t m, int64_t n, T* buf, int64_t ldb) {
-    randlapack_error_if_msg(m != A.n_rows, "m=%lld must equal A.n_rows=%lld for materialize specialization", (long long)m, (long long)A.n_rows);
-    randlapack_error_if_msg(n != A.n_cols, "n=%lld must equal A.n_cols=%lld for materialize specialization", (long long)n, (long long)A.n_cols);
-    randlapack_error_if_msg(ldb < m, "ldb=%lld < m=%lld (ldb must be >= m)", (long long)ldb, (long long)m);
+    randlapack_require(m == A.n_rows) << "m=" << m << " must equal A.n_rows=" << A.n_rows << " for materialize specialization";
+    randlapack_require(n == A.n_cols) << "n=" << n << " must equal A.n_cols=" << A.n_cols << " for materialize specialization";
+    randlapack_require(ldb >= m) << "ldb=" << ldb << " < m=" << m << " (ldb must be >= m)";
     if (A.buff_layout == blas::Layout::ColMajor) {
         lapack::lacpy(lapack::MatrixType::General, m, n, A.A_buff, A.lda, buf, ldb);
     } else {
@@ -69,9 +69,9 @@ template <RandBLAS::sparse_data::SparseMatrix SpMat>
 void materialize(linops::SparseLinOp<SpMat>& A, int64_t m, int64_t n,
                  typename SpMat::scalar_t* buf, int64_t ldb) {
     using T = typename SpMat::scalar_t;
-    randlapack_error_if_msg(m != A.n_rows, "m=%lld must equal A.n_rows=%lld for materialize specialization", (long long)m, (long long)A.n_rows);
-    randlapack_error_if_msg(n != A.n_cols, "n=%lld must equal A.n_cols=%lld for materialize specialization", (long long)n, (long long)A.n_cols);
-    randlapack_error_if_msg(ldb < m, "ldb=%lld < m=%lld (ldb must be >= m)", (long long)ldb, (long long)m);
+    randlapack_require(m == A.n_rows) << "m=" << m << " must equal A.n_rows=" << A.n_rows << " for materialize specialization";
+    randlapack_require(n == A.n_cols) << "n=" << n << " must equal A.n_cols=" << A.n_cols << " for materialize specialization";
+    randlapack_require(ldb >= m) << "ldb=" << ldb << " < m=" << m << " (ldb must be >= m)";
     // Zero the output buffer.
     for (int64_t j = 0; j < n; ++j)
         for (int64_t i = 0; i < m; ++i)

--- a/RandLAPACK/linops/rl_sparse_linop.hh
+++ b/RandLAPACK/linops/rl_sparse_linop.hh
@@ -2,6 +2,7 @@
 
 // Public API: SparseLinOp — linear operator backed by a sparse matrix (CSR, CSC, or COO).
 
+#include "rl_exceptions.hh"
 #include "rl_concepts.hh"
 #include "rl_sparse_views.hh"
 #include "rl_blaspp.hh"
@@ -161,15 +162,15 @@ public:
             // C := alpha * op(A_sp) * op(B) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(k, n, trans_B);
             auto [rows_submat_A, cols_submat_A] = RandBLAS::dims_before_op(m, k, trans_A);
-            randblas_require(rows_submat_A <= n_rows);
-            randblas_require(cols_submat_A <= n_cols);
+            randlapack_error_if_msg(rows_submat_A > n_rows, "op(A) submatrix row dim inferred from (m, k, trans_A) is %lld but exceeds operator n_rows=%lld", (long long)rows_submat_A, (long long)n_rows);
+            randlapack_error_if_msg(cols_submat_A > n_cols, "op(A) submatrix col dim inferred from (m, k, trans_A) is %lld but exceeds operator n_cols=%lld", (long long)cols_submat_A, (long long)n_cols);
 
             if (layout == Layout::ColMajor) {
-                randblas_require(ldb >= rows_B);
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {
-                randblas_require(ldb >= cols_B);
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             RandBLAS::sparse_data::left_spmm(layout, trans_A, trans_B, m, n, k, alpha, A_sp, 0, 0, B, ldb, beta, C, ldc);
@@ -177,15 +178,15 @@ public:
             // C := alpha * op(B) * op(A_sp) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(m, k, trans_B);
             auto [rows_submat_A, cols_submat_A] = RandBLAS::dims_before_op(k, n, trans_A);
-            randblas_require(rows_submat_A <= n_rows);
-            randblas_require(cols_submat_A <= n_cols);
+            randlapack_error_if_msg(rows_submat_A > n_rows, "op(A) submatrix row dim inferred from (m, k, trans_A) is %lld but exceeds operator n_rows=%lld", (long long)rows_submat_A, (long long)n_rows);
+            randlapack_error_if_msg(cols_submat_A > n_cols, "op(A) submatrix col dim inferred from (m, k, trans_A) is %lld but exceeds operator n_cols=%lld", (long long)cols_submat_A, (long long)n_cols);
 
             if (layout == Layout::ColMajor) {
-                randblas_require(ldb >= rows_B);
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {
-                randblas_require(ldb >= cols_B);
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             RandBLAS::sparse_data::right_spmm(layout, trans_B, trans_A, m, n, k, alpha, B, ldb, A_sp, 0, 0, beta, C, ldc);
@@ -233,13 +234,13 @@ public:
             // C := alpha * op(A_sp) * op(B_sp) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(k, n, trans_B);
             auto [rows_submat_A, cols_submat_A] = RandBLAS::dims_before_op(m, k, trans_A);
-            randblas_require(rows_submat_A <= n_rows);
-            randblas_require(cols_submat_A <= n_cols);
+            randlapack_error_if_msg(rows_submat_A > n_rows, "op(A) submatrix row dim inferred from (m, k, trans_A) is %lld but exceeds operator n_rows=%lld", (long long)rows_submat_A, (long long)n_rows);
+            randlapack_error_if_msg(cols_submat_A > n_cols, "op(A) submatrix col dim inferred from (m, k, trans_A) is %lld but exceeds operator n_cols=%lld", (long long)cols_submat_A, (long long)n_cols);
 
             if (layout == Layout::ColMajor) {
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             #if defined(RandBLAS_HAS_MKL)
@@ -260,13 +261,13 @@ public:
             // C := alpha * op(B_sp) * op(A_sp) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(m, k, trans_B);
             auto [rows_submat_A, cols_submat_A] = RandBLAS::dims_before_op(k, n, trans_A);
-            randblas_require(rows_submat_A <= n_rows);
-            randblas_require(cols_submat_A <= n_cols);
+            randlapack_error_if_msg(rows_submat_A > n_rows, "op(A) submatrix row dim inferred from (m, k, trans_A) is %lld but exceeds operator n_rows=%lld", (long long)rows_submat_A, (long long)n_rows);
+            randlapack_error_if_msg(cols_submat_A > n_cols, "op(A) submatrix col dim inferred from (m, k, trans_A) is %lld but exceeds operator n_cols=%lld", (long long)cols_submat_A, (long long)n_cols);
 
             if (layout == Layout::ColMajor) {
-                randblas_require(ldc >= m);
+                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
             } else {
-                randblas_require(ldc >= n);
+                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
             }
 
             #if defined(RandBLAS_HAS_MKL)
@@ -344,19 +345,19 @@ public:
 
                 if (side == Side::Left && trans_S == Op::NoTrans) {
                     auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
-                    randblas_require(rows_A == n_rows);
-                    randblas_require(cols_A == n_cols);
-                    if (layout == Layout::ColMajor) randblas_require(ldc >= m);
-                    else randblas_require(ldc >= n);
+                    randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
+                    randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
+                    if (layout == Layout::ColMajor) randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                    else randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
                     RandBLAS::spgemm(layout, trans_A, alpha, A_sp, S_coo, beta, C, ldc);
                     return;
                 }
                 if (side == Side::Right && trans_A == Op::NoTrans) {
                     auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
-                    randblas_require(rows_A == n_rows);
-                    randblas_require(cols_A == n_cols);
-                    if (layout == Layout::ColMajor) randblas_require(ldc >= m);
-                    else randblas_require(ldc >= n);
+                    randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
+                    randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
+                    if (layout == Layout::ColMajor) randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                    else randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
                     RandBLAS::spgemm(layout, trans_S, alpha, S_coo, A_sp, beta, C, ldc);
                     return;
                 }
@@ -370,17 +371,17 @@ public:
 
             if (side == Side::Left) {
                 auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
-                randblas_require(rows_A == n_rows);
-                randblas_require(cols_A == n_cols);
-                if (layout == Layout::ColMajor) randblas_require(ldc >= m);
-                else randblas_require(ldc >= n);
+                randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
+                randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
+                if (layout == Layout::ColMajor) randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                else randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
                 RandBLAS::sketch_general(layout, trans_A, trans_S, m, n, k, alpha, A_dense, lda, S, beta, C, ldc);
             } else {
                 auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
-                randblas_require(rows_A == n_rows);
-                randblas_require(cols_A == n_cols);
-                if (layout == Layout::ColMajor) randblas_require(ldc >= m);
-                else randblas_require(ldc >= n);
+                randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
+                randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
+                if (layout == Layout::ColMajor) randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                else randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
                 RandBLAS::sketch_general(layout, trans_S, trans_A, m, n, k, alpha, S, A_dense, lda, beta, C, ldc);
             }
 

--- a/RandLAPACK/linops/rl_sparse_linop.hh
+++ b/RandLAPACK/linops/rl_sparse_linop.hh
@@ -162,15 +162,15 @@ public:
             // C := alpha * op(A_sp) * op(B) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(k, n, trans_B);
             auto [rows_submat_A, cols_submat_A] = RandBLAS::dims_before_op(m, k, trans_A);
-            randlapack_error_if_msg(rows_submat_A > n_rows, "op(A) submatrix row dim inferred from (m, k, trans_A) is %lld but exceeds operator n_rows=%lld", (long long)rows_submat_A, (long long)n_rows);
-            randlapack_error_if_msg(cols_submat_A > n_cols, "op(A) submatrix col dim inferred from (m, k, trans_A) is %lld but exceeds operator n_cols=%lld", (long long)cols_submat_A, (long long)n_cols);
+            randlapack_require(rows_submat_A <= n_rows) << "op(A) submatrix row dim inferred from (m, k, trans_A) is " << rows_submat_A << " but exceeds operator n_rows=" << n_rows;
+            randlapack_require(cols_submat_A <= n_cols) << "op(A) submatrix col dim inferred from (m, k, trans_A) is " << cols_submat_A << " but exceeds operator n_cols=" << n_cols;
 
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldb >= rows_B) << "ldb=" << ldb << " < rows_B=" << rows_B << " (ldb must be >= rows of op(B) under ColMajor)";
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {
-                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldb >= cols_B) << "ldb=" << ldb << " < cols_B=" << cols_B << " (ldb must be >= cols of op(B) under RowMajor)";
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             RandBLAS::sparse_data::left_spmm(layout, trans_A, trans_B, m, n, k, alpha, A_sp, 0, 0, B, ldb, beta, C, ldc);
@@ -178,15 +178,15 @@ public:
             // C := alpha * op(B) * op(A_sp) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(m, k, trans_B);
             auto [rows_submat_A, cols_submat_A] = RandBLAS::dims_before_op(k, n, trans_A);
-            randlapack_error_if_msg(rows_submat_A > n_rows, "op(A) submatrix row dim inferred from (m, k, trans_A) is %lld but exceeds operator n_rows=%lld", (long long)rows_submat_A, (long long)n_rows);
-            randlapack_error_if_msg(cols_submat_A > n_cols, "op(A) submatrix col dim inferred from (m, k, trans_A) is %lld but exceeds operator n_cols=%lld", (long long)cols_submat_A, (long long)n_cols);
+            randlapack_require(rows_submat_A <= n_rows) << "op(A) submatrix row dim inferred from (m, k, trans_A) is " << rows_submat_A << " but exceeds operator n_rows=" << n_rows;
+            randlapack_require(cols_submat_A <= n_cols) << "op(A) submatrix col dim inferred from (m, k, trans_A) is " << cols_submat_A << " but exceeds operator n_cols=" << n_cols;
 
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldb < rows_B, "ldb=%lld < rows_B=%lld (ldb must be >= rows of op(B) under ColMajor)", (long long)ldb, (long long)rows_B);
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldb >= rows_B) << "ldb=" << ldb << " < rows_B=" << rows_B << " (ldb must be >= rows of op(B) under ColMajor)";
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {
-                randlapack_error_if_msg(ldb < cols_B, "ldb=%lld < cols_B=%lld (ldb must be >= cols of op(B) under RowMajor)", (long long)ldb, (long long)cols_B);
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldb >= cols_B) << "ldb=" << ldb << " < cols_B=" << cols_B << " (ldb must be >= cols of op(B) under RowMajor)";
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             RandBLAS::sparse_data::right_spmm(layout, trans_B, trans_A, m, n, k, alpha, B, ldb, A_sp, 0, 0, beta, C, ldc);
@@ -234,13 +234,13 @@ public:
             // C := alpha * op(A_sp) * op(B_sp) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(k, n, trans_B);
             auto [rows_submat_A, cols_submat_A] = RandBLAS::dims_before_op(m, k, trans_A);
-            randlapack_error_if_msg(rows_submat_A > n_rows, "op(A) submatrix row dim inferred from (m, k, trans_A) is %lld but exceeds operator n_rows=%lld", (long long)rows_submat_A, (long long)n_rows);
-            randlapack_error_if_msg(cols_submat_A > n_cols, "op(A) submatrix col dim inferred from (m, k, trans_A) is %lld but exceeds operator n_cols=%lld", (long long)cols_submat_A, (long long)n_cols);
+            randlapack_require(rows_submat_A <= n_rows) << "op(A) submatrix row dim inferred from (m, k, trans_A) is " << rows_submat_A << " but exceeds operator n_rows=" << n_rows;
+            randlapack_require(cols_submat_A <= n_cols) << "op(A) submatrix col dim inferred from (m, k, trans_A) is " << cols_submat_A << " but exceeds operator n_cols=" << n_cols;
 
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             #if defined(RandBLAS_HAS_MKL)
@@ -261,13 +261,13 @@ public:
             // C := alpha * op(B_sp) * op(A_sp) + beta * C
             auto [rows_B, cols_B] = RandBLAS::dims_before_op(m, k, trans_B);
             auto [rows_submat_A, cols_submat_A] = RandBLAS::dims_before_op(k, n, trans_A);
-            randlapack_error_if_msg(rows_submat_A > n_rows, "op(A) submatrix row dim inferred from (m, k, trans_A) is %lld but exceeds operator n_rows=%lld", (long long)rows_submat_A, (long long)n_rows);
-            randlapack_error_if_msg(cols_submat_A > n_cols, "op(A) submatrix col dim inferred from (m, k, trans_A) is %lld but exceeds operator n_cols=%lld", (long long)cols_submat_A, (long long)n_cols);
+            randlapack_require(rows_submat_A <= n_rows) << "op(A) submatrix row dim inferred from (m, k, trans_A) is " << rows_submat_A << " but exceeds operator n_rows=" << n_rows;
+            randlapack_require(cols_submat_A <= n_cols) << "op(A) submatrix col dim inferred from (m, k, trans_A) is " << cols_submat_A << " but exceeds operator n_cols=" << n_cols;
 
             if (layout == Layout::ColMajor) {
-                randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
+                randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
             } else {
-                randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
             }
 
             #if defined(RandBLAS_HAS_MKL)
@@ -345,19 +345,19 @@ public:
 
                 if (side == Side::Left && trans_S == Op::NoTrans) {
                     auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
-                    randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
-                    randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
-                    if (layout == Layout::ColMajor) randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
-                    else randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                    randlapack_require(rows_A == n_rows) << "op(A) row dim inferred from (m, k, trans_A) is " << rows_A << " but operator n_rows=" << n_rows;
+                    randlapack_require(cols_A == n_cols) << "op(A) col dim inferred from (m, k, trans_A) is " << cols_A << " but operator n_cols=" << n_cols;
+                    if (layout == Layout::ColMajor) randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
+                    else randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
                     RandBLAS::spgemm(layout, trans_A, alpha, A_sp, S_coo, beta, C, ldc);
                     return;
                 }
                 if (side == Side::Right && trans_A == Op::NoTrans) {
                     auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
-                    randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
-                    randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
-                    if (layout == Layout::ColMajor) randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
-                    else randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                    randlapack_require(rows_A == n_rows) << "op(A) row dim inferred from (m, k, trans_A) is " << rows_A << " but operator n_rows=" << n_rows;
+                    randlapack_require(cols_A == n_cols) << "op(A) col dim inferred from (m, k, trans_A) is " << cols_A << " but operator n_cols=" << n_cols;
+                    if (layout == Layout::ColMajor) randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
+                    else randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
                     RandBLAS::spgemm(layout, trans_S, alpha, S_coo, A_sp, beta, C, ldc);
                     return;
                 }
@@ -371,17 +371,17 @@ public:
 
             if (side == Side::Left) {
                 auto [rows_A, cols_A] = RandBLAS::dims_before_op(m, k, trans_A);
-                randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
-                randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
-                if (layout == Layout::ColMajor) randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
-                else randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(rows_A == n_rows) << "op(A) row dim inferred from (m, k, trans_A) is " << rows_A << " but operator n_rows=" << n_rows;
+                randlapack_require(cols_A == n_cols) << "op(A) col dim inferred from (m, k, trans_A) is " << cols_A << " but operator n_cols=" << n_cols;
+                if (layout == Layout::ColMajor) randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
+                else randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
                 RandBLAS::sketch_general(layout, trans_A, trans_S, m, n, k, alpha, A_dense, lda, S, beta, C, ldc);
             } else {
                 auto [rows_A, cols_A] = RandBLAS::dims_before_op(k, n, trans_A);
-                randlapack_error_if_msg(rows_A != n_rows, "op(A) row dim inferred from (m, k, trans_A) is %lld but operator n_rows=%lld", (long long)rows_A, (long long)n_rows);
-                randlapack_error_if_msg(cols_A != n_cols, "op(A) col dim inferred from (m, k, trans_A) is %lld but operator n_cols=%lld", (long long)cols_A, (long long)n_cols);
-                if (layout == Layout::ColMajor) randlapack_error_if_msg(ldc < m, "ldc=%lld < m=%lld (ldc must be >= m under ColMajor)", (long long)ldc, (long long)m);
-                else randlapack_error_if_msg(ldc < n, "ldc=%lld < n=%lld (ldc must be >= n under RowMajor)", (long long)ldc, (long long)n);
+                randlapack_require(rows_A == n_rows) << "op(A) row dim inferred from (m, k, trans_A) is " << rows_A << " but operator n_rows=" << n_rows;
+                randlapack_require(cols_A == n_cols) << "op(A) col dim inferred from (m, k, trans_A) is " << cols_A << " but operator n_cols=" << n_cols;
+                if (layout == Layout::ColMajor) randlapack_require(ldc >= m) << "ldc=" << ldc << " < m=" << m << " (ldc must be >= m under ColMajor)";
+                else randlapack_require(ldc >= n) << "ldc=" << ldc << " < n=" << n << " (ldc must be >= n under RowMajor)";
                 RandBLAS::sketch_general(layout, trans_S, trans_A, m, n, k, alpha, S, A_dense, lda, beta, C, ldc);
             }
 

--- a/RandLAPACK/linops/rl_sparse_views.hh
+++ b/RandLAPACK/linops/rl_sparse_views.hh
@@ -42,7 +42,7 @@ CSRRowBlockView<T, sint_t> csr_row_block(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t row_start, int64_t row_count
 ) {
-    randlapack_require(!(row_start < 0 && row_count > 0)) << "row_start=" << row_start << " must be >= 0 and row_count=" << row_count << " must be > 0";
+    randlapack_require(row_start >= 0 && row_count > 0) << "row_start=" << row_start << " must be >= 0 and row_count=" << row_count << " must be > 0";
     randlapack_require(row_start + row_count <= A.n_rows) << "row_start=" << row_start << " + row_count=" << row_count << " exceeds A.n_rows=" << A.n_rows;
     sint_t base = A.rowptr[row_start];
     int64_t block_nnz = A.rowptr[row_start + row_count] - base;
@@ -68,7 +68,7 @@ CSRColBlock<T, sint_t> csr_col_block(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t col_start, int64_t col_count
 ) {
-    randlapack_require(!(col_start < 0 && col_count > 0 && col_start + col_count <= A.n_cols)) << "column range must satisfy col_start=" << col_start << " >= 0, col_count=" << col_count << " > 0, col_start+col_count <= A.n_cols=" << A.n_cols;
+    randlapack_require(col_start >= 0 && col_count > 0 && col_start + col_count <= A.n_cols) << "column range must satisfy col_start=" << col_start << " >= 0, col_count=" << col_count << " > 0, col_start+col_count <= A.n_cols=" << A.n_cols;
     int64_t col_end = col_start + col_count;
     std::vector<sint_t> rowptr(A.n_rows + 1, 0);
     for (int64_t i = 0; i < A.n_rows; ++i)
@@ -106,7 +106,7 @@ CSCColBlockView<T, sint_t> csc_col_block(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t col_start, int64_t col_count
 ) {
-    randlapack_require(!(col_start < 0 && col_count > 0 && col_start + col_count <= A.n_cols)) << "column range must satisfy col_start=" << col_start << " >= 0, col_count=" << col_count << " > 0, col_start+col_count <= A.n_cols=" << A.n_cols;
+    randlapack_require(col_start >= 0 && col_count > 0 && col_start + col_count <= A.n_cols) << "column range must satisfy col_start=" << col_start << " >= 0, col_count=" << col_count << " > 0, col_start+col_count <= A.n_cols=" << A.n_cols;
     sint_t base = A.colptr[col_start];
     int64_t block_nnz = A.colptr[col_start + col_count] - base;
     std::vector<sint_t> rebased(col_count + 1);
@@ -131,7 +131,7 @@ CSCRowBlock<T, sint_t> csc_row_block(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t row_start, int64_t row_count
 ) {
-    randlapack_require(!(row_start < 0 && row_count > 0 && row_start + row_count <= A.n_rows)) << "row range must satisfy row_start=" << row_start << " >= 0, row_count=" << row_count << " > 0, row_start+row_count <= A.n_rows=" << A.n_rows;
+    randlapack_require(row_start >= 0 && row_count > 0 && row_start + row_count <= A.n_rows) << "row range must satisfy row_start=" << row_start << " >= 0, row_count=" << row_count << " > 0, row_start+row_count <= A.n_rows=" << A.n_rows;
     int64_t row_end = row_start + row_count;
     std::vector<sint_t> colptr(A.n_cols + 1, 0);
     for (int64_t j = 0; j < A.n_cols; ++j)
@@ -160,7 +160,7 @@ std::vector<CSRRowBlockView<T, sint_t>> csr_split_row_blocks(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randlapack_require(!(num_blocks <= 0 && A.n_rows % num_blocks == 0)) << "num_blocks=" << num_blocks << " must be > 0 and A.n_rows=" << A.n_rows << " must be divisible by num_blocks";
+    randlapack_require(num_blocks > 0 && A.n_rows % num_blocks == 0) << "num_blocks=" << num_blocks << " must be > 0 and A.n_rows=" << A.n_rows << " must be divisible by num_blocks";
     int64_t block_size = A.n_rows / num_blocks;
     std::vector<CSRRowBlockView<T, sint_t>> blocks;
     blocks.reserve(num_blocks);
@@ -176,7 +176,7 @@ std::vector<CSCColBlockView<T, sint_t>> csc_split_col_blocks(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randlapack_require(!(num_blocks <= 0 && A.n_cols % num_blocks == 0)) << "num_blocks=" << num_blocks << " must be > 0 and A.n_cols=" << A.n_cols << " must be divisible by num_blocks";
+    randlapack_require(num_blocks > 0 && A.n_cols % num_blocks == 0) << "num_blocks=" << num_blocks << " must be > 0 and A.n_cols=" << A.n_cols << " must be divisible by num_blocks";
     int64_t block_size = A.n_cols / num_blocks;
     std::vector<CSCColBlockView<T, sint_t>> blocks;
     blocks.reserve(num_blocks);
@@ -192,7 +192,7 @@ std::vector<CSRColBlock<T, sint_t>> csr_split_col_blocks(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randlapack_require(!(num_blocks <= 0 && A.n_cols % num_blocks == 0)) << "num_blocks=" << num_blocks << " must be > 0 and A.n_cols=" << A.n_cols << " must be divisible by num_blocks";
+    randlapack_require(num_blocks > 0 && A.n_cols % num_blocks == 0) << "num_blocks=" << num_blocks << " must be > 0 and A.n_cols=" << A.n_cols << " must be divisible by num_blocks";
     int64_t block_size = A.n_cols / num_blocks;
     std::vector<CSRColBlock<T, sint_t>> blocks;
     blocks.reserve(num_blocks);
@@ -208,7 +208,7 @@ std::vector<CSCRowBlock<T, sint_t>> csc_split_row_blocks(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randlapack_require(!(num_blocks <= 0 && A.n_rows % num_blocks == 0)) << "num_blocks=" << num_blocks << " must be > 0 and A.n_rows=" << A.n_rows << " must be divisible by num_blocks";
+    randlapack_require(num_blocks > 0 && A.n_rows % num_blocks == 0) << "num_blocks=" << num_blocks << " must be > 0 and A.n_rows=" << A.n_rows << " must be divisible by num_blocks";
     int64_t block_size = A.n_rows / num_blocks;
     std::vector<CSCRowBlock<T, sint_t>> blocks;
     blocks.reserve(num_blocks);

--- a/RandLAPACK/linops/rl_sparse_views.hh
+++ b/RandLAPACK/linops/rl_sparse_views.hh
@@ -42,8 +42,8 @@ CSRRowBlockView<T, sint_t> csr_row_block(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t row_start, int64_t row_count
 ) {
-    randlapack_error_if_msg(!(row_start >= 0 && row_count > 0), "row_start=%lld must be >= 0 and row_count=%lld must be > 0", (long long)row_start, (long long)row_count);
-    randlapack_error_if_msg(row_start + row_count > A.n_rows, "row_start=%lld + row_count=%lld exceeds A.n_rows=%lld", (long long)row_start, (long long)row_count, (long long)A.n_rows);
+    randlapack_require(!(row_start < 0 && row_count > 0)) << "row_start=" << row_start << " must be >= 0 and row_count=" << row_count << " must be > 0";
+    randlapack_require(row_start + row_count <= A.n_rows) << "row_start=" << row_start << " + row_count=" << row_count << " exceeds A.n_rows=" << A.n_rows;
     sint_t base = A.rowptr[row_start];
     int64_t block_nnz = A.rowptr[row_start + row_count] - base;
     std::vector<sint_t> rebased(row_count + 1);
@@ -68,7 +68,7 @@ CSRColBlock<T, sint_t> csr_col_block(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t col_start, int64_t col_count
 ) {
-    randlapack_error_if_msg(!(col_start >= 0 && col_count > 0 && col_start + col_count <= A.n_cols), "column range must satisfy col_start=%lld >= 0, col_count=%lld > 0, col_start+col_count <= A.n_cols=%lld", (long long)col_start, (long long)col_count, (long long)A.n_cols);
+    randlapack_require(!(col_start < 0 && col_count > 0 && col_start + col_count <= A.n_cols)) << "column range must satisfy col_start=" << col_start << " >= 0, col_count=" << col_count << " > 0, col_start+col_count <= A.n_cols=" << A.n_cols;
     int64_t col_end = col_start + col_count;
     std::vector<sint_t> rowptr(A.n_rows + 1, 0);
     for (int64_t i = 0; i < A.n_rows; ++i)
@@ -106,7 +106,7 @@ CSCColBlockView<T, sint_t> csc_col_block(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t col_start, int64_t col_count
 ) {
-    randlapack_error_if_msg(!(col_start >= 0 && col_count > 0 && col_start + col_count <= A.n_cols), "column range must satisfy col_start=%lld >= 0, col_count=%lld > 0, col_start+col_count <= A.n_cols=%lld", (long long)col_start, (long long)col_count, (long long)A.n_cols);
+    randlapack_require(!(col_start < 0 && col_count > 0 && col_start + col_count <= A.n_cols)) << "column range must satisfy col_start=" << col_start << " >= 0, col_count=" << col_count << " > 0, col_start+col_count <= A.n_cols=" << A.n_cols;
     sint_t base = A.colptr[col_start];
     int64_t block_nnz = A.colptr[col_start + col_count] - base;
     std::vector<sint_t> rebased(col_count + 1);
@@ -131,7 +131,7 @@ CSCRowBlock<T, sint_t> csc_row_block(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t row_start, int64_t row_count
 ) {
-    randlapack_error_if_msg(!(row_start >= 0 && row_count > 0 && row_start + row_count <= A.n_rows), "row range must satisfy row_start=%lld >= 0, row_count=%lld > 0, row_start+row_count <= A.n_rows=%lld", (long long)row_start, (long long)row_count, (long long)A.n_rows);
+    randlapack_require(!(row_start < 0 && row_count > 0 && row_start + row_count <= A.n_rows)) << "row range must satisfy row_start=" << row_start << " >= 0, row_count=" << row_count << " > 0, row_start+row_count <= A.n_rows=" << A.n_rows;
     int64_t row_end = row_start + row_count;
     std::vector<sint_t> colptr(A.n_cols + 1, 0);
     for (int64_t j = 0; j < A.n_cols; ++j)
@@ -160,7 +160,7 @@ std::vector<CSRRowBlockView<T, sint_t>> csr_split_row_blocks(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randlapack_error_if_msg(!(num_blocks > 0 && A.n_rows % num_blocks == 0), "num_blocks=%lld must be > 0 and A.n_rows=%lld must be divisible by num_blocks", (long long)num_blocks, (long long)A.n_rows);
+    randlapack_require(!(num_blocks <= 0 && A.n_rows % num_blocks == 0)) << "num_blocks=" << num_blocks << " must be > 0 and A.n_rows=" << A.n_rows << " must be divisible by num_blocks";
     int64_t block_size = A.n_rows / num_blocks;
     std::vector<CSRRowBlockView<T, sint_t>> blocks;
     blocks.reserve(num_blocks);
@@ -176,7 +176,7 @@ std::vector<CSCColBlockView<T, sint_t>> csc_split_col_blocks(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randlapack_error_if_msg(!(num_blocks > 0 && A.n_cols % num_blocks == 0), "num_blocks=%lld must be > 0 and A.n_cols=%lld must be divisible by num_blocks", (long long)num_blocks, (long long)A.n_cols);
+    randlapack_require(!(num_blocks <= 0 && A.n_cols % num_blocks == 0)) << "num_blocks=" << num_blocks << " must be > 0 and A.n_cols=" << A.n_cols << " must be divisible by num_blocks";
     int64_t block_size = A.n_cols / num_blocks;
     std::vector<CSCColBlockView<T, sint_t>> blocks;
     blocks.reserve(num_blocks);
@@ -192,7 +192,7 @@ std::vector<CSRColBlock<T, sint_t>> csr_split_col_blocks(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randlapack_error_if_msg(!(num_blocks > 0 && A.n_cols % num_blocks == 0), "num_blocks=%lld must be > 0 and A.n_cols=%lld must be divisible by num_blocks", (long long)num_blocks, (long long)A.n_cols);
+    randlapack_require(!(num_blocks <= 0 && A.n_cols % num_blocks == 0)) << "num_blocks=" << num_blocks << " must be > 0 and A.n_cols=" << A.n_cols << " must be divisible by num_blocks";
     int64_t block_size = A.n_cols / num_blocks;
     std::vector<CSRColBlock<T, sint_t>> blocks;
     blocks.reserve(num_blocks);
@@ -208,7 +208,7 @@ std::vector<CSCRowBlock<T, sint_t>> csc_split_row_blocks(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randlapack_error_if_msg(!(num_blocks > 0 && A.n_rows % num_blocks == 0), "num_blocks=%lld must be > 0 and A.n_rows=%lld must be divisible by num_blocks", (long long)num_blocks, (long long)A.n_rows);
+    randlapack_require(!(num_blocks <= 0 && A.n_rows % num_blocks == 0)) << "num_blocks=" << num_blocks << " must be > 0 and A.n_rows=" << A.n_rows << " must be divisible by num_blocks";
     int64_t block_size = A.n_rows / num_blocks;
     std::vector<CSCRowBlock<T, sint_t>> blocks;
     blocks.reserve(num_blocks);

--- a/RandLAPACK/linops/rl_sparse_views.hh
+++ b/RandLAPACK/linops/rl_sparse_views.hh
@@ -6,6 +6,7 @@
 // row_block(), col_block(), and submatrix(). Users should interact with these
 // through SparseLinOp's public interface rather than using them directly.
 
+#include "rl_exceptions.hh"
 #include "RandBLAS/sparse_data/base.hh"
 
 #include <RandBLAS.hh>
@@ -41,8 +42,8 @@ CSRRowBlockView<T, sint_t> csr_row_block(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t row_start, int64_t row_count
 ) {
-    randblas_require(row_start >= 0 && row_count > 0);
-    randblas_require(row_start + row_count <= A.n_rows);
+    randlapack_error_if_msg(!(row_start >= 0 && row_count > 0), "row_start=%lld must be >= 0 and row_count=%lld must be > 0", (long long)row_start, (long long)row_count);
+    randlapack_error_if_msg(row_start + row_count > A.n_rows, "row_start=%lld + row_count=%lld exceeds A.n_rows=%lld", (long long)row_start, (long long)row_count, (long long)A.n_rows);
     sint_t base = A.rowptr[row_start];
     int64_t block_nnz = A.rowptr[row_start + row_count] - base;
     std::vector<sint_t> rebased(row_count + 1);
@@ -67,7 +68,7 @@ CSRColBlock<T, sint_t> csr_col_block(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t col_start, int64_t col_count
 ) {
-    randblas_require(col_start >= 0 && col_count > 0 && col_start + col_count <= A.n_cols);
+    randlapack_error_if_msg(!(col_start >= 0 && col_count > 0 && col_start + col_count <= A.n_cols), "column range must satisfy col_start=%lld >= 0, col_count=%lld > 0, col_start+col_count <= A.n_cols=%lld", (long long)col_start, (long long)col_count, (long long)A.n_cols);
     int64_t col_end = col_start + col_count;
     std::vector<sint_t> rowptr(A.n_rows + 1, 0);
     for (int64_t i = 0; i < A.n_rows; ++i)
@@ -105,7 +106,7 @@ CSCColBlockView<T, sint_t> csc_col_block(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t col_start, int64_t col_count
 ) {
-    randblas_require(col_start >= 0 && col_count > 0 && col_start + col_count <= A.n_cols);
+    randlapack_error_if_msg(!(col_start >= 0 && col_count > 0 && col_start + col_count <= A.n_cols), "column range must satisfy col_start=%lld >= 0, col_count=%lld > 0, col_start+col_count <= A.n_cols=%lld", (long long)col_start, (long long)col_count, (long long)A.n_cols);
     sint_t base = A.colptr[col_start];
     int64_t block_nnz = A.colptr[col_start + col_count] - base;
     std::vector<sint_t> rebased(col_count + 1);
@@ -130,7 +131,7 @@ CSCRowBlock<T, sint_t> csc_row_block(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t row_start, int64_t row_count
 ) {
-    randblas_require(row_start >= 0 && row_count > 0 && row_start + row_count <= A.n_rows);
+    randlapack_error_if_msg(!(row_start >= 0 && row_count > 0 && row_start + row_count <= A.n_rows), "row range must satisfy row_start=%lld >= 0, row_count=%lld > 0, row_start+row_count <= A.n_rows=%lld", (long long)row_start, (long long)row_count, (long long)A.n_rows);
     int64_t row_end = row_start + row_count;
     std::vector<sint_t> colptr(A.n_cols + 1, 0);
     for (int64_t j = 0; j < A.n_cols; ++j)
@@ -159,7 +160,7 @@ std::vector<CSRRowBlockView<T, sint_t>> csr_split_row_blocks(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randblas_require(num_blocks > 0 && A.n_rows % num_blocks == 0);
+    randlapack_error_if_msg(!(num_blocks > 0 && A.n_rows % num_blocks == 0), "num_blocks=%lld must be > 0 and A.n_rows=%lld must be divisible by num_blocks", (long long)num_blocks, (long long)A.n_rows);
     int64_t block_size = A.n_rows / num_blocks;
     std::vector<CSRRowBlockView<T, sint_t>> blocks;
     blocks.reserve(num_blocks);
@@ -175,7 +176,7 @@ std::vector<CSCColBlockView<T, sint_t>> csc_split_col_blocks(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randblas_require(num_blocks > 0 && A.n_cols % num_blocks == 0);
+    randlapack_error_if_msg(!(num_blocks > 0 && A.n_cols % num_blocks == 0), "num_blocks=%lld must be > 0 and A.n_cols=%lld must be divisible by num_blocks", (long long)num_blocks, (long long)A.n_cols);
     int64_t block_size = A.n_cols / num_blocks;
     std::vector<CSCColBlockView<T, sint_t>> blocks;
     blocks.reserve(num_blocks);
@@ -191,7 +192,7 @@ std::vector<CSRColBlock<T, sint_t>> csr_split_col_blocks(
     RandBLAS::sparse_data::CSRMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randblas_require(num_blocks > 0 && A.n_cols % num_blocks == 0);
+    randlapack_error_if_msg(!(num_blocks > 0 && A.n_cols % num_blocks == 0), "num_blocks=%lld must be > 0 and A.n_cols=%lld must be divisible by num_blocks", (long long)num_blocks, (long long)A.n_cols);
     int64_t block_size = A.n_cols / num_blocks;
     std::vector<CSRColBlock<T, sint_t>> blocks;
     blocks.reserve(num_blocks);
@@ -207,7 +208,7 @@ std::vector<CSCRowBlock<T, sint_t>> csc_split_row_blocks(
     RandBLAS::sparse_data::CSCMatrix<T, sint_t>& A,
     int64_t num_blocks
 ) {
-    randblas_require(num_blocks > 0 && A.n_rows % num_blocks == 0);
+    randlapack_error_if_msg(!(num_blocks > 0 && A.n_rows % num_blocks == 0), "num_blocks=%lld must be > 0 and A.n_rows=%lld must be divisible by num_blocks", (long long)num_blocks, (long long)A.n_rows);
     int64_t block_size = A.n_rows / num_blocks;
     std::vector<CSCRowBlock<T, sint_t>> blocks;
     blocks.reserve(num_blocks);

--- a/RandLAPACK/linops/rl_sym_linops.hh
+++ b/RandLAPACK/linops/rl_sym_linops.hh
@@ -283,7 +283,7 @@ struct SpectralPrecond {
     }
 
     void reset_owned_buffers(int64_t arg_dim_pre, int64_t arg_num_rhs, int64_t arg_num_ops) {
-        randlapack_require(!(arg_num_rhs != arg_num_ops || arg_num_ops == 1)) << "arg_num_rhs=" << arg_num_rhs << " must equal arg_num_ops=" << arg_num_ops << ", or arg_num_ops must be 1";
+        randlapack_require(arg_num_rhs == arg_num_ops || arg_num_ops == 1) << "arg_num_rhs=" << arg_num_rhs << " must equal arg_num_ops=" << arg_num_ops << ", or arg_num_ops must be 1";
 
         if (arg_dim_pre * arg_num_ops > dim_pre * num_ops) {
             if (D != nullptr) delete [] D;

--- a/RandLAPACK/linops/rl_sym_linops.hh
+++ b/RandLAPACK/linops/rl_sym_linops.hh
@@ -3,6 +3,7 @@
 // Public API: ExplicitSymLinOp, RegExplicitSymLinOp, SpectralPrecond —
 // symmetric linear operators for use with SymmetricLinearOperator-templated algorithms.
 
+#include "rl_exceptions.hh"
 #include "rl_concepts.hh"
 #include "rl_blaspp.hh"
 
@@ -83,8 +84,8 @@ struct ExplicitSymLinOp {
         T* C,
         int64_t ldc
     ) {
-        randblas_require(ldb >= dim);
-        randblas_require(ldc >= dim);
+        randlapack_error_if_msg(ldb < dim, "ldb=%lld < dim=%lld (ldb must be >= operator dimension)", (long long)ldb, (long long)dim);
+        randlapack_error_if_msg(ldc < dim, "ldc=%lld < dim=%lld (ldc must be >= operator dimension)", (long long)ldc, (long long)dim);
         auto blas_call_uplo = this->uplo;
         if (layout != this->buff_layout)
             blas_call_uplo = (this->uplo == Uplo::Upper) ? Uplo::Lower : Uplo::Upper;
@@ -97,7 +98,7 @@ struct ExplicitSymLinOp {
     }
 
     inline T operator()(int64_t i, int64_t j) {
-        randblas_require(this->uplo == Uplo::Upper && this->buff_layout == Layout::ColMajor);
+        randlapack_error_if_msg(!(this->uplo == Uplo::Upper && this->buff_layout == Layout::ColMajor), "element access operator()(i,j) requires upper-triangle + ColMajor storage");
         if (i > j) {
             return A_buff[j + i*lda];
         } else {
@@ -148,7 +149,7 @@ struct RegExplicitSymLinOp {
     RegExplicitSymLinOp(
         int64_t dim, const T* A_buff, int64_t lda, T* arg_regs, int64_t arg_num_ops
     ) : m(dim), dim(dim), A_buff(A_buff), lda(lda) {
-        randblas_require(lda >= dim);
+        randlapack_error_if_msg(lda < dim, "lda=%lld < dim=%lld (lda must be >= operator dimension)", (long long)lda, (long long)dim);
         _eval_includes_reg = false;
         num_ops = arg_num_ops;
         num_ops = std::max(num_ops, (int64_t) 1);
@@ -169,13 +170,13 @@ struct RegExplicitSymLinOp {
     }
 
     void operator()(Layout layout, int64_t n, T alpha, T* const B, int64_t ldb, T beta, T* C, int64_t ldc) {
-        randblas_require(layout == this->buff_layout);
-        randblas_require(ldb >= dim);
-        randblas_require(ldc >= dim);
+        randlapack_error_if_msg(layout != this->buff_layout, "operation layout must match the operator storage layout (buff_layout)");
+        randlapack_error_if_msg(ldb < dim, "ldb=%lld < dim=%lld (ldb must be >= operator dimension)", (long long)ldb, (long long)dim);
+        randlapack_error_if_msg(ldc < dim, "ldc=%lld < dim=%lld (ldc must be >= operator dimension)", (long long)ldc, (long long)dim);
         blas::symm(layout, blas::Side::Left, this->uplo, dim, n, alpha, this->A_buff, this->lda, B, ldb, beta, C, ldc);
 
         if (_eval_includes_reg) {
-            if (num_ops != 1) randblas_require(n == num_ops);
+            if (num_ops != 1) randlapack_error_if_msg(n != num_ops, "with num_ops>1, n=%lld must equal num_ops=%lld so each column gets its own regularization", (long long)n, (long long)num_ops);
             for (int64_t i = 0; i < n; ++i) {
                 T coeff =  alpha * regs[std::min(i, num_ops - 1)];
                 blas::axpy(dim, coeff, B + i*ldb, 1, C +  i*ldc, 1);
@@ -192,7 +193,7 @@ struct RegExplicitSymLinOp {
             val = A_buff[i + j*lda];
         }
         if (_eval_includes_reg && i == j) {
-            randblas_require(num_ops == 1);
+            randlapack_error_if_msg(num_ops != 1, "this operation requires num_ops=1; got num_ops=%lld", (long long)num_ops);
             val += regs[0];
         }
         return val;
@@ -282,7 +283,7 @@ struct SpectralPrecond {
     }
 
     void reset_owned_buffers(int64_t arg_dim_pre, int64_t arg_num_rhs, int64_t arg_num_ops) {
-        randblas_require(arg_num_rhs == arg_num_ops || arg_num_ops == 1);
+        randlapack_error_if_msg(!(arg_num_rhs == arg_num_ops || arg_num_ops == 1), "arg_num_rhs=%lld must equal arg_num_ops=%lld, or arg_num_ops must be 1", (long long)arg_num_rhs, (long long)arg_num_ops);
 
         if (arg_dim_pre * arg_num_ops > dim_pre * num_ops) {
             if (D != nullptr) delete [] D;
@@ -327,13 +328,13 @@ struct SpectralPrecond {
     void operator()(
         Layout layout, int64_t n, T alpha, const T* B, int64_t ldb, T beta, T* C, int64_t ldc
     ) {
-        randblas_require(layout == Layout::ColMajor);
-        randblas_require(ldb >= dim);
-        randblas_require(ldc >= dim);
+        randlapack_error_if_msg(layout != Layout::ColMajor, "this operator only supports ColMajor layout");
+        randlapack_error_if_msg(ldb < dim, "ldb=%lld < dim=%lld (ldb must be >= operator dimension)", (long long)ldb, (long long)dim);
+        randlapack_error_if_msg(ldc < dim, "ldc=%lld < dim=%lld (ldc must be >= operator dimension)", (long long)ldc, (long long)dim);
         if (this->num_ops != 1) {
-            randblas_require(n == num_ops);
+            randlapack_error_if_msg(n != num_ops, "with num_ops>1, n=%lld must equal num_ops=%lld so each column gets its own regularization", (long long)n, (long long)num_ops);
         } else {
-            randblas_require(this->num_rhs >= n);
+            randlapack_error_if_msg(this->num_rhs < n, "this->num_rhs=%lld must be >= n=%lld", (long long)this->num_rhs, (long long)n);
         }
         // update C = alpha*(V diag(D) V' + I)B + beta*C
         //      Step 1: w = V'B                    with blas::gemm

--- a/RandLAPACK/linops/rl_sym_linops.hh
+++ b/RandLAPACK/linops/rl_sym_linops.hh
@@ -84,8 +84,8 @@ struct ExplicitSymLinOp {
         T* C,
         int64_t ldc
     ) {
-        randlapack_error_if_msg(ldb < dim, "ldb=%lld < dim=%lld (ldb must be >= operator dimension)", (long long)ldb, (long long)dim);
-        randlapack_error_if_msg(ldc < dim, "ldc=%lld < dim=%lld (ldc must be >= operator dimension)", (long long)ldc, (long long)dim);
+        randlapack_require(ldb >= dim) << "ldb=" << ldb << " < dim=" << dim << " (ldb must be >= operator dimension)";
+        randlapack_require(ldc >= dim) << "ldc=" << ldc << " < dim=" << dim << " (ldc must be >= operator dimension)";
         auto blas_call_uplo = this->uplo;
         if (layout != this->buff_layout)
             blas_call_uplo = (this->uplo == Uplo::Upper) ? Uplo::Lower : Uplo::Upper;
@@ -98,7 +98,7 @@ struct ExplicitSymLinOp {
     }
 
     inline T operator()(int64_t i, int64_t j) {
-        randlapack_error_if_msg(!(this->uplo == Uplo::Upper && this->buff_layout == Layout::ColMajor), "element access operator()(i,j) requires upper-triangle + ColMajor storage");
+        randlapack_require(this->uplo == Uplo::Upper && this->buff_layout == Layout::ColMajor) << "element access operator()(i,j) requires upper-triangle + ColMajor storage";
         if (i > j) {
             return A_buff[j + i*lda];
         } else {
@@ -149,7 +149,7 @@ struct RegExplicitSymLinOp {
     RegExplicitSymLinOp(
         int64_t dim, const T* A_buff, int64_t lda, T* arg_regs, int64_t arg_num_ops
     ) : m(dim), dim(dim), A_buff(A_buff), lda(lda) {
-        randlapack_error_if_msg(lda < dim, "lda=%lld < dim=%lld (lda must be >= operator dimension)", (long long)lda, (long long)dim);
+        randlapack_require(lda >= dim) << "lda=" << lda << " < dim=" << dim << " (lda must be >= operator dimension)";
         _eval_includes_reg = false;
         num_ops = arg_num_ops;
         num_ops = std::max(num_ops, (int64_t) 1);
@@ -170,13 +170,13 @@ struct RegExplicitSymLinOp {
     }
 
     void operator()(Layout layout, int64_t n, T alpha, T* const B, int64_t ldb, T beta, T* C, int64_t ldc) {
-        randlapack_error_if_msg(layout != this->buff_layout, "operation layout must match the operator storage layout (buff_layout)");
-        randlapack_error_if_msg(ldb < dim, "ldb=%lld < dim=%lld (ldb must be >= operator dimension)", (long long)ldb, (long long)dim);
-        randlapack_error_if_msg(ldc < dim, "ldc=%lld < dim=%lld (ldc must be >= operator dimension)", (long long)ldc, (long long)dim);
+        randlapack_require(layout == this->buff_layout) << "operation layout must match the operator storage layout (buff_layout)";
+        randlapack_require(ldb >= dim) << "ldb=" << ldb << " < dim=" << dim << " (ldb must be >= operator dimension)";
+        randlapack_require(ldc >= dim) << "ldc=" << ldc << " < dim=" << dim << " (ldc must be >= operator dimension)";
         blas::symm(layout, blas::Side::Left, this->uplo, dim, n, alpha, this->A_buff, this->lda, B, ldb, beta, C, ldc);
 
         if (_eval_includes_reg) {
-            if (num_ops != 1) randlapack_error_if_msg(n != num_ops, "with num_ops>1, n=%lld must equal num_ops=%lld so each column gets its own regularization", (long long)n, (long long)num_ops);
+            if (num_ops != 1) randlapack_require(n == num_ops) << "with num_ops>1, n=" << n << " must equal num_ops=" << num_ops << " so each column gets its own regularization";
             for (int64_t i = 0; i < n; ++i) {
                 T coeff =  alpha * regs[std::min(i, num_ops - 1)];
                 blas::axpy(dim, coeff, B + i*ldb, 1, C +  i*ldc, 1);
@@ -193,7 +193,7 @@ struct RegExplicitSymLinOp {
             val = A_buff[i + j*lda];
         }
         if (_eval_includes_reg && i == j) {
-            randlapack_error_if_msg(num_ops != 1, "this operation requires num_ops=1; got num_ops=%lld", (long long)num_ops);
+            randlapack_require(num_ops == 1) << "this operation requires num_ops=1; got num_ops=" << num_ops;
             val += regs[0];
         }
         return val;
@@ -283,7 +283,7 @@ struct SpectralPrecond {
     }
 
     void reset_owned_buffers(int64_t arg_dim_pre, int64_t arg_num_rhs, int64_t arg_num_ops) {
-        randlapack_error_if_msg(!(arg_num_rhs == arg_num_ops || arg_num_ops == 1), "arg_num_rhs=%lld must equal arg_num_ops=%lld, or arg_num_ops must be 1", (long long)arg_num_rhs, (long long)arg_num_ops);
+        randlapack_require(!(arg_num_rhs != arg_num_ops || arg_num_ops == 1)) << "arg_num_rhs=" << arg_num_rhs << " must equal arg_num_ops=" << arg_num_ops << ", or arg_num_ops must be 1";
 
         if (arg_dim_pre * arg_num_ops > dim_pre * num_ops) {
             if (D != nullptr) delete [] D;
@@ -328,13 +328,13 @@ struct SpectralPrecond {
     void operator()(
         Layout layout, int64_t n, T alpha, const T* B, int64_t ldb, T beta, T* C, int64_t ldc
     ) {
-        randlapack_error_if_msg(layout != Layout::ColMajor, "this operator only supports ColMajor layout");
-        randlapack_error_if_msg(ldb < dim, "ldb=%lld < dim=%lld (ldb must be >= operator dimension)", (long long)ldb, (long long)dim);
-        randlapack_error_if_msg(ldc < dim, "ldc=%lld < dim=%lld (ldc must be >= operator dimension)", (long long)ldc, (long long)dim);
+        randlapack_require(layout == Layout::ColMajor) << "this operator only supports ColMajor layout";
+        randlapack_require(ldb >= dim) << "ldb=" << ldb << " < dim=" << dim << " (ldb must be >= operator dimension)";
+        randlapack_require(ldc >= dim) << "ldc=" << ldc << " < dim=" << dim << " (ldc must be >= operator dimension)";
         if (this->num_ops != 1) {
-            randlapack_error_if_msg(n != num_ops, "with num_ops>1, n=%lld must equal num_ops=%lld so each column gets its own regularization", (long long)n, (long long)num_ops);
+            randlapack_require(n == num_ops) << "with num_ops>1, n=" << n << " must equal num_ops=" << num_ops << " so each column gets its own regularization";
         } else {
-            randlapack_error_if_msg(this->num_rhs < n, "this->num_rhs=%lld must be >= n=%lld", (long long)this->num_rhs, (long long)n);
+            randlapack_require(this->num_rhs >= n) << "this->num_rhs=" << this->num_rhs << " must be >= n=" << n;
         }
         // update C = alpha*(V diag(D) V' + I)B + beta*C
         //      Step 1: w = V'B                    with blas::gemm

--- a/RandLAPACK/misc/rl_pdkernels.hh
+++ b/RandLAPACK/misc/rl_pdkernels.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_blaspp.hh"
 #include <RandBLAS.hh>
 
@@ -33,7 +34,7 @@ template <typename T>
 void standardize_dataset(
     int64_t rows_x, int64_t cols_x, T* X, T* mu, T* sigma, bool use_input_mu_sigma = false
 ) {
-    randblas_require(cols_x >= 2);
+    randlapack_error_if_msg(cols_x < 2, "cols_x=%lld must be >= 2 (need at least 2 samples to compute std deviation)", (long long)cols_x);
     if (! use_input_mu_sigma) {
         std::fill(mu, mu + rows_x, (T) 0.0);
         std::fill(sigma, sigma + rows_x, (T) 0.0);
@@ -74,8 +75,8 @@ void euclidean_distance_submatrix(
     int64_t rows_x, int64_t cols_x, const T* X, const T* sq_colnorms_x,
     int64_t rows_eds, int64_t cols_eds, T* Eds, int64_t ro_eds, int64_t co_eds
 ) {
-    randblas_require((0 <= co_eds) && ((co_eds + cols_eds) <= cols_x));
-    randblas_require((0 <= ro_eds) && ((ro_eds + rows_eds) <= cols_x));
+    randlapack_error_if_msg(!((0 <= co_eds) && ((co_eds + cols_eds) <= cols_x)), "column window must satisfy 0 <= co_eds and co_eds+cols_eds <= cols_x; got co_eds=%lld cols_eds=%lld cols_x=%lld", (long long)co_eds, (long long)cols_eds, (long long)cols_x);
+    randlapack_error_if_msg(!((0 <= ro_eds) && ((ro_eds + rows_eds) <= cols_x)), "row window must satisfy 0 <= ro_eds and ro_eds+rows_eds <= cols_x; got ro_eds=%lld rows_eds=%lld cols_x=%lld", (long long)ro_eds, (long long)rows_eds, (long long)cols_x);
     const T* sq_colnorms_for_rows = sq_colnorms_x + ro_eds;
     const T* sq_colnorms_for_cols = sq_colnorms_x + co_eds;
 
@@ -135,7 +136,7 @@ void squared_exp_kernel_submatrix(
     T bandwidth
 ) {
     int64_t size_Ksub = rows_ksub * cols_ksub;
-    randblas_require(bandwidth > 0);
+    randlapack_error_if_msg(!(bandwidth > 0), "kernel bandwidth must be > 0; got bandwidth=%g", (double)bandwidth);
     euclidean_distance_submatrix(rows_x, cols_x, X, sq_colnorms_x, rows_ksub, cols_ksub, Ksub, ro_ksub, co_ksub);
     T scale = -1.0 / (2.0 * bandwidth * bandwidth);
     auto inplace_exp = [scale](T &val) { val = std::exp(scale*val); };
@@ -236,7 +237,7 @@ struct RBFKernelMatrix {
     }
 
     void _prep_eval_work1(int64_t rows_ksub, int64_t cols_ksub, int64_t ro_ksub, int64_t co_ksub) {
-        randblas_require(rows_ksub * cols_ksub <= (int64_t) _eval_work1.size());
+        randlapack_error_if_msg(rows_ksub * cols_ksub > (int64_t) _eval_work1.size(), "kernel submatrix rows_ksub*cols_ksub=%lld exceeds _eval_work1 size=%lld", (long long)(rows_ksub*cols_ksub), (long long)_eval_work1.size());
         squared_exp_kernel_submatrix(
             rows_x, dim, X, _sq_colnorms_x.data(),
             rows_ksub, cols_ksub, _eval_work1.data(), ro_ksub, co_ksub, bandwidth
@@ -248,9 +249,9 @@ struct RBFKernelMatrix {
     }
 
     void operator()(blas::Layout layout, int64_t n, T alpha, T* const B, int64_t ldb, T beta, T* C, int64_t ldc) {
-        randblas_require(layout == blas::Layout::ColMajor);
-        randblas_require(ldb >= dim);
-        randblas_require(ldc >= dim);
+        randlapack_error_if_msg(layout != blas::Layout::ColMajor, "this kernel matrix only supports ColMajor layout");
+        randlapack_error_if_msg(ldb < dim, "ldb=%lld < dim=%lld (ldb must be >= operator dimension)", (long long)ldb, (long long)dim);
+        randlapack_error_if_msg(ldc < dim, "ldc=%lld < dim=%lld (ldc must be >= operator dimension)", (long long)ldc, (long long)dim);
 
         _eval_work2.resize(dim * n);
         for (int64_t i = 0; i < n; ++i) {
@@ -274,7 +275,7 @@ struct RBFKernelMatrix {
             todo -= k;
         }
         if (_eval_includes_reg) {
-            randblas_require(num_ops == 1 || n == num_ops);
+            randlapack_error_if_msg(!(num_ops == 1 || n == num_ops), "with num_ops>1, n=%lld must equal num_ops=%lld so each column gets its own regularization", (long long)n, (long long)num_ops);
             for (int64_t i = 0; i < n; ++i) {
                 T coeff =  alpha * regs[std::min(i, num_ops - 1)];
                 blas::axpy(dim, coeff, B + i*ldb, 1, C +  i*ldc, 1);
@@ -286,7 +287,7 @@ struct RBFKernelMatrix {
     inline T operator()(int64_t i, int64_t j) {
         T val = squared_exp_kernel(rows_x, X + i*rows_x, X + j*rows_x, bandwidth);
         if (_eval_includes_reg && i == j) {
-            randblas_require(num_ops == 1);
+            randlapack_error_if_msg(num_ops != 1, "this operation requires num_ops=1; got num_ops=%lld", (long long)num_ops);
             val += regs[0];
         }
         return val;

--- a/RandLAPACK/misc/rl_pdkernels.hh
+++ b/RandLAPACK/misc/rl_pdkernels.hh
@@ -34,7 +34,7 @@ template <typename T>
 void standardize_dataset(
     int64_t rows_x, int64_t cols_x, T* X, T* mu, T* sigma, bool use_input_mu_sigma = false
 ) {
-    randlapack_error_if_msg(cols_x < 2, "cols_x=%lld must be >= 2 (need at least 2 samples to compute std deviation)", (long long)cols_x);
+    randlapack_require(cols_x >= 2) << "cols_x=" << cols_x << " must be >= 2 (need at least 2 samples to compute std deviation)";
     if (! use_input_mu_sigma) {
         std::fill(mu, mu + rows_x, (T) 0.0);
         std::fill(sigma, sigma + rows_x, (T) 0.0);
@@ -75,8 +75,8 @@ void euclidean_distance_submatrix(
     int64_t rows_x, int64_t cols_x, const T* X, const T* sq_colnorms_x,
     int64_t rows_eds, int64_t cols_eds, T* Eds, int64_t ro_eds, int64_t co_eds
 ) {
-    randlapack_error_if_msg(!((0 <= co_eds) && ((co_eds + cols_eds) <= cols_x)), "column window must satisfy 0 <= co_eds and co_eds+cols_eds <= cols_x; got co_eds=%lld cols_eds=%lld cols_x=%lld", (long long)co_eds, (long long)cols_eds, (long long)cols_x);
-    randlapack_error_if_msg(!((0 <= ro_eds) && ((ro_eds + rows_eds) <= cols_x)), "row window must satisfy 0 <= ro_eds and ro_eds+rows_eds <= cols_x; got ro_eds=%lld rows_eds=%lld cols_x=%lld", (long long)ro_eds, (long long)rows_eds, (long long)cols_x);
+    randlapack_require(!((0 > co_eds) && ((co_eds + cols_eds) <= cols_x))) << "column window must satisfy 0 <= co_eds and co_eds+cols_eds <= cols_x; got co_eds=" << co_eds << " cols_eds=" << cols_eds << " cols_x=" << cols_x;
+    randlapack_require(!((0 > ro_eds) && ((ro_eds + rows_eds) <= cols_x))) << "row window must satisfy 0 <= ro_eds and ro_eds+rows_eds <= cols_x; got ro_eds=" << ro_eds << " rows_eds=" << rows_eds << " cols_x=" << cols_x;
     const T* sq_colnorms_for_rows = sq_colnorms_x + ro_eds;
     const T* sq_colnorms_for_cols = sq_colnorms_x + co_eds;
 
@@ -136,7 +136,7 @@ void squared_exp_kernel_submatrix(
     T bandwidth
 ) {
     int64_t size_Ksub = rows_ksub * cols_ksub;
-    randlapack_error_if_msg(!(bandwidth > 0), "kernel bandwidth must be > 0; got bandwidth=%g", (double)bandwidth);
+    randlapack_require(!(bandwidth <= 0)) << "kernel bandwidth must be > 0; got bandwidth=" << bandwidth;
     euclidean_distance_submatrix(rows_x, cols_x, X, sq_colnorms_x, rows_ksub, cols_ksub, Ksub, ro_ksub, co_ksub);
     T scale = -1.0 / (2.0 * bandwidth * bandwidth);
     auto inplace_exp = [scale](T &val) { val = std::exp(scale*val); };
@@ -237,7 +237,7 @@ struct RBFKernelMatrix {
     }
 
     void _prep_eval_work1(int64_t rows_ksub, int64_t cols_ksub, int64_t ro_ksub, int64_t co_ksub) {
-        randlapack_error_if_msg(rows_ksub * cols_ksub > (int64_t) _eval_work1.size(), "kernel submatrix rows_ksub*cols_ksub=%lld exceeds _eval_work1 size=%lld", (long long)(rows_ksub*cols_ksub), (long long)_eval_work1.size());
+        randlapack_require(rows_ksub * cols_ksub <= (int64_t) _eval_work1.size()) << "kernel submatrix rows_ksub*cols_ksub=" << (rows_ksub*cols_ksub) << " exceeds _eval_work1 size=" << _eval_work1.size();
         squared_exp_kernel_submatrix(
             rows_x, dim, X, _sq_colnorms_x.data(),
             rows_ksub, cols_ksub, _eval_work1.data(), ro_ksub, co_ksub, bandwidth
@@ -249,9 +249,9 @@ struct RBFKernelMatrix {
     }
 
     void operator()(blas::Layout layout, int64_t n, T alpha, T* const B, int64_t ldb, T beta, T* C, int64_t ldc) {
-        randlapack_error_if_msg(layout != blas::Layout::ColMajor, "this kernel matrix only supports ColMajor layout");
-        randlapack_error_if_msg(ldb < dim, "ldb=%lld < dim=%lld (ldb must be >= operator dimension)", (long long)ldb, (long long)dim);
-        randlapack_error_if_msg(ldc < dim, "ldc=%lld < dim=%lld (ldc must be >= operator dimension)", (long long)ldc, (long long)dim);
+        randlapack_require(layout == blas::Layout::ColMajor) << "this kernel matrix only supports ColMajor layout";
+        randlapack_require(ldb >= dim) << "ldb=" << ldb << " < dim=" << dim << " (ldb must be >= operator dimension)";
+        randlapack_require(ldc >= dim) << "ldc=" << ldc << " < dim=" << dim << " (ldc must be >= operator dimension)";
 
         _eval_work2.resize(dim * n);
         for (int64_t i = 0; i < n; ++i) {
@@ -275,7 +275,7 @@ struct RBFKernelMatrix {
             todo -= k;
         }
         if (_eval_includes_reg) {
-            randlapack_error_if_msg(!(num_ops == 1 || n == num_ops), "with num_ops>1, n=%lld must equal num_ops=%lld so each column gets its own regularization", (long long)n, (long long)num_ops);
+            randlapack_require(!(num_ops != 1 || n == num_ops)) << "with num_ops>1, n=" << n << " must equal num_ops=" << num_ops << " so each column gets its own regularization";
             for (int64_t i = 0; i < n; ++i) {
                 T coeff =  alpha * regs[std::min(i, num_ops - 1)];
                 blas::axpy(dim, coeff, B + i*ldb, 1, C +  i*ldc, 1);
@@ -287,7 +287,7 @@ struct RBFKernelMatrix {
     inline T operator()(int64_t i, int64_t j) {
         T val = squared_exp_kernel(rows_x, X + i*rows_x, X + j*rows_x, bandwidth);
         if (_eval_includes_reg && i == j) {
-            randlapack_error_if_msg(num_ops != 1, "this operation requires num_ops=1; got num_ops=%lld", (long long)num_ops);
+            randlapack_require(num_ops == 1) << "this operation requires num_ops=1; got num_ops=" << num_ops;
             val += regs[0];
         }
         return val;

--- a/RandLAPACK/misc/rl_pdkernels.hh
+++ b/RandLAPACK/misc/rl_pdkernels.hh
@@ -75,8 +75,8 @@ void euclidean_distance_submatrix(
     int64_t rows_x, int64_t cols_x, const T* X, const T* sq_colnorms_x,
     int64_t rows_eds, int64_t cols_eds, T* Eds, int64_t ro_eds, int64_t co_eds
 ) {
-    randlapack_require(!((0 > co_eds) && ((co_eds + cols_eds) <= cols_x))) << "column window must satisfy 0 <= co_eds and co_eds+cols_eds <= cols_x; got co_eds=" << co_eds << " cols_eds=" << cols_eds << " cols_x=" << cols_x;
-    randlapack_require(!((0 > ro_eds) && ((ro_eds + rows_eds) <= cols_x))) << "row window must satisfy 0 <= ro_eds and ro_eds+rows_eds <= cols_x; got ro_eds=" << ro_eds << " rows_eds=" << rows_eds << " cols_x=" << cols_x;
+    randlapack_require((0 <= co_eds) && ((co_eds + cols_eds) <= cols_x)) << "column window must satisfy 0 <= co_eds and co_eds+cols_eds <= cols_x; got co_eds=" << co_eds << " cols_eds=" << cols_eds << " cols_x=" << cols_x;
+    randlapack_require((0 <= ro_eds) && ((ro_eds + rows_eds) <= cols_x)) << "row window must satisfy 0 <= ro_eds and ro_eds+rows_eds <= cols_x; got ro_eds=" << ro_eds << " rows_eds=" << rows_eds << " cols_x=" << cols_x;
     const T* sq_colnorms_for_rows = sq_colnorms_x + ro_eds;
     const T* sq_colnorms_for_cols = sq_colnorms_x + co_eds;
 
@@ -136,7 +136,7 @@ void squared_exp_kernel_submatrix(
     T bandwidth
 ) {
     int64_t size_Ksub = rows_ksub * cols_ksub;
-    randlapack_require(!(bandwidth <= 0)) << "kernel bandwidth must be > 0; got bandwidth=" << bandwidth;
+    randlapack_require(bandwidth > 0) << "kernel bandwidth must be > 0; got bandwidth=" << bandwidth;
     euclidean_distance_submatrix(rows_x, cols_x, X, sq_colnorms_x, rows_ksub, cols_ksub, Ksub, ro_ksub, co_ksub);
     T scale = -1.0 / (2.0 * bandwidth * bandwidth);
     auto inplace_exp = [scale](T &val) { val = std::exp(scale*val); };
@@ -275,7 +275,7 @@ struct RBFKernelMatrix {
             todo -= k;
         }
         if (_eval_includes_reg) {
-            randlapack_require(!(num_ops != 1 || n == num_ops)) << "with num_ops>1, n=" << n << " must equal num_ops=" << num_ops << " so each column gets its own regularization";
+            randlapack_require(num_ops == 1 || n == num_ops) << "with num_ops>1, n=" << n << " must equal num_ops=" << num_ops << " so each column gets its own regularization";
             for (int64_t i = 0; i < n; ++i) {
                 T coeff =  alpha * regs[std::min(i, num_ops - 1)];
                 blas::axpy(dim, coeff, B + i*ldb, 1, C +  i*ldc, 1);

--- a/RandLAPACK/rl_exceptions.hh
+++ b/RandLAPACK/rl_exceptions.hh
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <exception>
+#include <cstdarg>
+#include <cstdio>
+#include <string>
+
+// Most code in this file is structurally adapted from RandBLAS/exceptions.hh
+// (which itself was adapted from BLAS++). The macros and helpers here throw a
+// distinct RandLAPACK::Error so that callers can catch RandLAPACK failures
+// independently of RandBLAS failures.
+
+namespace RandLAPACK {
+
+// -----------------------------------------------------------------------------
+/// Minimalist exception class for RandLAPACK errors.
+///
+/// @verbatim embed:rst:leading-slashes
+///  These are typically triggered by statements of the form
+///  ``randlapack_require(cond)`` where ``cond`` was false, or
+///  ``randlapack_error_if_msg(cond, fmt, ...)`` where ``cond`` was true.
+///  See ``RandLAPACK/rl_exceptions.hh`` for the macro definitions.
+///
+///  RandLAPACK errors are distinct from ``RandBLAS::Error``; catch each type
+///  separately if a caller cares which library raised the problem.
+/// @endverbatim
+///
+class Error : public std::exception {
+private:
+    std::string msg_;
+public:
+    Error() : std::exception() {}
+    Error(std::string const &msg) : Error() { msg_ = msg; }
+
+    // Constructs RandLAPACK error with message: "msg, in function func"
+    Error(const char* msg, const char* func)
+        : Error(std::string(msg) + ", in function " + func) {}
+
+    // ---------------------------------------------------------------
+    /// Returns a C-string representation of this error's message.
+    /// It's common to wrap this function's return value with std::string.
+    virtual const char* what() const noexcept override
+        { return msg_.c_str(); }
+};
+
+} // namespace RandLAPACK
+
+namespace RandLAPACK::exceptions {
+
+namespace internal {
+
+// -----------------------------------------------------------------------------
+// internal helper: throws RandLAPACK::Error if cond is true.
+// Called by the randlapack_error_if macro.
+inline void throw_if(bool cond, const char* condstr, const char* func) {
+    if (cond) {
+        throw Error(condstr, func);
+    }
+}
+
+#if defined(_MSC_VER)
+    #define RandLAPACK_ATTR_FORMAT(I, F)
+#else
+    #define RandLAPACK_ATTR_FORMAT(I, F) __attribute__((format(printf, I, F)))
+#endif
+
+#define RandLAPACK_ERROR_MESSAGE_SIZE 256
+
+// -----------------------------------------------------------------------------
+// internal helper: printf-style; throws RandLAPACK::Error if cond is true.
+// Called by the randlapack_error_if_msg macro.
+// condstr is captured for symmetry with the non-message overload but ignored
+// here; the formatted buffer carries the user-supplied message instead.
+inline void throw_if(bool cond, const char* condstr, const char* func, const char* format, ...)
+    RandLAPACK_ATTR_FORMAT(4, 5);
+
+inline void throw_if(bool cond, const char* condstr, const char* func, const char* format, ...) {
+    (void) condstr;
+    if (cond) {
+        char buf[RandLAPACK_ERROR_MESSAGE_SIZE];
+        va_list va;
+        va_start(va, format);
+        vsnprintf(buf, sizeof(buf), format, va);
+        va_end(va);
+        throw Error(buf, func);
+    }
+}
+
+#undef RandLAPACK_ATTR_FORMAT
+
+} // namespace internal
+
+
+// Macro: throws RandLAPACK::Error if cond is true.
+// Example: randlapack_error_if(m < 0);
+#define randlapack_error_if(cond) \
+    RandLAPACK::exceptions::internal::throw_if((cond), #cond, __func__)
+
+// Macro: printf-style; throws RandLAPACK::Error if cond is true.
+// Example: randlapack_error_if_msg(m < 0, "m must be >= 0; got m=%ld", m);
+#define randlapack_error_if_msg(cond, ...) \
+    RandLAPACK::exceptions::internal::throw_if((cond), #cond, __func__, __VA_ARGS__)
+
+// Macro: throws RandLAPACK::Error if cond is false (i.e. the required
+// invariant did not hold).
+// Example: randlapack_require(m >= 0);
+#define randlapack_require(cond) \
+    RandLAPACK::exceptions::internal::throw_if(!(cond), "(" #cond ") was required, but did not hold", __func__)
+
+
+} // namespace RandLAPACK::exceptions

--- a/RandLAPACK/rl_exceptions.hh
+++ b/RandLAPACK/rl_exceptions.hh
@@ -1,14 +1,24 @@
 #pragma once
 
 #include <exception>
-#include <cstdarg>
-#include <cstdio>
+#include <sstream>
 #include <string>
 
-// Most code in this file is structurally adapted from RandBLAS/exceptions.hh
-// (which itself was adapted from BLAS++). The macros and helpers here throw a
-// distinct RandLAPACK::Error so that callers can catch RandLAPACK failures
-// independently of RandBLAS failures.
+// RandLAPACK error infrastructure. Throws a distinct RandLAPACK::Error so
+// callers can catch RandLAPACK failures independently of RandBLAS failures.
+//
+// Usage at call sites uses iostream-style chaining:
+//
+//   randlapack_require(b_sz >= 1)
+//       << "BQRRP::call: b_sz=" << b_sz << " must be positive";
+//
+// On the happy path (cond is true) the macro short-circuits with zero cost;
+// no temporary is constructed and no stream is touched. On failure, a
+// StreamThrower temporary is built, the operator<< chain populates its
+// stringstream, and the temporary's destructor throws RandLAPACK::Error at
+// the end of the full expression. The message can be omitted entirely
+// (`randlapack_require(cond);`) — the destructor falls back to the
+// stringified condition.
 
 namespace RandLAPACK {
 
@@ -16,10 +26,9 @@ namespace RandLAPACK {
 /// Minimalist exception class for RandLAPACK errors.
 ///
 /// @verbatim embed:rst:leading-slashes
-///  These are typically triggered by statements of the form
-///  ``randlapack_require(cond)`` where ``cond`` was false, or
-///  ``randlapack_error_if_msg(cond, fmt, ...)`` where ``cond`` was true.
-///  See ``RandLAPACK/rl_exceptions.hh`` for the macro definitions.
+///  Typically triggered by a statement of the form
+///  ``randlapack_require(cond) << "message"`` where ``cond`` was false.
+///  See ``RandLAPACK/rl_exceptions.hh`` for the macro definition.
 ///
 ///  RandLAPACK errors are distinct from ``RandBLAS::Error``; catch each type
 ///  separately if a caller cares which library raised the problem.
@@ -33,79 +42,57 @@ public:
     Error(std::string const &msg) : Error() { msg_ = msg; }
 
     // Constructs RandLAPACK error with message: "msg, in function func"
-    Error(const char* msg, const char* func)
-        : Error(std::string(msg) + ", in function " + func) {}
+    Error(std::string const &msg, const char* func)
+        : Error(msg + ", in function " + func) {}
 
     // ---------------------------------------------------------------
     /// Returns a C-string representation of this error's message.
-    /// It's common to wrap this function's return value with std::string.
     virtual const char* what() const noexcept override
         { return msg_.c_str(); }
 };
 
 } // namespace RandLAPACK
 
-namespace RandLAPACK::exceptions {
+namespace RandLAPACK::exceptions::internal {
 
-namespace internal {
+// RAII helper used by randlapack_require. Constructed only when the required
+// condition fails; destructor throws RandLAPACK::Error at end of full
+// expression after operator<< populates the stream.
+class StreamThrower {
+    const char* condstr_;
+    const char* func_;
+    std::ostringstream ss_;
+public:
+    StreamThrower(const char* condstr, const char* func)
+        : condstr_(condstr), func_(func) {}
 
-// -----------------------------------------------------------------------------
-// internal helper: throws RandLAPACK::Error if cond is true.
-// Called by the randlapack_error_if macro.
-inline void throw_if(bool cond, const char* condstr, const char* func) {
-    if (cond) {
-        throw Error(condstr, func);
+    StreamThrower(const StreamThrower&) = delete;
+    StreamThrower& operator=(const StreamThrower&) = delete;
+
+    template <typename T>
+    StreamThrower& operator<<(const T& v) { ss_ << v; return *this; }
+
+    [[noreturn]] ~StreamThrower() noexcept(false) {
+        std::string msg = ss_.str();
+        if (msg.empty()) msg = condstr_;
+        throw Error(msg, func_);
     }
-}
+};
 
-#if defined(_MSC_VER)
-    #define RandLAPACK_ATTR_FORMAT(I, F)
-#else
-    #define RandLAPACK_ATTR_FORMAT(I, F) __attribute__((format(printf, I, F)))
-#endif
-
-#define RandLAPACK_ERROR_MESSAGE_SIZE 256
-
-// -----------------------------------------------------------------------------
-// internal helper: printf-style; throws RandLAPACK::Error if cond is true.
-// Called by the randlapack_error_if_msg macro.
-// condstr is captured for symmetry with the non-message overload but ignored
-// here; the formatted buffer carries the user-supplied message instead.
-inline void throw_if(bool cond, const char* condstr, const char* func, const char* format, ...)
-    RandLAPACK_ATTR_FORMAT(4, 5);
-
-inline void throw_if(bool cond, const char* condstr, const char* func, const char* format, ...) {
-    (void) condstr;
-    if (cond) {
-        char buf[RandLAPACK_ERROR_MESSAGE_SIZE];
-        va_list va;
-        va_start(va, format);
-        vsnprintf(buf, sizeof(buf), format, va);
-        va_end(va);
-        throw Error(buf, func);
-    }
-}
-
-#undef RandLAPACK_ATTR_FORMAT
-
-} // namespace internal
+} // namespace RandLAPACK::exceptions::internal
 
 
-// Macro: throws RandLAPACK::Error if cond is true.
-// Example: randlapack_error_if(m < 0);
-#define randlapack_error_if(cond) \
-    RandLAPACK::exceptions::internal::throw_if((cond), #cond, __func__)
-
-// Macro: printf-style; throws RandLAPACK::Error if cond is true.
-// Example: randlapack_error_if_msg(m < 0, "m must be >= 0; got m=%ld", m);
-#define randlapack_error_if_msg(cond, ...) \
-    RandLAPACK::exceptions::internal::throw_if((cond), #cond, __func__, __VA_ARGS__)
-
-// Macro: throws RandLAPACK::Error if cond is false (i.e. the required
-// invariant did not hold).
-// Example: randlapack_require(m >= 0);
+// Macro: throws RandLAPACK::Error if cond is false. Supports an optional
+// stream-style message appended via operator<<.
+// Examples:
+//   randlapack_require(m >= 0);
+//   randlapack_require(m >= n) << "BQRRP requires m >= n; got m=" << m
+//                              << ", n=" << n;
+//
+// The `for` form (instead of `if (cond) ; else ...`) is deliberate: it
+// shields the macro from -Wdangling-else when used inside an unbraced outer
+// `if`, while preserving the zero-cost happy path (the loop body is not
+// entered when cond holds) and the throw-on-destruct semantics of the
+// StreamThrower temporary.
 #define randlapack_require(cond) \
-    RandLAPACK::exceptions::internal::throw_if(!(cond), "(" #cond ") was required, but did not hold", __func__)
-
-
-} // namespace RandLAPACK::exceptions
+    for (; !(cond); ) ::RandLAPACK::exceptions::internal::StreamThrower(#cond, __func__)

--- a/RandLAPACK/testing/rl_gen.hh
+++ b/RandLAPACK/testing/rl_gen.hh
@@ -620,8 +620,8 @@ RandBLAS::sparse_data::coo::COOMatrix<T> gen_sparse_from_singvals(
 ) {
     using namespace RandBLAS::sparse_data;
 
-    randlapack_error_if_msg(m < n, "tall sparse matrix requires m >= n; got m=%lld, n=%lld", (long long)m, (long long)n);
-    randlapack_error_if_msg(n < 1, "n=%lld must be >= 1", (long long)n);
+    randlapack_require(m >= n) << "tall sparse matrix requires m >= n; got m=" << m << ", n=" << n;
+    randlapack_require(n >= 1) << "n=" << n << " must be >= 1";
 
     // Build top n×n block as B = diag(σ) · V^T.
     // V is a Haar-random orthogonal matrix from QR of a Gaussian.
@@ -690,7 +690,7 @@ RandBLAS::sparse_data::coo::COOMatrix<T> gen_sparse_cond_coo(
     RandBLAS::RNGState<RNG> &state,
     T target_density = (T)0.0
 ) {
-    randlapack_error_if_msg(cond_num < (T)1.0, "cond_num=%g must be >= 1.0", (double)cond_num);
+    randlapack_require(cond_num >= (T)1.0) << "cond_num=" << cond_num << " must be >= 1.0";
 
     std::vector<T> sigma(n);
     if (n == 1) {

--- a/RandLAPACK/testing/rl_gen.hh
+++ b/RandLAPACK/testing/rl_gen.hh
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "rl_exceptions.hh"
 #include "rl_blaspp.hh"
 #include "rl_lapackpp.hh"
 
@@ -619,8 +620,8 @@ RandBLAS::sparse_data::coo::COOMatrix<T> gen_sparse_from_singvals(
 ) {
     using namespace RandBLAS::sparse_data;
 
-    randblas_require(m >= n);
-    randblas_require(n >= 1);
+    randlapack_error_if_msg(m < n, "tall sparse matrix requires m >= n; got m=%lld, n=%lld", (long long)m, (long long)n);
+    randlapack_error_if_msg(n < 1, "n=%lld must be >= 1", (long long)n);
 
     // Build top n×n block as B = diag(σ) · V^T.
     // V is a Haar-random orthogonal matrix from QR of a Gaussian.
@@ -689,7 +690,7 @@ RandBLAS::sparse_data::coo::COOMatrix<T> gen_sparse_cond_coo(
     RandBLAS::RNGState<RNG> &state,
     T target_density = (T)0.0
 ) {
-    randblas_require(cond_num >= (T)1.0);
+    randlapack_error_if_msg(cond_num < (T)1.0, "cond_num=%g must be >= 1.0", (double)cond_num);
 
     std::vector<T> sigma(n);
     if (n == 1) {

--- a/RandLAPACK/testing/rl_test_utils.hh
+++ b/RandLAPACK/testing/rl_test_utils.hh
@@ -203,7 +203,7 @@ template <typename T>
     int64_t info = ::lapack::gesdd(::lapack::Job::NoVec,
                     m, n, A_dense, m, sigma.data(),
                     nullptr, 1, nullptr, 1);
-    randlapack_error_if_msg(info != 0, "LAPACK call returned info=%lld (expected 0)", (long long)info);
+    randlapack_require(info == 0) << "LAPACK call returned info=" << info << " (expected 0)";
     return sigma;
 }
 

--- a/RandLAPACK/testing/rl_test_utils.hh
+++ b/RandLAPACK/testing/rl_test_utils.hh
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "rl_exceptions.hh"
 #include <blas.hh>
 #include <lapack.hh>
 #include <RandBLAS.hh>
@@ -202,7 +203,7 @@ template <typename T>
     int64_t info = ::lapack::gesdd(::lapack::Job::NoVec,
                     m, n, A_dense, m, sigma.data(),
                     nullptr, 1, nullptr, 1);
-    randblas_require(info == 0);
+    randlapack_error_if_msg(info != 0, "LAPACK call returned info=%lld (expected 0)", (long long)info);
     return sigma;
 }
 

--- a/install.sh
+++ b/install.sh
@@ -197,6 +197,87 @@ else
     echo "Directory cleared at: $RANDNLA_PROJECT_DIR/build/benchmark-build/"
 fi
 
+#==============================================================================
+# Discovery phase: probe for already-installed dependencies via env vars.
+# If <DEP>_INSTALL_DIR is set and points at a valid install, skip clone+build
+# and reuse it. Otherwise fall back to the fresh clone+build path below.
+# Supported env vars:
+#   BLASPP_INSTALL_DIR    -- root of blaspp install (containing lib/cmake/blaspp/ or lib64/...)
+#   LAPACKPP_INSTALL_DIR  -- root of lapackpp install
+#   RANDOM123_INSTALL_DIR -- root containing include/Random123/
+# RandBLAS is intentionally not covered here -- it stays a submodule.
+#==============================================================================
+
+# find_cmake_config <install_root> <pkg_name>
+# Echoes the directory containing <pkg_name>Config.cmake, or empty if not found.
+# Always returns 0; the caller checks for an empty result (avoids tripping set -e).
+find_cmake_config() {
+    local root="$1"
+    local pkg="$2"
+    local libdir
+    for libdir in lib lib64 lib/x86_64-linux-gnu; do
+        if [[ -f "$root/$libdir/cmake/$pkg/${pkg}Config.cmake" ]]; then
+            echo "$root/$libdir/cmake/$pkg/"
+            return 0
+        fi
+    done
+    return 0
+}
+
+USE_EXTERNAL_BLASPP=false
+USE_EXTERNAL_LAPACKPP=false
+USE_EXTERNAL_RANDOM123=false
+BLASPP_CMAKE_DIR=""
+LAPACKPP_CMAKE_DIR=""
+RANDOM123_DIR=""
+BLASPP_LIB_DIR=""
+LAPACKPP_LIB_DIR=""
+
+echo "=========================================="
+echo "Dependency discovery..."
+echo "=========================================="
+
+if [[ -n "${BLASPP_INSTALL_DIR:-}" ]]; then
+    BLASPP_CMAKE_DIR=$(find_cmake_config "$BLASPP_INSTALL_DIR" "blaspp")
+    if [[ -n "$BLASPP_CMAKE_DIR" ]]; then
+        USE_EXTERNAL_BLASPP=true
+        BLASPP_LIB_DIR=$(dirname "$(dirname "$BLASPP_CMAKE_DIR")")
+        echo "  [blaspp]    Using external install at $BLASPP_INSTALL_DIR"
+        echo "              CMake config: $BLASPP_CMAKE_DIR"
+    else
+        echo "  [blaspp]    BLASPP_INSTALL_DIR=$BLASPP_INSTALL_DIR set but blasppConfig.cmake not found; will build from source."
+    fi
+else
+    echo "  [blaspp]    No BLASPP_INSTALL_DIR set; will build from source."
+fi
+
+if [[ -n "${LAPACKPP_INSTALL_DIR:-}" ]]; then
+    LAPACKPP_CMAKE_DIR=$(find_cmake_config "$LAPACKPP_INSTALL_DIR" "lapackpp")
+    if [[ -n "$LAPACKPP_CMAKE_DIR" ]]; then
+        USE_EXTERNAL_LAPACKPP=true
+        LAPACKPP_LIB_DIR=$(dirname "$(dirname "$LAPACKPP_CMAKE_DIR")")
+        echo "  [lapackpp]  Using external install at $LAPACKPP_INSTALL_DIR"
+        echo "              CMake config: $LAPACKPP_CMAKE_DIR"
+    else
+        echo "  [lapackpp]  LAPACKPP_INSTALL_DIR=$LAPACKPP_INSTALL_DIR set but lapackppConfig.cmake not found; will build from source."
+    fi
+else
+    echo "  [lapackpp]  No LAPACKPP_INSTALL_DIR set; will build from source."
+fi
+
+if [[ -n "${RANDOM123_INSTALL_DIR:-}" ]]; then
+    if [[ -f "$RANDOM123_INSTALL_DIR/include/Random123/philox.h" ]]; then
+        USE_EXTERNAL_RANDOM123=true
+        RANDOM123_DIR="$RANDOM123_INSTALL_DIR/include/"
+        echo "  [random123] Using external install at $RANDOM123_INSTALL_DIR"
+    else
+        echo "  [random123] RANDOM123_INSTALL_DIR=$RANDOM123_INSTALL_DIR set but include/Random123/philox.h not found; will clone from source."
+    fi
+else
+    echo "  [random123] No RANDOM123_INSTALL_DIR set; will clone from source."
+fi
+echo ""
+
 # Initialize and update RandLAPACK submodule -- RandBLAS
 git -C $SCRIPT_DIR submodule init; git -C $SCRIPT_DIR submodule update
 
@@ -205,14 +286,14 @@ if [[ ! -d "$RANDNLA_PROJECT_DIR/lib/RandLAPACK" ]]; then
     mv "$SCRIPT_DIR" "$PARENT_DIR/RandNLA-project/lib/RandLAPACK"
 fi
 
-# Obtain BLAS++ and LAPACK++
-if [[ ! -d "$RANDNLA_PROJECT_DIR/lib/lapackpp" ]]; then
+# Obtain BLAS++ and LAPACK++ (skip the clones for any dep discovered above)
+if [[ "$USE_EXTERNAL_LAPACKPP" != "true" && ! -d "$RANDNLA_PROJECT_DIR/lib/lapackpp" ]]; then
 git clone https://github.com/icl-utk-edu/lapackpp         $RANDNLA_PROJECT_DIR/lib/lapackpp
 fi
-if [[ ! -d "$RANDNLA_PROJECT_DIR/lib/blaspp" ]]; then
+if [[ "$USE_EXTERNAL_BLASPP" != "true" && ! -d "$RANDNLA_PROJECT_DIR/lib/blaspp" ]]; then
 git clone https://github.com/icl-utk-edu/blaspp           $RANDNLA_PROJECT_DIR/lib/blaspp
 fi
-if [[ ! -d "$RANDNLA_PROJECT_DIR/install/random123" ]]; then
+if [[ "$USE_EXTERNAL_RANDOM123" != "true" && ! -d "$RANDNLA_PROJECT_DIR/install/random123" ]]; then
 git clone https://github.com/DEShawResearch/random123.git $RANDNLA_PROJECT_DIR/install/random123
 fi
 
@@ -244,31 +325,38 @@ if [[ "$(uname)" == "Darwin" ]]; then
     # Flags use semicolon cmake-list syntax to avoid bash word-splitting on spaces.
     MACOS_OPENMP_FLAGS="-DOpenMP_C_LIB_NAMES=omp -DOpenMP_CXX_LIB_NAMES=omp -DOpenMP_omp_LIBRARY=/opt/homebrew/opt/libomp/lib/libomp.dylib -DOpenMP_C_FLAGS=-Xpreprocessor;-fopenmp -DOpenMP_CXX_FLAGS=-Xpreprocessor;-fopenmp"
 fi
-cmake  -S $RANDNLA_PROJECT_DIR/lib/blaspp/ -B $RANDNLA_PROJECT_DIR/build/blaspp-build/ \
-    -Dgpu_backend=$RANDNLA_PROJECT_GPU_AVAIL \
-    -DCMAKE_BUILD_TYPE=Release \
-    -Dblas_int=$BLAS_INT \
-    -DCMAKE_INSTALL_PREFIX=$RANDNLA_PROJECT_DIR/install/blaspp-install/ \
-    $MACOS_BLAS_FLAGS $MACOS_OPENMP_FLAGS
-make  -C $RANDNLA_PROJECT_DIR/build/blaspp-build/ -j20 install
+if [[ "$USE_EXTERNAL_BLASPP" != "true" ]]; then
+    cmake  -S $RANDNLA_PROJECT_DIR/lib/blaspp/ -B $RANDNLA_PROJECT_DIR/build/blaspp-build/ \
+        -Dgpu_backend=$RANDNLA_PROJECT_GPU_AVAIL \
+        -DCMAKE_BUILD_TYPE=Release \
+        -Dblas_int=$BLAS_INT \
+        -DCMAKE_INSTALL_PREFIX=$RANDNLA_PROJECT_DIR/install/blaspp-install/ \
+        $MACOS_BLAS_FLAGS $MACOS_OPENMP_FLAGS
+    make  -C $RANDNLA_PROJECT_DIR/build/blaspp-build/ -j20 install
 
-# Check if lib or lib64 folder name will be in use
-LIB_VAR="lib"
-if [[ -d "$RANDNLA_PROJECT_DIR/install/blaspp-install/lib" ]]; then
-    LIB_VAR="lib"
-elif [[ -d "$RANDNLA_PROJECT_DIR/install/blaspp-install/lib64" ]]; then
-    LIB_VAR="lib64"
+    BLASPP_CMAKE_DIR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/blaspp-install" "blaspp")
+    BLASPP_LIB_DIR=$(dirname "$(dirname "$BLASPP_CMAKE_DIR")")
 fi
 
 # Configure, build, and install LAPACK++
 # Add "-DBLAS_LIBRARIES='-lflame -lblis'" if using AMD AOCL
-cmake  -S $RANDNLA_PROJECT_DIR/lib/lapackpp/ -B $RANDNLA_PROJECT_DIR/build/lapackpp-build/ -Dgpu_backend=$RANDNLA_PROJECT_GPU_AVAIL -DCMAKE_BUILD_TYPE=Release  -Dblaspp_DIR=$RANDNLA_PROJECT_DIR/install/blaspp-install/$LIB_VAR/cmake/blaspp/  -DCMAKE_INSTALL_PREFIX=$RANDNLA_PROJECT_DIR/install/lapackpp-install -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON $MACOS_LAPACK_FLAGS $MACOS_OPENMP_FLAGS
-make  -C $RANDNLA_PROJECT_DIR/build/lapackpp-build/ -j20 install
+if [[ "$USE_EXTERNAL_LAPACKPP" != "true" ]]; then
+    cmake  -S $RANDNLA_PROJECT_DIR/lib/lapackpp/ -B $RANDNLA_PROJECT_DIR/build/lapackpp-build/ -Dgpu_backend=$RANDNLA_PROJECT_GPU_AVAIL -DCMAKE_BUILD_TYPE=Release  -Dblaspp_DIR=$BLASPP_CMAKE_DIR  -DCMAKE_INSTALL_PREFIX=$RANDNLA_PROJECT_DIR/install/lapackpp-install -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON $MACOS_LAPACK_FLAGS $MACOS_OPENMP_FLAGS
+    make  -C $RANDNLA_PROJECT_DIR/build/lapackpp-build/ -j20 install
+
+    LAPACKPP_CMAKE_DIR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/lapackpp-install" "lapackpp")
+    LAPACKPP_LIB_DIR=$(dirname "$(dirname "$LAPACKPP_CMAKE_DIR")")
+fi
+
+# random123 is header-only; pin RANDOM123_DIR to the local clone if we're not using an external install
+if [[ "$USE_EXTERNAL_RANDOM123" != "true" ]]; then
+    RANDOM123_DIR="$RANDNLA_PROJECT_DIR/install/random123/include/"
+fi
 # Configure, build, and install RandLAPACK
 echo "=========================================="
 echo "Configuring and building RandLAPACK..."
 echo "=========================================="
-cmake  -S $RANDNLA_PROJECT_DIR/lib/RandLAPACK/ -B $RANDNLA_PROJECT_DIR/build/RandLAPACK-build/ -DCMAKE_BUILD_TYPE=Release -DRequireCUDA=$RANDLAPACK_CUDA -Dlapackpp_DIR=$RANDNLA_PROJECT_DIR/install/lapackpp-install/$LIB_VAR/cmake/lapackpp/ -Dblaspp_DIR=$RANDNLA_PROJECT_DIR/install/blaspp-install/$LIB_VAR/cmake/blaspp/  -DRandom123_DIR=$RANDNLA_PROJECT_DIR/install/random123/include/  -DCMAKE_INSTALL_PREFIX=$RANDNLA_PROJECT_DIR/install/RandLAPACK-install -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON $MACOS_OPENMP_FLAGS
+cmake  -S $RANDNLA_PROJECT_DIR/lib/RandLAPACK/ -B $RANDNLA_PROJECT_DIR/build/RandLAPACK-build/ -DCMAKE_BUILD_TYPE=Release -DRequireCUDA=$RANDLAPACK_CUDA -Dlapackpp_DIR=$LAPACKPP_CMAKE_DIR -Dblaspp_DIR=$BLASPP_CMAKE_DIR -DRandom123_DIR=$RANDOM123_DIR -DCMAKE_INSTALL_PREFIX=$RANDNLA_PROJECT_DIR/install/RandLAPACK-install -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON $MACOS_OPENMP_FLAGS
 if [ $? -ne 0 ]; then
     echo "ERROR: RandLAPACK configuration failed!"
     exit 1
@@ -278,12 +366,17 @@ if [ $? -ne 0 ]; then
     echo "ERROR: RandLAPACK build failed!"
     exit 1
 fi
+RANDLAPACK_CMAKE_DIR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/RandLAPACK-install" "RandLAPACK")
+RANDLAPACK_LIB_DIR=$(dirname "$(dirname "$RANDLAPACK_CMAKE_DIR")")
 echo "RandLAPACK configured and built successfully"
 echo ""
 
-# If GPU support is disabled, prevent extras and benchmarks from auto-detecting CUDA
+# If GPU support is disabled AND we're building blaspp from source (not using an
+# external install), prevent extras and benchmarks from auto-detecting CUDA.
+# When using an external blaspp install, the external install's configuration
+# dictates whether CUDAToolkit is required (its config calls find_dependency on it).
 DISABLE_CUDA_FLAG=""
-if [[ "$RANDLAPACK_CUDA" == "OFF" ]]; then
+if [[ "$RANDLAPACK_CUDA" == "OFF" && "$USE_EXTERNAL_BLASPP" != "true" ]]; then
     DISABLE_CUDA_FLAG="-DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=TRUE"
 fi
 
@@ -291,7 +384,7 @@ fi
 echo "=========================================="
 echo "Configuring and building RandLAPACK extras..."
 echo "=========================================="
-cmake  -S $RANDNLA_PROJECT_DIR/lib/RandLAPACK/extras/ -B $RANDNLA_PROJECT_DIR/build/extras-build/ -DCMAKE_BUILD_TYPE=Release -DFETCHCONTENT_BASE_DIR=$RANDNLA_PROJECT_DIR/build/fetchcontent-cache/ -DRandLAPACK_DIR=$RANDNLA_PROJECT_DIR/install/RandLAPACK-install/$LIB_VAR/cmake/RandLAPACK/ -Dlapackpp_DIR=$RANDNLA_PROJECT_DIR/install/lapackpp-install/$LIB_VAR/cmake/lapackpp/ -Dblaspp_DIR=$RANDNLA_PROJECT_DIR/install/blaspp-install/$LIB_VAR/cmake/blaspp/ -DRandom123_DIR=$RANDNLA_PROJECT_DIR/install/random123/include/ -DCMAKE_BUILD_RPATH="$RANDNLA_PROJECT_DIR/install/blaspp-install/$LIB_VAR;$RANDNLA_PROJECT_DIR/install/lapackpp-install/$LIB_VAR;$RANDNLA_PROJECT_DIR/install/RandLAPACK-install/$LIB_VAR" $DISABLE_CUDA_FLAG $MACOS_OPENMP_FLAGS
+cmake  -S $RANDNLA_PROJECT_DIR/lib/RandLAPACK/extras/ -B $RANDNLA_PROJECT_DIR/build/extras-build/ -DCMAKE_BUILD_TYPE=Release -DFETCHCONTENT_BASE_DIR=$RANDNLA_PROJECT_DIR/build/fetchcontent-cache/ -DRandLAPACK_DIR=$RANDLAPACK_CMAKE_DIR -Dlapackpp_DIR=$LAPACKPP_CMAKE_DIR -Dblaspp_DIR=$BLASPP_CMAKE_DIR -DRandom123_DIR=$RANDOM123_DIR -DCMAKE_BUILD_RPATH="$BLASPP_LIB_DIR;$LAPACKPP_LIB_DIR;$RANDLAPACK_LIB_DIR" $DISABLE_CUDA_FLAG $MACOS_OPENMP_FLAGS
 if [ $? -ne 0 ]; then
     echo "ERROR: RandLAPACK extras configuration failed!"
     exit 1
@@ -308,7 +401,7 @@ echo ""
 echo "=========================================="
 echo "Configuring and building RandLAPACK benchmarks..."
 echo "=========================================="
-cmake  -S $RANDNLA_PROJECT_DIR/lib/RandLAPACK/benchmark/ -B $RANDNLA_PROJECT_DIR/build/benchmark-build/  -DCMAKE_BUILD_TYPE=Release -DFETCHCONTENT_BASE_DIR=$RANDNLA_PROJECT_DIR/build/fetchcontent-cache/ -DRandLAPACK_DIR=$RANDNLA_PROJECT_DIR/install/RandLAPACK-install/$LIB_VAR/cmake/RandLAPACK/ -Dlapackpp_DIR=$RANDNLA_PROJECT_DIR/install/lapackpp-install/$LIB_VAR/cmake/lapackpp/ -Dblaspp_DIR=$RANDNLA_PROJECT_DIR/install/blaspp-install/$LIB_VAR/cmake/blaspp/ -DRandom123_DIR=$RANDNLA_PROJECT_DIR/install/random123/include/ -DCMAKE_BUILD_RPATH="$RANDNLA_PROJECT_DIR/install/blaspp-install/$LIB_VAR;$RANDNLA_PROJECT_DIR/install/lapackpp-install/$LIB_VAR;$RANDNLA_PROJECT_DIR/install/RandLAPACK-install/$LIB_VAR" $DISABLE_CUDA_FLAG $MACOS_OPENMP_FLAGS
+cmake  -S $RANDNLA_PROJECT_DIR/lib/RandLAPACK/benchmark/ -B $RANDNLA_PROJECT_DIR/build/benchmark-build/  -DCMAKE_BUILD_TYPE=Release -DFETCHCONTENT_BASE_DIR=$RANDNLA_PROJECT_DIR/build/fetchcontent-cache/ -DRandLAPACK_DIR=$RANDLAPACK_CMAKE_DIR -Dlapackpp_DIR=$LAPACKPP_CMAKE_DIR -Dblaspp_DIR=$BLASPP_CMAKE_DIR -DRandom123_DIR=$RANDOM123_DIR -DCMAKE_BUILD_RPATH="$BLASPP_LIB_DIR;$LAPACKPP_LIB_DIR;$RANDLAPACK_LIB_DIR" $DISABLE_CUDA_FLAG $MACOS_OPENMP_FLAGS
 if [ $? -ne 0 ]; then
     echo "ERROR: RandLAPACK benchmarks configuration failed!"
     exit 1


### PR DESCRIPTION
Four coordinated changes preparing RandLAPACK for the bindings repo:

install.sh dependency discovery via BLASPP_INSTALL_DIR / LAPACKPP_INSTALL_DIR / RANDOM123_INSTALL_DIR env vars; skip clones and reuse existing installs when set. Also fixes a CUDA flag conflict when external blaspp depends on CUDAToolkit.

New RandLAPACK/rl_exceptions.hh defines RandLAPACK::Error plus a single `randlapack_require(cond) << "msg " << x;` macro backed by a RAII StreamThrower whose destructor throws at end of full expression. Registered in the umbrella header and CMakeLists.txt. The macro uses `for(; !(cond); )` rather than `if(cond);else` to short circuit without triggering -Wdangling-else inside unbraced outer ifs.

211 call sites across 19 RandLAPACK source files migrate from randblas_require to randlapack_require with hand readable messages that include the actual parameter values, e.g. `randlapack_require(b_sz >= 1) << "BQRRP::call: b_sz=" << b_sz << " must be positive"`. Polarity flips from "error if BAD" to "require GOOD"; (long long) casts drop since operator<< handles int64_t directly.

Driver entry point validation in every driver's call() and constructor, closing the segfault paths that bindings would expose: BQRRP (8 checks), RSVD (5), CQRRT (7), CQRRPT (8), REVD2 (6 across 2 overloads), ABRIK (9 across 3 overloads), krill_full_rpchol (6 new + 1 retained mu_size).
