### PR TITLE
Fix clang -Wall -Wextra warnings GCC silently misses (closes #137)

### DIFF
--- a/RandLAPACK/drivers/rl_abrik.hh
+++ b/RandLAPACK/drivers/rl_abrik.hh
@@ -278,12 +278,12 @@ class ABRIK {
             // also needs to be used together with the input's abstract linear operator form.
             // OMP_NUM_THREADS=4 seems to be the best option for dense sketch generation.
             #ifdef RandBLAS_HAS_OpenMP
-                omp_set_num_threads(this->num_threads_min);
+            omp_set_num_threads(this->num_threads_min);
             #endif
             RandBLAS::DenseDist D(n, k);
             state = RandBLAS::fill_dense(D, Y_i, state);
             #ifdef RandBLAS_HAS_OpenMP
-                omp_set_num_threads(this->num_threads_max);
+            omp_set_num_threads(this->num_threads_max);
             #endif
 
             if(this -> timing) {
@@ -412,11 +412,11 @@ class ABRIK {
 
                         // Copy R_ii over to R's (in transposed format).
                         #ifdef RandBLAS_HAS_OpenMP
-                                    omp_set_num_threads(this->num_threads_min);
+                        omp_set_num_threads(this->num_threads_min);
                         #endif
                         util::transposition(0, k, Y_i, n, R_ii, n, 1);
                         #ifdef RandBLAS_HAS_OpenMP
-                                    omp_set_num_threads(this->num_threads_max);
+                        omp_set_num_threads(this->num_threads_max);
                         #endif
 
                         if(this -> timing) {

--- a/RandLAPACK/testing/rl_gen.hh
+++ b/RandLAPACK/testing/rl_gen.hh
@@ -171,10 +171,8 @@ std::vector<T> gen_exp_singvals(int64_t k, T cond) {
     T t = -log(1 / cond) / (k - offset);
     T cnt = 0.0;
     std::fill(s.begin(), s.begin() + offset, 1.0);
-    int idx = offset;
     for (int i = offset; i < k; ++i) {
         s[i] = std::exp(++cnt * -t);
-        ++idx;
     }
     return s;
 }


### PR DESCRIPTION
Two RandLAPACK sources triggered clang `-Wunused-but-set-variable` and `-Wmisleading-indentation` under `-Wall -Wextra`. GCC 13.3 heuristics do not flag either, which is why they passed through the prior warnings-cleanup PR #136.

`RandLAPACK/testing/rl_gen.hh:174`: removed dead `int idx = offset;` and `++idx;` inside `gen_exp_singvals`; the variable was written but never read.

`RandLAPACK/drivers/rl_abrik.hh:281, 286, 415, 419`: de-indented the bodies of four `#ifdef RandBLAS_HAS_OpenMP` blocks so they align with the surrounding function-body indent. The previous extra indent visually chained off the preceding single-statement `if(this->timing)`, which is what triggers
`-Wmisleading-indentation`. No control-flow change.

Verified inside ghcr.io/rileyjmurray/randlapack-python-workshop with clang 20.1.8: 0 warnings under `-Wall -Wextra` (down from 46), 708/708 ctest pass. GCC 13.3 build unchanged.