### PR TITLE
Cmake improvements

### DIFF
--- a/CMake/RandLAPACKConfig.cmake.in
+++ b/CMake/RandLAPACKConfig.cmake.in
@@ -13,6 +13,12 @@ if (NOT RandBLAS_DIR)
 endif()
 find_dependency(RandBLAS)
 
+# OpenMP (RandLAPACK's INTERFACE links OpenMP::OpenMP_CXX directly when built with OpenMP).
+set(RandLAPACK_HAS_OpenMP @RandBLAS_HAS_OpenMP@)
+if (RandLAPACK_HAS_OpenMP)
+    find_dependency(OpenMP COMPONENTS CXX)
+endif()
+
 # lapack++
 if (NOT lapackpp_DIR)
     set(lapackpp_DIR "@RandLAPACK_lapackpp_DIR@")

--- a/CMake/RandLAPACKConfig.cmake.in
+++ b/CMake/RandLAPACKConfig.cmake.in
@@ -8,8 +8,8 @@ set(RandLAPACK_VERSION_PATCH "@RandLAPACK_VERSION_PATCH@")
 
 # randblas
 if (NOT RandBLAS_DIR)
-    # RandBLAS currently installs to lib/cmake/ not lib/cmake/RandBLAS/
-    set(RandBLAS_DIR ${CMAKE_CURRENT_LIST_DIR}/..)
+    # RandBLAS installs to lib/cmake/RandBLAS/ when bundled under the same prefix.
+    set(RandBLAS_DIR ${CMAKE_CURRENT_LIST_DIR}/../RandBLAS)
 endif()
 find_dependency(RandBLAS)
 

--- a/CMake/rl_build_options.cmake
+++ b/CMake/rl_build_options.cmake
@@ -1,6 +1,7 @@
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_SHARED_LIBS "Configure to build shared or static libraries" OFF)
+option(RandLAPACK_BUILD_TESTS "Build RandLAPACK's test suite" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,9 @@ add_subdirectory(RandBLAS)
 
 # Compile sources
 add_subdirectory(RandLAPACK)
-add_subdirectory(test)
+if (RandLAPACK_BUILD_TESTS)
+    add_subdirectory(test)
+endif()
 
 # Export the configuration
 include(rl_config)

--- a/RandLAPACK/CMakeLists.txt
+++ b/RandLAPACK/CMakeLists.txt
@@ -29,11 +29,11 @@ set(RandLAPACK_cxx_sources
 
 add_library(RandLAPACK INTERFACE)
 
-target_link_libraries(RandLAPACK INTERFACE 
+target_link_libraries(RandLAPACK INTERFACE
     RandBLAS
     lapackpp
     blaspp
-    Random123
+    Random123::Random123
 )
 
 if (RandBLAS_HAS_OpenMP)

--- a/RandLAPACK/CMakeLists.txt
+++ b/RandLAPACK/CMakeLists.txt
@@ -28,6 +28,7 @@ set(RandLAPACK_cxx_sources
 )
 
 add_library(RandLAPACK INTERFACE)
+target_compile_features(RandLAPACK INTERFACE cxx_std_20)
 
 target_link_libraries(RandLAPACK INTERFACE
     RandBLAS
@@ -45,12 +46,15 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/rl_config.hh
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/RandLAPACK)
 
 
-set(RandLAPACK_cxx_opts -Wall -Wextra)
+# Build-time only: warning and sanitizer flags should not leak into the installed target.
+target_compile_options(RandLAPACK INTERFACE
+    $<BUILD_INTERFACE:-Wall>
+    $<BUILD_INTERFACE:-Wextra>)
+
 if (SANITIZE_ADDRESS)
-    list(APPEND RandLAPACK_cxx_opts -fsanitize=address)
-    target_link_options(RandLAPACK INTERFACE -fsanitize=address)
+    target_compile_options(RandLAPACK INTERFACE $<BUILD_INTERFACE:-fsanitize=address>)
+    target_link_options(RandLAPACK    INTERFACE $<BUILD_INTERFACE:-fsanitize=address>)
 endif()
-target_compile_options(RandLAPACK INTERFACE ${RandLAPACK_cxx_opts})
 
 target_include_directories(
     RandLAPACK INTERFACE
@@ -99,5 +103,4 @@ install(
     NAMESPACE RandLAPACK::
     FILE RandLAPACKTargets.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/RandLAPACK
-    EXPORT_LINK_INTERFACE_LIBRARIES
 )

--- a/extras/test/CMakeLists.txt
+++ b/extras/test/CMakeLists.txt
@@ -8,15 +8,9 @@ if (GTest_FOUND)
     # Include path to extras subdirectories for utilities
     include_directories(${CMAKE_SOURCE_DIR})
 
-    # RandBLAS test utilities (comparison.hh) are not installed;
-    # resolve them from the source tree via the RandBLAS submodule.
-    set(RANDBLAS_SOURCE_DIR "${CMAKE_SOURCE_DIR}/../RandBLAS")
-    if(EXISTS "${RANDBLAS_SOURCE_DIR}/test/comparison.hh")
-        include_directories(${RANDBLAS_SOURCE_DIR})
-        message(STATUS "RandBLAS source tree found at: ${RANDBLAS_SOURCE_DIR}")
-    else()
-        message(WARNING "RandBLAS source tree not found - test comparison utilities unavailable")
-    endif()
+    # RandBLAS testing utilities (comparison.hh, sparse_data.hh, etc.) are
+    # installed as part of the RandBLAS library headers under RandBLAS/testing/;
+    # they're reachable through the RandLAPACK::RandLAPACK transitive include path.
 
     set(RandLAPACK_extras_test_srcs
         linops/test_ext_solver_linop_unified.cc

--- a/extras/test/linops/test_ext_solver_linop_unified.cc
+++ b/extras/test/linops/test_ext_solver_linop_unified.cc
@@ -21,7 +21,7 @@
 #include "../../linops/ext_lusolver_linop.hh"
 #include "../../misc/ext_util.hh"
 #include <RandLAPACK/testing/rl_test_utils.hh>
-#include <test/comparison.hh>
+#include <RandBLAS/testing/comparison.hh>
 
 using std::vector;
 using blas::Layout;
@@ -283,7 +283,7 @@ protected:
 
         T atol = 500 * std::numeric_limits<T>::epsilon() * dim;
         T rtol = 100 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, m, n, C_solver.data(), m,
             C_reference.data(), m, __PRETTY_FUNCTION__, __FILE__, __LINE__,
             atol, rtol
@@ -344,7 +344,7 @@ protected:
 
         T atol = 500 * std::numeric_limits<T>::epsilon() * dim;
         T rtol = 100 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, m, n, C_halfsv.data(), m,
             C_reference.data(), m, __PRETTY_FUNCTION__, __FILE__, __LINE__,
             atol, rtol
@@ -400,7 +400,7 @@ protected:
 
         T atol = 500 * std::numeric_limits<T>::epsilon() * dim;
         T rtol = 100 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, m, n, C_halfsv.data(), m,
             C_reference.data(), m, __PRETTY_FUNCTION__, __FILE__, __LINE__,
             atol, rtol

--- a/install.sh
+++ b/install.sh
@@ -356,7 +356,7 @@ fi
 echo "=========================================="
 echo "Configuring and building RandLAPACK..."
 echo "=========================================="
-cmake  -S $RANDNLA_PROJECT_DIR/lib/RandLAPACK/ -B $RANDNLA_PROJECT_DIR/build/RandLAPACK-build/ -DCMAKE_BUILD_TYPE=Release -DRequireCUDA=$RANDLAPACK_CUDA -Dlapackpp_DIR=$LAPACKPP_CMAKE_DIR -Dblaspp_DIR=$BLASPP_CMAKE_DIR -DRandom123_DIR=$RANDOM123_DIR -DCMAKE_INSTALL_PREFIX=$RANDNLA_PROJECT_DIR/install/RandLAPACK-install -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON $MACOS_OPENMP_FLAGS
+cmake  -S $RANDNLA_PROJECT_DIR/lib/RandLAPACK/ -B $RANDNLA_PROJECT_DIR/build/RandLAPACK-build/ -DCMAKE_BUILD_TYPE=Release -DRequireCUDA=$RANDLAPACK_CUDA -Dlapackpp_DIR=$LAPACKPP_CMAKE_DIR -Dblaspp_DIR=$BLASPP_CMAKE_DIR -DRandom123_DIR=$RANDOM123_DIR -DCMAKE_INSTALL_PREFIX=$RANDNLA_PROJECT_DIR/install/RandLAPACK-install -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DBUILD_TESTS=OFF -DRandLAPACK_BUILD_TESTS=ON $MACOS_OPENMP_FLAGS
 if [ $? -ne 0 ]; then
     echo "ERROR: RandLAPACK configuration failed!"
     exit 1

--- a/test/comps/test_determiter.cc
+++ b/test/comps/test_determiter.cc
@@ -1,6 +1,6 @@
 #include "RandLAPACK.hh"
 #include "rl_blaspp.hh"
-#include "../../RandBLAS/test/comparison.hh"
+#include <RandBLAS/testing/comparison.hh>
 
 #include <RandBLAS.hh>
 #include <math.h>
@@ -114,7 +114,7 @@ class TestDetermiterLockBlockPCG : public ::testing::Test {
         T tol_scale = std::sqrt((T)m);
         T atol = tol_scale * std::pow(std::numeric_limits<T>::epsilon(), 0.5);
         T rtol = tol_scale * atol;
-        test::comparison::buffs_approx_equal(X_init.data(), X_star.data(), m * s,
+        RandBLAS::testing::buffs_approx_equal(X_init.data(), X_star.data(), m * s,
             __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol
         );
         return;
@@ -164,7 +164,7 @@ class TestDetermiterLockBlockPCG : public ::testing::Test {
         T tol_scale = std::sqrt((T)m);
         T atol = tol_scale * std::pow(std::numeric_limits<T>::epsilon(), 0.5);
         T rtol = tol_scale * atol;
-        test::comparison::buffs_approx_equal(X_init.data(), X_star.data(), m * s,
+        RandBLAS::testing::buffs_approx_equal(X_init.data(), X_star.data(), m * s,
             __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol
         );
         return;

--- a/test/comps/test_preconditioners.cc
+++ b/test/comps/test_preconditioners.cc
@@ -5,7 +5,7 @@
 #include <math.h>
 #include <lapack.hh>
 
-#include "../../RandBLAS/test/comparison.hh"
+#include <RandBLAS/testing/comparison.hh>
 
 
 template <typename T>

--- a/test/comps/test_rpchol.cc
+++ b/test/comps/test_rpchol.cc
@@ -3,7 +3,7 @@
 #include "rl_blaspp.hh"
 #include "rl_gen.hh"
 #include <RandLAPACK/testing/rl_test_utils.hh>
-#include "../../RandBLAS/test/comparison.hh"
+#include <RandBLAS/testing/comparison.hh>
 
 #include <RandBLAS.hh>
 #include <math.h>
@@ -45,7 +45,7 @@ class TestRPCholesky : public ::testing::Test {
 
         vector<T> Arecovered(F);
         full_gram(n, Arecovered, blas::Op::NoTrans, k);
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             blas::Layout::ColMajor, blas::Op::NoTrans, n, n, Abuff, n, Arecovered.data(), n, __PRETTY_FUNCTION__, __FILE__, __LINE__,
             atol, rtol
         );

--- a/test/drivers/test_abrik.cc
+++ b/test/drivers/test_abrik.cc
@@ -4,7 +4,7 @@
 #include "rl_gen.hh"
 
 #include <RandBLAS.hh>
-#include "../../RandBLAS/test/test_datastructures/test_spmats/common.hh"
+#include <RandBLAS/testing/sparse_data.hh>
 #include <fstream>
 #include <gtest/gtest.h>
 
@@ -208,7 +208,7 @@ TEST_F(TestABRIK, ABRIK_sparse_csc) {
     ABRIK.num_threads_max = RandLAPACK::util::get_omp_threads();
 
     RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::gaussian);
-    test::test_datastructures::test_spmats::iid_sparsify_random_dense<double, r123::Philox4x32>(m, n, Layout::ColMajor, all_data.A_buff, 0.9, 0);
+    RandBLAS::testing::iid_sparsify_random_dense<double, r123::Philox4x32>(m, n, Layout::ColMajor, all_data.A_buff, 0.9, 0);
     RandBLAS::sparse_data::csc::dense_to_csc<double>(Layout::ColMajor, all_data.A_buff, 0.0, all_data.A);
 
     test_ABRIK_general<double>(b_sz, target_rank, custom_rank, all_data, ABRIK, state);
@@ -229,7 +229,7 @@ TEST_F(TestABRIK, ABRIK_sparse_csr) {
     ABRIK.num_threads_max = RandLAPACK::util::get_omp_threads();
 
     RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::gaussian);
-    test::test_datastructures::test_spmats::iid_sparsify_random_dense<double, r123::Philox4x32>(m, n, Layout::ColMajor, all_data.A_buff, 0.9, 0);
+    RandBLAS::testing::iid_sparsify_random_dense<double, r123::Philox4x32>(m, n, Layout::ColMajor, all_data.A_buff, 0.9, 0);
     RandBLAS::sparse_data::csr::dense_to_csr<double>(Layout::ColMajor, all_data.A_buff, 0.0, all_data.A);
 
     test_ABRIK_general<double>(b_sz, target_rank, custom_rank, all_data, ABRIK, state);
@@ -250,7 +250,7 @@ TEST_F(TestABRIK, ABRIK_sparse_coo) {
     ABRIK.num_threads_max = RandLAPACK::util::get_omp_threads();
 
     RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::gaussian);
-    test::test_datastructures::test_spmats::iid_sparsify_random_dense<double, r123::Philox4x32>(m, n, Layout::ColMajor, all_data.A_buff, 0.9, 0);
+    RandBLAS::testing::iid_sparsify_random_dense<double, r123::Philox4x32>(m, n, Layout::ColMajor, all_data.A_buff, 0.9, 0);
     RandBLAS::sparse_data::coo::dense_to_coo<double>(Layout::ColMajor, all_data.A_buff, 0.0, all_data.A);
 
     test_ABRIK_general<double>(b_sz, target_rank, custom_rank, all_data, ABRIK, state);
@@ -272,7 +272,7 @@ TEST_F(TestABRIK, ABRIK_sparse_coo_cqrrt) {
     ABRIK.num_threads_max = RandLAPACK::util::get_omp_threads();
 
     RandLAPACK::gen::mat_gen_info<double> m_info(m, n, RandLAPACK::gen::gaussian);
-    test::test_datastructures::test_spmats::iid_sparsify_random_dense<double, r123::Philox4x32>(m, n, Layout::ColMajor, all_data.A_buff, 0.9, 0);
+    RandBLAS::testing::iid_sparsify_random_dense<double, r123::Philox4x32>(m, n, Layout::ColMajor, all_data.A_buff, 0.9, 0);
     RandBLAS::sparse_data::coo::dense_to_coo<double>(Layout::ColMajor, all_data.A_buff, 0.0, all_data.A);
 
 test_ABRIK_general<double>(b_sz, target_rank, custom_rank, all_data, ABRIK, state);

--- a/test/drivers/test_krill.cc
+++ b/test/drivers/test_krill.cc
@@ -6,7 +6,7 @@
 #include <lapack.hh>
 
 #include <RandLAPACK/testing/rl_test_utils.hh>
-#include "../../RandBLAS/test/comparison.hh"
+#include <RandBLAS/testing/comparison.hh>
 
 
 using std::vector;
@@ -60,7 +60,7 @@ class TestKrillIsh: public ::testing::Test {
         T tol_scale = std::sqrt((T)m);
         T atol = tol_scale * std::pow(std::numeric_limits<T>::epsilon(), 0.5);
         T rtol = tol_scale * atol;
-        test::comparison::buffs_approx_equal(X_init.data(), X_star.data(), m * s,
+        RandBLAS::testing::buffs_approx_equal(X_init.data(), X_star.data(), m * s,
             __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol
         );
         return;
@@ -155,7 +155,7 @@ class TestKrillx: public ::testing::Test {
         T tol_scale = std::sqrt((T)m);
         T atol = tol_scale * std::pow(std::numeric_limits<T>::epsilon(), 0.5);
         T rtol = tol_scale * atol;
-        test::comparison::buffs_approx_equal(X_init.data(), X_star.data(), m * s,
+        RandBLAS::testing::buffs_approx_equal(X_init.data(), X_star.data(), m * s,
             __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, rtol
         );
         return;

--- a/test/linops/test_linop_block_views.cc
+++ b/test/linops/test_linop_block_views.cc
@@ -13,7 +13,7 @@
 #include <gtest/gtest.h>
 #include <math.h>
 #include <lapack.hh>
-#include "../../RandBLAS/test/comparison.hh"
+#include <RandBLAS/testing/comparison.hh>
 #include "../../RandLAPACK/testing/rl_test_utils.hh"
 
 using std::vector;
@@ -81,7 +81,7 @@ protected:
             }
         }
 
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, k,
             C_block.data(), row_count,
             C_expected.data(), row_count,
@@ -137,7 +137,7 @@ protected:
             }
         }
 
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, k, col_count,
             C_block.data(), k,
             C_expected.data(), k,
@@ -192,7 +192,7 @@ protected:
                    alpha, A_sub_dense.data(), ld_sub, B.data(), ldb,
                    beta, C_expected.data(), ldc);
 
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, k,
             C_block.data(), row_count,
             C_expected.data(), row_count,
@@ -345,7 +345,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, k,
             C_block.data(), row_count,
             C_expected.data(), row_count,
@@ -402,7 +402,7 @@ protected:
 
             T atol = 100 * std::numeric_limits<T>::epsilon();
             T rtol = 10 * std::numeric_limits<T>::epsilon();
-            test::comparison::matrices_approx_equal(
+            RandBLAS::testing::matrices_approx_equal(
                 Layout::ColMajor, Op::NoTrans, block_size, k,
                 C_block.data(), block_size,
                 C_expected.data(), block_size,
@@ -543,7 +543,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, k, col_count,
             C_block.data(), k,
             C_expected.data(), k,
@@ -600,7 +600,7 @@ protected:
 
             T atol = 100 * std::numeric_limits<T>::epsilon();
             T rtol = 10 * std::numeric_limits<T>::epsilon();
-            test::comparison::matrices_approx_equal(
+            RandBLAS::testing::matrices_approx_equal(
                 Layout::ColMajor, Op::NoTrans, k, block_size,
                 C_block.data(), k,
                 C_expected.data(), k,
@@ -775,7 +775,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, m, k,
             C_block.data(), m,
             C_expected.data(), m,
@@ -1100,7 +1100,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, n,
             blk_dense.data(), row_count,
             expected.data(), row_count,
@@ -1127,7 +1127,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, m, col_count,
             blk_dense.data(), m,
             expected.data(), m,
@@ -1155,7 +1155,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, col_count,
             blk_dense.data(), row_count,
             expected.data(), row_count,
@@ -1185,7 +1185,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, n,
             blk_dense.data(), row_count,
             expected.data(), row_count,
@@ -1211,7 +1211,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, m, col_count,
             blk_dense.data(), m,
             expected.data(), m,
@@ -1238,7 +1238,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, col_count,
             blk_dense.data(), row_count,
             expected.data(), row_count,
@@ -1390,7 +1390,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, k,
             C_blk.data(), row_count,
             C_expected.data(), row_count,
@@ -1443,7 +1443,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, k, col_count,
             C_blk.data(), k,
             C_expected.data(), k,
@@ -1498,7 +1498,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, k,
             C_blk.data(), row_count,
             C_expected.data(), row_count,
@@ -1544,7 +1544,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, k,
             C_blk.data(), row_count,
             C_expected.data(), row_count,
@@ -1592,7 +1592,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, k, col_count,
             C_blk.data(), k,
             C_expected.data(), k,
@@ -1644,7 +1644,7 @@ protected:
 
         T atol = 100 * std::numeric_limits<T>::epsilon();
         T rtol = 10 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, row_count, k,
             C_blk.data(), row_count,
             C_expected.data(), row_count,

--- a/test/linops/test_linop_unified.cc
+++ b/test/linops/test_linop_unified.cc
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 #include <type_traits>
 #include <optional>
-#include "../../RandBLAS/test/comparison.hh"
+#include <RandBLAS/testing/comparison.hh>
 #include "../../RandLAPACK/testing/rl_test_utils.hh"
 
 using blas::Layout;
@@ -463,7 +463,7 @@ private:
                                err_beta, E, dims.ldc);
 
         // Compare results using componentwise bounds
-        test::comparison::buffs_approx_equal(
+        RandBLAS::testing::buffs_approx_equal(
             C_op, C_reference, E, m * n,
             __PRETTY_FUNCTION__, __FILE__, __LINE__
         );

--- a/test/linops/test_linops.cc
+++ b/test/linops/test_linops.cc
@@ -4,7 +4,7 @@
 #include <gtest/gtest.h>
 #include <math.h>
 #include <lapack.hh>
-#include "../../RandBLAS/test/comparison.hh"
+#include <RandBLAS/testing/comparison.hh>
 
 
 using std::vector;
@@ -66,7 +66,7 @@ class TestSpectralPrecondLinearOperator: public ::testing::Test {
         invP_operator.prep(pcV, pceigs, mus, n);
         vector<T> G_mu_pre_actual(n*n, 0.0);
         invP_operator(blas::Layout::ColMajor, n, (T) 1.0,  G_mu.data(), n, (T)0.0, G_mu_pre_actual.data(), n);
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             Layout::ColMajor, Op::NoTrans, n, n, G_mu_pre_actual.data(), n,
             G_mu_pre_expect.data(), n, __PRETTY_FUNCTION__, 
             __FILE__, __LINE__

--- a/test/misc/test_pdkernels.cc
+++ b/test/misc/test_pdkernels.cc
@@ -4,7 +4,7 @@
 
 #include <RandBLAS.hh>
 #include <RandLAPACK/testing/rl_test_utils.hh>
-#include "../../RandBLAS/test/comparison.hh"
+#include <RandBLAS/testing/comparison.hh>
 
 #include <math.h>
 #include <gtest/gtest.h>
@@ -47,7 +47,7 @@ class TestPDK_SquaredExponential : public ::testing::Test {
             }
         }
         T atol = 3 * d * std::numeric_limits<T>::epsilon() * (1.0 + std::pow(bandwidth, -2));
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             blas::Layout::ColMajor, blas::Op::NoTrans, n, n, K_blockimpl.data(), n,
             K_entrywise.data(), n, __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, atol
         );
@@ -76,7 +76,7 @@ class TestPDK_SquaredExponential : public ::testing::Test {
             d, n, _X, squarednorms.data(), n, n, K.data(), 0, 0, bandwidth
         );
         vector<T> expected(n*n, 1.0);
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             blas::Layout::ColMajor, blas::Op::NoTrans, n, n, K.data(), n,
             expected.data(), n, __PRETTY_FUNCTION__, __FILE__, __LINE__
         );
@@ -112,7 +112,7 @@ class TestPDK_SquaredExponential : public ::testing::Test {
             }
         }
         T atol = 50 * std::numeric_limits<T>::epsilon();
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             blas::Layout::ColMajor, blas::Op::NoTrans, n, n, K.data(), n,
             expect.data(), n,  __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, atol
         );
@@ -194,7 +194,7 @@ class TestPDK_RBFKernelMatrix : public ::testing::Test {
         K(blas::Layout::ColMajor, m, alpha, eye.data(), m, 0.0, K_out_actual1.data(), m);
 
         T atol = d * std::numeric_limits<T>::epsilon() * (1.0 + std::pow(bandwidth, -2));
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             blas::Layout::ColMajor, blas::Op::NoTrans, m, m, K_out_actual1.data(), m, 
             K_out_expect.data(), m, __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, atol
         );
@@ -206,7 +206,7 @@ class TestPDK_RBFKernelMatrix : public ::testing::Test {
         vector<T> K_out_actual2(m * m, 1.0);
         K(blas::Layout::ColMajor, m, alpha, eye.data(), m, beta, K_out_actual2.data(), m);
 
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             blas::Layout::ColMajor, blas::Op::NoTrans, m, m, K_out_actual2.data(), m, 
             K_out_expect.data(), m, __PRETTY_FUNCTION__, __FILE__, __LINE__, atol, atol
         );

--- a/test/misc/test_util.cc
+++ b/test/misc/test_util.cc
@@ -3,7 +3,7 @@
 #include "rl_gen.hh"
 
 #include <RandBLAS.hh>
-#include <RandBLAS/test/comparison.hh>
+#include <RandBLAS/testing/comparison.hh>
 
 #include <math.h>
 #include <chrono>
@@ -348,7 +348,7 @@ class Test_Inplace_Square_Transpose : public ::testing::Test
         double *A2 = new double[n*n];
         blas::copy(n*n, A1, 1, A2, 1);
         RandLAPACK::util::transpose_square(A2, n);
-        test::comparison::matrices_approx_equal(
+        RandBLAS::testing::matrices_approx_equal(
             layout, blas::Op::Trans, n, n, A1, n, A2, n, 
             __PRETTY_FUNCTION__, __FILE__, __LINE__
         );


### PR DESCRIPTION
Coordinates RandLAPACK with RandBLAS PRs #158, #169, and #172. Each change stands alone; the commit history reflects that grouping.

### Submodule bump

`6abdfcf` → `8417f4b` (current `origin/main`), covering #158 (test infrastructure refactor), #160, #164, #169 (CMake improvements), #170, #171, and #172.

### Required follow-on changes from #169

**`Random123::Random123` rename.** RandBLAS #169 retired the bare `Random123` INTERFACE target in favor of the namespaced `Random123::Random123 IMPORTED GLOBAL`. The `target_link_libraries` entry in `RandLAPACK/CMakeLists.txt` is updated to match.

**`RandBLAS_DIR` layout.** RandBLAS #169 moved the installed config from `lib/cmake/RandBLASConfig.cmake` to `lib/cmake/RandBLAS/RandBLASConfig.cmake`. The fallback in `RandLAPACKConfig.cmake.in` now points at `${CMAKE_CURRENT_LIST_DIR}/../RandBLAS` instead of `${CMAKE_CURRENT_LIST_DIR}/..`.

### Test migration (forced by #158)

RandBLAS #158 promoted the test-only comparison and sparse-data utilities from `RandBLAS/test/` headers into the library proper under `RandBLAS/RandBLAS/testing/`. They install with the library; consumers reach them via the `RandLAPACK::RandLAPACK` transitive include path. Eleven files updated (10 RandLAPACK tests + 1 extras test):

| Before | After |
|---|---|
| `"../../RandBLAS/test/comparison.hh"` | `<RandBLAS/testing/comparison.hh>` |
| `"../../RandBLAS/test/test_datastructures/test_spmats/common.hh"` | `<RandBLAS/testing/sparse_data.hh>` |
| `test::comparison::` | `RandBLAS::testing::` |
| `test::test_datastructures::test_spmats::` | `RandBLAS::testing::` |

`extras/test/CMakeLists.txt` drops the now-obsolete probe that added the RandBLAS source tree to the include path to resolve a test-only header that wasn't installed. Post-#158 those headers are part of the library install and reach consumers through the package's normal include path; re-pointing the probe at the new source location would re-introduce the same anti-pattern, so it's deleted.

### Consumer-facing CMake target improvements (ported from #169)

- Build-time-only flags wrapped in `$<BUILD_INTERFACE:...>` so `-Wall -Wextra` (and `-fsanitize=address` when `SANITIZE_ADDRESS=ON`) apply in-tree but disappear from the installed export.
- `target_compile_features(RandLAPACK INTERFACE cxx_std_20)` advertises the language requirement on the exported target.
- `RandLAPACKConfig.cmake` calls `find_dependency(OpenMP COMPONENTS CXX)` directly when RandLAPACK was built with OpenMP, rather than relying on RandBLAS' Config to incidentally pull it into scope.
- `EXPORT_LINK_INTERFACE_LIBRARIES` (deprecated since CMake 2.8.12) removed from `install(EXPORT)`.

### `RandLAPACK_BUILD_TESTS` option

New `option(RandLAPACK_BUILD_TESTS "Build RandLAPACK's test suite" ON)` gates `add_subdirectory(test)` at the top level. The name is prefixed so it can coexist with RandBLAS's own `BUILD_TESTS` when RandBLAS is embedded as a subdirectory; the two options control their respective test subdirs independently.

`install.sh` is updated to pass `-DBUILD_TESTS=OFF -DRandLAPACK_BUILD_TESTS=ON` to the RandLAPACK cmake invocation: the end-user installation path doesn't run RandBLAS's tests anyway (they're covered by RandBLAS's own CI) and skipping them shaves measurable time off the install.