### PR TITLE
Quick-win issue batch: fixes #63, #109, #110, #118, #120, #143

### DIFF
--- a/RandLAPACK/comps/rl_determiter.hh
+++ b/RandLAPACK/comps/rl_determiter.hh
@@ -47,7 +47,7 @@ void pcg_saddle(
 
     //  b1 = A'b - c
     blas::copy(n, c, 1, b1, 1);
-    blas::gemv(Layout::ColMajor, Op::Trans, m, n, 1.0, A, lda, b, 1, -1.0, b1, 1);
+    blas::gemv(Layout::ColMajor, Op::Trans, m, n, (T) 1.0, A, lda, b, 1, (T) -1.0, b1, 1);
 
     // r = b1 - (A'(A x0) + delta x0)
     //		out_a1 = A x0
@@ -55,14 +55,14 @@ void pcg_saddle(
     //		out_at1 += delta x0
     //		r -= out_at1
     blas::copy(n, b1, 1, r, 1);
-    blas::gemv(Layout::ColMajor, Op::NoTrans, m, n, 1.0, A, lda, x0, 1, delta, out_a1, 1);
-    blas::gemv(Layout::ColMajor, Op::Trans, m, n, 1.0, A, lda, out_a1, 1, 0.0, out_at1, 1);
+    blas::gemv(Layout::ColMajor, Op::NoTrans, m, n, (T) 1.0, A, lda, x0, 1, delta, out_a1, 1);
+    blas::gemv(Layout::ColMajor, Op::Trans, m, n, (T) 1.0, A, lda, out_a1, 1, (T) 0.0, out_at1, 1);
     blas::axpy(n, delta, x0, 1, out_at1, 1);
-    blas::axpy(n, -1.0, out_at1, 1, r, 1);
+    blas::axpy(n, (T) -1.0, out_at1, 1, r, 1);
 
     // d = M (M' r);
-    blas::gemv(Layout::ColMajor, Op::Trans, n, k, 1.0, M, ldm, r, 1, 0.0, out_mt1, 1);
-    blas::gemv(Layout::ColMajor, Op::NoTrans, n, k, 1.0, M, ldm, out_mt1, 1, 0.0, d, 1);
+    blas::gemv(Layout::ColMajor, Op::Trans, n, k, (T) 1.0, M, ldm, r, 1, (T) 0.0, out_mt1, 1);
+    blas::gemv(Layout::ColMajor, Op::NoTrans, n, k, (T) 1.0, M, ldm, out_mt1, 1, (T) 0.0, d, 1);
 
     bool reg = delta > 0;
     blas::copy(n, x0, 1, x, 1);
@@ -78,8 +78,8 @@ void pcg_saddle(
 
         // q = A'(A d) + delta d
         //		q = out_at1
-        blas::gemv(Layout::ColMajor, Op::NoTrans, m, n, 1.0,  A, lda, d, 1, 0.0, out_a1, 1);
-        blas::gemv(Layout::ColMajor, Op::Trans, m, n, 1.0, A, lda, out_a1, 1, 0.0, out_at1, 1);
+        blas::gemv(Layout::ColMajor, Op::NoTrans, m, n, (T) 1.0,  A, lda, d, 1, (T) 0.0, out_a1, 1);
+        blas::gemv(Layout::ColMajor, Op::Trans, m, n, (T) 1.0, A, lda, out_a1, 1, (T) 0.0, out_at1, 1);
         if (reg) blas::axpy(n, delta,  d, 1, out_at1, 1);
 
         // alpha = delta1_new / (d' q)
@@ -96,10 +96,10 @@ void pcg_saddle(
             //		r = b1
             //		r -= out_at1
             //		r -= delta x
-            blas::gemv(Layout::ColMajor, Op::NoTrans, m, n, 1.0,  A, lda, x, 1, 0.0, out_a1, 1);
-            blas::gemv(Layout::ColMajor, Op::Trans, m, n, 1.0, A, lda, out_a1, 1, 0.0, out_at1, 1);
+            blas::gemv(Layout::ColMajor, Op::NoTrans, m, n, (T) 1.0,  A, lda, x, 1, (T) 0.0, out_a1, 1);
+            blas::gemv(Layout::ColMajor, Op::Trans, m, n, (T) 1.0, A, lda, out_a1, 1, (T) 0.0, out_at1, 1);
             blas::copy(n, b1, 1, r, 1);
-            blas::axpy(n, -1.0, out_at1, 1, r, 1 );
+            blas::axpy(n, (T) -1.0, out_at1, 1, r, 1 );
             if (reg) blas::axpy(n, -delta, x, 1, r, 1);
         } else {
             // r -= alpha q
@@ -110,8 +110,8 @@ void pcg_saddle(
         //		out_mt1 = M' r
         //		out_m1 = M out_mt1
         //		s = out_m1
-        blas::gemv(Layout::ColMajor, Op::Trans, n, k, 1.0, M, ldm, r, 1, 0.0, out_mt1, 1);
-        blas::gemv(Layout::ColMajor, Op::NoTrans, n, k, 1.0, M, ldm, out_mt1, 1, 0.0, out_m1, 1);
+        blas::gemv(Layout::ColMajor, Op::Trans, n, k, (T) 1.0, M, ldm, r, 1, (T) 0.0, out_mt1, 1);
+        blas::gemv(Layout::ColMajor, Op::NoTrans, n, k, (T) 1.0, M, ldm, out_mt1, 1, (T) 0.0, out_m1, 1);
 
         // scalars and update d
         delta1_old = delta1_new;
@@ -128,7 +128,7 @@ void pcg_saddle(
 
     // recover y = b - Ax
     blas::copy(m, b, 1, y, 1);
-    blas::gemv(Layout::ColMajor, Op::NoTrans, m, n, -1.0, A, lda, x, 1, 1.0, y, 1);
+    blas::gemv(Layout::ColMajor, Op::NoTrans, m, n, (T) -1.0, A, lda, x, 1, (T) 1.0, y, 1);
     delete [] allwork;
     return;
 }
@@ -409,11 +409,11 @@ void pcg(
 
     G(layout, s, 1.0, X, n, 0.0, GP, n
     ); // GP <- G X
-    blas::axpy(ns, -1.0, GP, 1, R, 1
+    blas::axpy(ns, (T) -1.0, GP, 1, R, 1
     ); // R <- R - GP
     N(layout, s, 1.0, R, n, 0.0, P, n
     ); // P <- N R
-    blas::gemm(layout, Op::Trans, Op::NoTrans, s, s, n, 1.0, R, n, P, n, 0.0, RNR, s
+    blas::gemm(layout, Op::Trans, Op::NoTrans, s, s, n, (T) 1.0, R, n, P, n, (T) 0.0, RNR, s
     ); // RNR <- R^T P = R^T N R
     if (treat_as_separable) zero_off_diagonal(RNR, s);
 
@@ -435,7 +435,7 @@ void pcg(
 
         G(layout, s, (T) 1.0, P, n, (T) 0.0, GP, n
         ); // ^ GP <- G P
-        blas::gemm(layout, Op::Trans, Op::NoTrans, s, s, n, 1.0, P, n, GP, n, 0.0, ableft, s
+        blas::gemm(layout, Op::Trans, Op::NoTrans, s, s, n, (T) 1.0, P, n, GP, n, (T) 0.0, ableft, s
         ); // ableft <- P^T G P
         if (treat_as_separable) zero_off_diagonal(ableft, s);
         int64_t subspace_incr = posm_square(s, ableft, alpha, scratch
@@ -447,9 +447,9 @@ void pcg(
             break;
         subspace_dim = subspace_dim + subspace_incr;
 
-        blas::gemm(layout, Op::NoTrans, Op::NoTrans, n, s, s, 1.0, P, n, alpha, s, 1.0, X, n
+        blas::gemm(layout, Op::NoTrans, Op::NoTrans, n, s, s, (T) 1.0, P, n, alpha, s, (T) 1.0, X, n
         ); // X <- X + P alpha
-        blas::gemm(layout, Op::NoTrans, Op::NoTrans, n, s, s, -1.0, GP, n, alpha, s, 1.0, R, n
+        blas::gemm(layout, Op::NoTrans, Op::NoTrans, n, s, s, (T) -1.0, GP, n, alpha, s, (T) 1.0, R, n
         ); // R <- R - GP alpha
 
         //
@@ -471,7 +471,7 @@ void pcg(
         //
         std::copy(RNR, RNR + ss, ableft
         ); // ableft <- RNR
-        blas::gemm(layout, Op::Trans, Op::NoTrans, s, s, n, 1.0, R, n, NR, n, 0.0, RNR, s
+        blas::gemm(layout, Op::Trans, Op::NoTrans, s, s, n, (T) 1.0, R, n, NR, n, (T) 0.0, RNR, s
         ); // RNR <- R^T NR
         if (treat_as_separable) zero_off_diagonal(RNR, s);
         std::copy(RNR, RNR + ss, alpha
@@ -482,7 +482,7 @@ void pcg(
         ); // beta <- (ableft)^-1 beta
         if (err < - ((int64_t) s))
             break;
-        blas::gemm(layout, Op::NoTrans, Op::NoTrans, n, s, s, 1.0, P, n, beta, s, 1.0, NR, n
+        blas::gemm(layout, Op::NoTrans, Op::NoTrans, n, s, s, (T) 1.0, P, n, beta, s, (T) 1.0, NR, n
         ); // NR <- P beta
         std::copy(NR, NR + ns, P
         ); // P <- NR

--- a/RandLAPACK/comps/rl_orth.hh
+++ b/RandLAPACK/comps/rl_orth.hh
@@ -75,7 +75,7 @@ int CholQRQ<T>::call(
     T* A_gram  = new T[k * k]();
 
     // Find normal equation Q'Q - Just the upper triangular portion
-    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, A, m, 0.0, A_gram, k);
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, (T) 1.0, A, m, (T) 0.0, A_gram, k);
 
     // Positive definite cholesky factorization
     if (lapack::potrf(Uplo::Upper, k, A_gram, k)) {
@@ -92,7 +92,7 @@ int CholQRQ<T>::call(
         }
     }
 
-    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, 1.0, A_gram, k, A, m);
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, (T) 1.0, A_gram, k, A, m);
     delete[] A_gram;
     return 0;
 }
@@ -216,10 +216,11 @@ int PLUL<T>::call(
 ){
     int64_t* ipiv  = new int64_t[n]();
 
-    if(lapack::getrf(m, n, A, m, ipiv)) {
-        delete[] ipiv;
-        return 1; // failure condition
-    }
+    // A positive exit code from GETRF means the U-factor is singular; the
+    // factorization itself is still valid, and this routine discards U
+    // anyway, so it is not a failure here. LAPACK++ throws on
+    // its own for invalid arguments (info < 0).
+    lapack::getrf(m, n, A, m, ipiv);
 
     util::get_L(m, n, A, 1);
     lapack::laswp(n, A, m, 1, n, ipiv, 1);

--- a/RandLAPACK/comps/rl_qb.hh
+++ b/RandLAPACK/comps/rl_qb.hh
@@ -209,13 +209,13 @@ int QB<T, RNG>::call(
         // No need to reorthogonalize on the 1st pass
         if(curr_sz != 0) {
             // Q_i = orth(Q_i - Q(Q'Q_i))
-            blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, curr_sz, b_sz, m, 1.0, Q, m, Q_i, m, 0.0, QtQi, next_sz);
-            blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, b_sz, curr_sz, -1.0, Q, m, QtQi, next_sz, 1.0, Q_i, m);
+            blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, curr_sz, b_sz, m, (T) 1.0, Q, m, Q_i, m, (T) 0.0, QtQi, next_sz);
+            blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, b_sz, curr_sz, (T) -1.0, Q, m, QtQi, next_sz, (T) 1.0, Q_i, m);
             this->orth.call(m, b_sz, Q_i);
         }
 
         //B_i' = A' * Q_i'
-        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, b_sz, m, 1.0, A_cpy, m, Q_i, m, 0.0, BT_i, n);
+        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, b_sz, m, (T) 1.0, A_cpy, m, Q_i, m, (T) 0.0, BT_i, n);
 
         // Updating B norm estimation
         T norm_B_i = lapack::lange(Norm::Fro, n, b_sz, BT_i, n);
@@ -257,7 +257,7 @@ int QB<T, RNG>::call(
 
         // This step is only necessary for the next iteration
         // A = A - Q_i * B_i
-        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::Trans, m, n, b_sz, -1.0, Q_i, m, BT_i, n, 1.0, A_cpy, m);
+        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::Trans, m, n, b_sz, (T) -1.0, Q_i, m, BT_i, n, (T) 1.0, A_cpy, m);
     }
 
     free(A_cpy);

--- a/RandLAPACK/comps/rl_rf.hh
+++ b/RandLAPACK/comps/rl_rf.hh
@@ -120,7 +120,7 @@ int RF<T, RNG>::call(
     }
 
     // Q = orth(A * Omega)
-    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, n, 1.0, A, m, Omega, n, 0.0, Q, m);
+    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, n, (T) 1.0, A, m, Omega, n, (T) 0.0, Q, m);
 
     if(this->cond_check)
         // Writes into this->cond_nums

--- a/RandLAPACK/comps/rl_rs.hh
+++ b/RandLAPACK/comps/rl_rs.hh
@@ -139,7 +139,7 @@ int RS<T, RNG>::call(
         state = RandBLAS::fill_dense(D, Omega_1, state);
 
         // multiply A' by Omega results in n by k omega
-        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, k, m, 1.0, A, m, Omega_1, m, 0.0, Omega, n);
+        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, k, m, (T) 1.0, A, m, Omega_1, m, (T) 0.0, Omega, n);
 
         ++ p_done;
         if ((p_done % q == 0) && (this->Stab_Obj.call(n, k, Omega))) {
@@ -150,7 +150,7 @@ int RS<T, RNG>::call(
 
     while (p - p_done > 0) {
         // Omega = A * Omega
-        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, n, 1.0, A, m, Omega, n, 0.0, Omega_1, m);
+        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, n, (T) 1.0, A, m, Omega, n, (T) 0.0, Omega_1, m);
         ++ p_done;
 
         if(this->cond_check)
@@ -162,7 +162,7 @@ int RS<T, RNG>::call(
         }
 
         // Omega = A' * Omega
-        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, k, m, 1.0, A, m, Omega_1, m, 0.0, Omega, n);
+        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, n, k, m, (T) 1.0, A, m, Omega_1, m, (T) 0.0, Omega, n);
         ++ p_done;
 
         if (this->cond_check)

--- a/RandLAPACK/drivers/rl_abrik.hh
+++ b/RandLAPACK/drivers/rl_abrik.hh
@@ -383,14 +383,14 @@ class ABRIK {
 
                     if (iter != 1) {
                         // R_i' = Y_i' * Y_od
-                        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, iter_ev * k, n, 1.0, Y_i, n, Y_od, n, 0.0, R_i, n);            
+                        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, iter_ev * k, n, (T) 1.0, Y_i, n, Y_od, n, (T) 0.0, R_i, n);            
                         
                         // Y_i = Y_i - Y_od * R_i
-                        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::Trans, n, k, iter_ev * k, -1.0, Y_od, n, R_i, n, 1.0, Y_i, n);
+                        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::Trans, n, k, iter_ev * k, (T) -1.0, Y_od, n, R_i, n, (T) 1.0, Y_i, n);
 
                         // Reorthogonalization
-                        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, iter_ev * k, n, 1.0, Y_i, n, Y_od, n, 0.0, Y_orth_buf, k);
-                        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::Trans, n, k, iter_ev * k, -1.0, Y_od, n, Y_orth_buf, k, 1.0, Y_i, n);
+                        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, iter_ev * k, n, (T) 1.0, Y_i, n, Y_od, n, (T) 0.0, Y_orth_buf, k);
+                        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::Trans, n, k, iter_ev * k, (T) -1.0, Y_od, n, Y_orth_buf, k, (T) 1.0, Y_i, n);
                     }
 
                     if(this -> timing) {
@@ -512,14 +512,14 @@ class ABRIK {
                     }
 
                     // S_i = X_ev' * X_i 
-                    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, iter_od * k, k, m, 1.0, X_ev, m, X_i, m, 0.0, S_i, n + k);
+                    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, iter_od * k, k, m, (T) 1.0, X_ev, m, X_i, m, (T) 0.0, S_i, n + k);
                     
                     //X_i = X_i - X_ev * S_i;
-                    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, iter_od * k, -1.0, X_ev, m, S_i, n + k, 1.0, X_i, m);
+                    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, iter_od * k, (T) -1.0, X_ev, m, S_i, n + k, (T) 1.0, X_i, m);
 
                     // Reorthogonalization
-                    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, iter_od * k, k, m, 1.0, X_ev, m, X_i, m, 0.0, X_orth_buf, n + k);
-                    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, iter_od * k, -1.0, X_ev, m, X_orth_buf, n + k, 1.0, X_i, m);
+                    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, iter_od * k, k, m, (T) 1.0, X_ev, m, X_i, m, (T) 0.0, X_orth_buf, n + k);
+                    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, k, iter_od * k, (T) -1.0, X_ev, m, X_orth_buf, n + k, (T) 1.0, X_i, m);
 
                     if(this -> timing) {
                         reorth_t_stop  = steady_clock::now();
@@ -587,7 +587,7 @@ class ABRIK {
                     // REMOVE ME
                     std::vector<double> buffer2 (iter_ev * k * iter_ev * k, 0.0);
                     RandLAPACK::util::eye(iter_ev * k, iter_ev * k, buffer2.data());
-                    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, iter_ev * k, iter_ev * k, m, 1.0, X_ev, m, X_ev, m, -1.0, buffer2.data(), iter_ev * k);
+                    blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, iter_ev * k, iter_ev * k, m, (T) 1.0, X_ev, m, X_ev, m, (T) -1.0, buffer2.data(), iter_ev * k);
                     std::cout << "Orthonormality error in the basis for the left Krylov subspace at iteration " << iter << ": " << std::scientific << lapack::lange(Norm::Fro, iter_ev * k, iter_ev * k, buffer2.data(), iter_ev * k) / sqrt(iter_ev * k) << "\n\n";
 
                     // Early termination
@@ -696,9 +696,9 @@ class ABRIK {
             }
 
             // U = X_ev * U_hat
-            blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, end_cols, end_rows, 1.0, X_ev, m, U_hat, end_rows, 0.0, U, m);
+            blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, end_cols, end_rows, (T) 1.0, X_ev, m, U_hat, end_rows, (T) 0.0, U, m);
             // V = Y_od * V_hat
-            blas::gemm(Layout::ColMajor, Op::NoTrans, Op::Trans, n, end_cols, end_cols, 1.0, Y_od, n, VT_hat, end_cols, 0.0, V, n);
+            blas::gemm(Layout::ColMajor, Op::NoTrans, Op::Trans, n, end_cols, end_cols, (T) 1.0, Y_od, n, VT_hat, end_cols, (T) 0.0, V, n);
 
             this->singular_triplets_found = end_cols;
 

--- a/RandLAPACK/drivers/rl_bqrrp.hh
+++ b/RandLAPACK/drivers/rl_bqrrp.hh
@@ -261,9 +261,8 @@ int BQRRP<T, RNG>::call(
 
     // J_buffer serves as a buffer for the pivots found at every iteration, of size n.
     // At every iteration, it would only hold "cols" entries.
-    // Cannot really fully switch this to pointers bc we do not want data to be modified in "col_swap."
-    std::vector<int64_t> J_buf (n, 0);
-    int64_t* J_buffer = J_buf.data();
+    // col_swap uses it as scratch internally but always restores it on exit.
+    int64_t* J_buffer = new int64_t[n]();
     // Special pivoting buffer for LU factorization, capturing the swaps on A_sk'.
     // Needs to be converted in a proper format of length rows(A_sk')
     int64_t* J_buffer_lu = new int64_t[std::min(d, n)]();
@@ -352,7 +351,7 @@ int BQRRP<T, RNG>::call(
                 J_buffer[i] = tmp;
             }
             // Apply pivots to A_sk
-            util::col_swap(sampling_dimension, cols, cols, A_sk, d, J_buf);
+            util::col_swap(sampling_dimension, cols, cols, A_sk, d, J_buffer);
             // Perform an unpivoted QR on A_sk
             lapack::geqrf(sampling_dimension, cols, A_sk, d, Work2);
         }
@@ -367,7 +366,7 @@ int BQRRP<T, RNG>::call(
         // Remember that the R-factor is stored the upper-triangular portion of A.
         // Pivoting the trailing R and the ``current'' A.      
         // The copy of A operation is done on a separete stream. If it was not, it would have been done here.  
-        util::col_swap(m, cols, cols, &A[lda * curr_sz], lda, J_buf);
+        util::col_swap(m, cols, cols, &A[lda * curr_sz], lda, J_buffer);
 
         // Checking for the zero matrix post-pivoting is the best idea, 
         // as we would only need to check one column (pivoting moves the column with the largest norm upfront)
@@ -386,10 +385,11 @@ int BQRRP<T, RNG>::call(
             if(iter == 0) {
                 blas::copy(cols, J_buffer, 1, J, 1);
             } else {
-                RandLAPACK::util::col_swap<T>(cols, cols, &J[curr_sz], J_buf);
+                RandLAPACK::util::col_swap(cols, cols, &J[curr_sz], J_buffer);
             }
 
             delete[] J_buffer_lu;
+            delete[] J_buffer;
             delete[] A_sk_const;
             delete[] A_sk_trans;
             delete[] R_tall_qr;
@@ -402,7 +402,7 @@ int BQRRP<T, RNG>::call(
         if(iter == 0) {
             blas::copy(cols, J_buffer, 1, J, 1);
         } else {
-            RandLAPACK::util::col_swap<T>(cols, cols, &J[curr_sz], J_buf);
+            RandLAPACK::util::col_swap(cols, cols, &J[curr_sz], J_buffer);
         }
 
         // Defining the new "working subportion" of matrix A.
@@ -607,6 +607,7 @@ int BQRRP<T, RNG>::call(
                 std::cout << "/-------------BQRRP TIMING RESULTS END-------------/\n\n";
             }
             delete[] J_buffer_lu;
+            delete[] J_buffer;
             delete[] A_sk_const;
             delete[] A_sk_trans;
             delete[] R_tall_qr;
@@ -658,6 +659,7 @@ int BQRRP<T, RNG>::call(
         rows -= b_sz;
         cols -= b_sz;
     }
+    delete[] J_buffer;
     #endif
     return 0;
 }

--- a/RandLAPACK/drivers/rl_bqrrp.hh
+++ b/RandLAPACK/drivers/rl_bqrrp.hh
@@ -310,7 +310,7 @@ int BQRRP<T, RNG>::call(
     T* S = new T[d * m]();
     RandBLAS::DenseDist D(d, m);
     state = RandBLAS::fill_dense(D, S, state);
-    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, d, n, m, 1.0, S, d, A, m, 0.0, A_sk, d);
+    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, d, n, m, (T) 1.0, S, d, A, m, (T) 0.0, A_sk, d);
     delete[] S;
 
     if(this -> timing) {

--- a/RandLAPACK/drivers/rl_bqrrp_gpu.hh
+++ b/RandLAPACK/drivers/rl_bqrrp_gpu.hh
@@ -717,21 +717,21 @@ int BQRRP_GPU<T, RNG>::call(
         if (block_rank != b_sz_const) {
             if (iter == 0) {
                 // Compute optimal workspace size
-                cusolverDnDormqr_bufferSize(cusolverH, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, block_rank, cols - b_sz, block_rank, A_work, lda, &tau[iter * b_sz], Work1, lda, &lwork_ormqr);
+                RandLAPACK::cuda_kernels::cusolver_ormqr_buffer_size(cusolverH, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, block_rank, cols - b_sz, block_rank, A_work, lda, &tau[iter * b_sz], Work1, lda, &lwork_ormqr);
                 // Allocate workspace
-                cudaMalloc(reinterpret_cast<void **>(&d_work_ormqr), sizeof(double) * lwork_ormqr);
+                cudaMalloc(reinterpret_cast<void **>(&d_work_ormqr), sizeof(T) * lwork_ormqr);
             }
-            cusolverDnDormqr(cusolverH, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, block_rank, cols - b_sz, block_rank, A_work, lda, &tau[iter * b_sz], Work1, lda, d_work_ormqr, lwork_ormqr, d_info_cusolver);
+            RandLAPACK::cuda_kernels::cusolver_ormqr(cusolverH, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, block_rank, cols - b_sz, block_rank, A_work, lda, &tau[iter * b_sz], Work1, lda, d_work_ormqr, lwork_ormqr, d_info_cusolver);
             // Synchronization required after using cusolver
             cudaStreamSynchronize(strm);
         } else {
             if (iter == 0) {
                 // Compute optimal workspace size
-                cusolverDnDormqr_bufferSize(cusolverH, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, rows, cols - b_sz, block_rank, A_work, lda, &tau[iter * b_sz], Work1, lda, &lwork_ormqr);
+                RandLAPACK::cuda_kernels::cusolver_ormqr_buffer_size(cusolverH, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, rows, cols - b_sz, block_rank, A_work, lda, &tau[iter * b_sz], Work1, lda, &lwork_ormqr);
                 // Allocate workspace
-                cudaMalloc(reinterpret_cast<void **>(&d_work_ormqr), sizeof(double) * lwork_ormqr);
+                cudaMalloc(reinterpret_cast<void **>(&d_work_ormqr), sizeof(T) * lwork_ormqr);
             }
-            cusolverDnDormqr(cusolverH, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, rows, cols - b_sz, block_rank, A_work, lda, &tau[iter * b_sz], Work1, lda, d_work_ormqr, lwork_ormqr, d_info_cusolver);
+            RandLAPACK::cuda_kernels::cusolver_ormqr(cusolverH, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, rows, cols - b_sz, block_rank, A_work, lda, &tau[iter * b_sz], Work1, lda, d_work_ormqr, lwork_ormqr, d_info_cusolver);
             // Synchronization required after using cusolver
             cudaStreamSynchronize(strm);
         }

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -205,7 +205,7 @@ int CQRRPT<T, RNG>::call(
     T* A_hat = new T[d * n]();
     T* tau   = new T[n]();
     // Buffer for column pivoting.
-    std::vector<int64_t> J_buf(n, 0);
+    int64_t* J_buf = new int64_t[n]();
 
     if(this -> timing)
         saso_t_start = steady_clock::now();
@@ -254,6 +254,9 @@ int CQRRPT<T, RNG>::call(
 
     // Check if the input is all zeros
     if (!A_hat[0]) {
+        delete[] A_hat;
+        delete[] tau;
+        delete[] J_buf;
         return 0;
     }
 
@@ -281,7 +284,7 @@ int CQRRPT<T, RNG>::call(
         a_mod_piv_t_start = steady_clock::now();
 
     // Swap k columns of A with pivots from J
-    blas::copy(n, J, 1, J_buf.data(), 1);
+    blas::copy(n, J, 1, J_buf, 1);
     util::col_swap(m, n, k, A, lda, J_buf);
 
     if(this -> timing) {
@@ -293,6 +296,7 @@ int CQRRPT<T, RNG>::call(
     if (!RandLAPACK::util::diag_is_nonzero(k, R_sp, ldr)) {
         delete[] A_hat;
         delete[] tau;
+        delete[] J_buf;
         return 1;
     }
     blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, (T) 1.0, R_sp, ldr, A, lda);
@@ -381,6 +385,7 @@ int CQRRPT<T, RNG>::call(
 
     delete[] A_hat;
     delete[] tau;
+    delete[] J_buf;
 
     return 0;
 }

--- a/RandLAPACK/drivers/rl_cqrrpt.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt.hh
@@ -295,7 +295,7 @@ int CQRRPT<T, RNG>::call(
         delete[] tau;
         return 1;
     }
-    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, 1.0, R_sp, ldr, A, lda);
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, (T) 1.0, R_sp, ldr, A, lda);
 
     if(this -> timing) {
         a_mod_trsm_t_stop = steady_clock::now();
@@ -303,7 +303,7 @@ int CQRRPT<T, RNG>::call(
     }
 
     // Do Cholesky QR
-    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, A, lda, 0.0, R_sp, ldr);
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, (T) 1.0, A, lda, (T) 0.0, R_sp, ldr);
     if(lapack::potrf(Uplo::Upper, k, R_sp, ldr)) {
         // Perform aposteriori rank estimation of CholQR failed?
 
@@ -331,14 +331,14 @@ int CQRRPT<T, RNG>::call(
     this->rank = new_rank;
 
     // Obtain the output Q-factor
-    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, new_rank, 1.0, R_sp, ldr, A, lda);
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, new_rank, (T) 1.0, R_sp, ldr, A, lda);
 
     if(this -> timing)
         cholqr_t_stop = steady_clock::now();
 
     if (!this->orthogonalization) {
         // Get the final R-factor -- undoing the preconditioning
-        blas::trmm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, new_rank, n, 1.0, A_hat, d, R_sp, ldr); 
+        blas::trmm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, new_rank, n, (T) 1.0, A_hat, d, R_sp, ldr); 
     } 
     else if (new_rank != n) {
         // Complete the orthonormal set
@@ -351,9 +351,9 @@ int CQRRPT<T, RNG>::call(
         // First compute QQ^T * G and store temporarily
         T* temp = new T[m * cols_to_fill]();
         // temp = Q^T * G
-        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, new_rank, cols_to_fill, m, 1.0, A, lda, &A[new_rank * lda], lda, 0.0, temp, new_rank);
+        blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, new_rank, cols_to_fill, m, (T) 1.0, A, lda, &A[new_rank * lda], lda, (T) 0.0, temp, new_rank);
         // G := G - Q * temp (i.e., G = G - QQ^T * G)
-        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, cols_to_fill, new_rank, -1.0, A, lda, temp, new_rank, 1.0, &A[new_rank * lda], lda);
+        blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, cols_to_fill, new_rank, (T) -1.0, A, lda, temp, new_rank, (T) 1.0, &A[new_rank * lda], lda);
         delete[] temp;
         
         // Orthogonalize G using QRF + ORGQR

--- a/RandLAPACK/drivers/rl_cqrrpt_gpu.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt_gpu.hh
@@ -300,7 +300,7 @@ int CQRRPT_GPU<T, RNG>::call(
     //RandBLAS::util::print_colmaj(m, n, A, name);
 
     // A_pre * R_sp = AP
-    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, 1.0, R_sp_device, k, A_device, lda, blas_queue);
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, (T) 1.0, R_sp_device, k, A_device, lda, blas_queue);
 
     if(this -> timing) {
         a_mod_trsm_t_stop = steady_clock::now();
@@ -308,7 +308,7 @@ int CQRRPT_GPU<T, RNG>::call(
     }
 
     // Do Cholesky QR
-    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, 1.0, A_device, lda, 0.0, R_sp_device, k, blas_queue);
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, k, m, (T) 1.0, A_device, lda, (T) 0.0, R_sp_device, k, blas_queue);
     lapack::potrf(Uplo::Upper, k, R_sp_device, k, d_info, lapack_queue);
     blas_queue.sync();
 
@@ -344,13 +344,13 @@ int CQRRPT_GPU<T, RNG>::call(
         }
     }
 
-    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, new_rank, 1.0, R_sp_device, k, A_device, lda, blas_queue);
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, new_rank, (T) 1.0, R_sp_device, k, A_device, lda, blas_queue);
 
     if(this -> timing)
         cholqr_t_stop = steady_clock::now();
 
     // Get the final R-factor.
-    blas::trmm(Layout::ColMajor, Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, new_rank, n, 1.0, R_sp_device, k, R_device, ldr, blas_queue);
+    blas::trmm(Layout::ColMajor, Side::Left, Uplo::Upper, Op::NoTrans, Diag::NonUnit, new_rank, n, (T) 1.0, R_sp_device, k, R_device, ldr, blas_queue);
 
     // Set the rank parameter to the value comuted a posteriori.
     this->rank = k;

--- a/RandLAPACK/drivers/rl_cqrrpt_gpu.hh
+++ b/RandLAPACK/drivers/rl_cqrrpt_gpu.hh
@@ -193,7 +193,7 @@ int CQRRPT_GPU<T, RNG>::call(
     T* A_hat = new T[d * n]();
     T* tau   = new T[n]();
     // Buffer for column pivoting.
-    std::vector<int64_t> J_buf(n, 0);
+    int64_t* J_buf = new int64_t[n]();
 
     if(this -> timing)
         saso_t_start = steady_clock::now();
@@ -256,7 +256,7 @@ int CQRRPT_GPU<T, RNG>::call(
         a_mod_piv_t_start = steady_clock::now();
 
     // Swap k columns of A with pivots from J
-    blas::copy(n, J, 1, J_buf.data(), 1);
+    blas::copy(n, J, 1, J_buf, 1);
     util::col_swap(m, n, k, A, lda, J_buf);
 
     if(this -> timing) {
@@ -378,6 +378,7 @@ int CQRRPT_GPU<T, RNG>::call(
     cudaFree(R_device);
     cudaFree(R_sp_device);
     delete[] A_hat;
+    delete[] J_buf;
     delete[] R_sp;
     delete[] tau;    
     delete[] R_sp_diag;

--- a/RandLAPACK/drivers/rl_cqrrt.hh
+++ b/RandLAPACK/drivers/rl_cqrrt.hh
@@ -205,7 +205,7 @@ int CQRRT<T, RNG>::call(
         delete[] tau;
         return 1;
     }
-    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, n, 1.0, R_sk, ldr, A, lda);
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, n, (T) 1.0, R_sk, ldr, A, lda);
 
     if(this -> timing) {
         precond_t_stop = steady_clock::now();
@@ -213,7 +213,7 @@ int CQRRT<T, RNG>::call(
     }
 
     // Gram matrix: G = A^T * A (SYRK, upper triangle only)
-    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, n, m, 1.0, A, lda, 0.0, R_sk, ldr);
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, n, m, (T) 1.0, A, lda, (T) 0.0, R_sk, ldr);
 
     if(this -> timing) {
         gram_t_stop = steady_clock::now();
@@ -235,7 +235,7 @@ int CQRRT<T, RNG>::call(
         if(this -> timing)
             q_t_start = steady_clock::now();
 
-        blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, n, 1.0, R_sk, ldr, A, lda);
+        blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, n, (T) 1.0, R_sk, ldr, A, lda);
 
         if(this -> timing)
             q_t_stop = steady_clock::now();
@@ -247,7 +247,7 @@ int CQRRT<T, RNG>::call(
     if (!this->orthogonalization) {
         // Get the final R-factor - undoing the preconditioning
         // R := R_chol * R_sk (returned by QR on sketch)
-        blas::trmm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, n, n, 1.0, A_hat, d, R_sk, ldr);
+        blas::trmm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, n, n, (T) 1.0, A_hat, d, R_sk, ldr);
     }
 
     if(this -> timing) {

--- a/RandLAPACK/drivers/rl_cqrrt_linops.hh
+++ b/RandLAPACK/drivers/rl_cqrrt_linops.hh
@@ -236,7 +236,7 @@ class CQRRT_linops {
                 delete[] Eye;
                 return 1;
             }
-            blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, n, n, 1.0, A_hat, d, Eye, n);
+            blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, n, n, (T) 1.0, A_hat, d, Eye, n);
             if (n > 1) {
                 // Clear the below-diagonal
                 lapack::laset(MatrixType::Lower, n-1, n-1, (T)0.0, (T)0.0, &Eye[1], n);
@@ -394,7 +394,7 @@ class CQRRT_linops {
             // R := R_chol * R_sk, where R_sk is the upper triangle of A_hat
             // trmm with Uplo::Upper only reads upper triangle of A_hat (can use ld=d directly)
             // and expects R to be upper triangular on input
-            blas::trmm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, n, n, 1.0, A_hat, d, R, ldr);
+            blas::trmm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, n, n, (T) 1.0, A_hat, d, R, ldr);
 
             if(this -> timing)
                 finalize_t_stop = steady_clock::now();

--- a/RandLAPACK/drivers/rl_hqrrp.hh
+++ b/RandLAPACK/drivers/rl_hqrrp.hh
@@ -539,14 +539,14 @@ static int64_t CHOLQR_mod_WY(
         num_stages = std::min( m_A, n_A );
 
     // Find R = A^TA.
-    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, n_A, m_A, 1.0, buff_A, ldim_A, 0.0, buff_R, ldim_R);
+    blas::syrk(Layout::ColMajor, Uplo::Upper, Op::Trans, n_A, m_A, (T) 1.0, buff_A, ldim_A, (T) 0.0, buff_R, ldim_R);
 
     // Perform Cholesky factorization on A.
     if (lapack::potrf(Uplo::Upper, n_A, buff_R, ldim_R))
         return 1;
     // Find Q = A * inv(R)
 
-    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m_A, n_A, 1.0, buff_R, ldim_R, buff_A, ldim_A);
+    blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m_A, n_A, (T) 1.0, buff_R, ldim_R, buff_A, ldim_A);
 
     // Perform Householder reconstruction
     lapack::orhr_col(m_A, n_A, n_A, buff_A, ldim_A, buff_T, ldim_T, buff_D);

--- a/RandLAPACK/drivers/rl_revd2.hh
+++ b/RandLAPACK/drivers/rl_revd2.hh
@@ -61,7 +61,7 @@ T power_error_est(
 
         // Compute w = (A * g / ||g|| - V * diag(eigvals) * V' * g / ||g||)
         // Result is stored in the 4th column of vector_buf
-        blas::axpy(m, -1.0, &vector_buf[2 * m], 1, &vector_buf[3 * m], 1);
+        blas::axpy(m, (T) -1.0, &vector_buf[2 * m], 1, &vector_buf[3 * m], 1);
         // Compute (g / ||g||)' * w - this is our measure for the error
         err = blas::dot(m, vector_buf, 1, &vector_buf[3 * m], 1);	
         // v_0 <- v
@@ -187,11 +187,11 @@ class REVD2 {
                 // We further need R = chol(Omega' Y)
                 // Solve this as R = chol(Omega' Y + v Omega'Omega)
                 // Compute v Omega' Omega; syrk only computes the lower triangular part. Need full.
-                blas::syrk(Layout::ColMajor, Uplo::Lower, Op::Trans, k, m, nu, Omega_dat, m, 0.0, R_dat, k);
+                blas::syrk(Layout::ColMajor, Uplo::Lower, Op::Trans, k, m, nu, Omega_dat, m, (T) 0.0, R_dat, k);
                 for(int i = 1; i < k; ++i)
                     blas::copy(k - i, &R_dat[i + ((i-1) * k)], 1, &R_dat[(i - 1) + (i * k)], k);
                 // Compute Omega' Y + v Omega' Omega
-                blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, m, 1.0, Omega_dat, m, Y_dat, m, 1.0, R_dat, k);
+                blas::gemm(Layout::ColMajor, Op::Trans, Op::NoTrans, k, k, m, (T) 1.0, Omega_dat, m, Y_dat, m, (T) 1.0, R_dat, k);
 
                 // Compute R = chol(Omega' Y + v Omega' Omega)
                 // Looks like if POTRF gets passed a non-triangular matrix, it will also output a non-triangular one
@@ -200,7 +200,7 @@ class REVD2 {
                 RandLAPACK::util::get_U(k, k, R_dat, k);
 
                 // B = Y(R')^-1 - need to transpose R
-                blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, 1.0, R_dat, k, Y_dat, m);
+                blas::trsm(Layout::ColMajor, Side::Right, Uplo::Upper, Op::NoTrans, Diag::NonUnit, m, k, (T) 1.0, R_dat, k, Y_dat, m);
 
                 //[V, S, ~] = SVD(B)
                 // Although we don't need the right singular vectors, we need to give space for those.

--- a/RandLAPACK/drivers/rl_rsvd.hh
+++ b/RandLAPACK/drivers/rl_rsvd.hh
@@ -145,7 +145,7 @@ int RSVD<T, RNG>::call(
     // SVD of B
     lapack::gesdd(Job::SomeVec, n, k, BT, n, S, V, n, UT_buf, k);
     // Adjusting U
-    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::Trans, m, k, k, 1.0, Q, m, UT_buf, k, 0.0, U, m);
+    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::Trans, m, k, k, (T) 1.0, Q, m, UT_buf, k, (T) 0.0, U, m);
 
     free(Q);
     free(BT);

--- a/RandLAPACK/gpu_functions/rl_cuda_kernels.cuh
+++ b/RandLAPACK/gpu_functions/rl_cuda_kernels.cuh
@@ -2,12 +2,34 @@
 #include "rl_cuda_macros.hh"
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <cusolverDn.h>
 #include <cooperative_groups.h>
+#include <type_traits>
 
 namespace RandLAPACK::cuda_kernels {
 
 // This conditional allows us to make sure that the cuda kernels are only compiled with nvcc.
 #ifdef USE_CUDA
+
+// cuSOLVER's ormqr interface is typed by precision; these templates infer
+// the element type from the arguments and dispatch to the S or D symbol at
+// compile time (if constexpr), so the indirection has no runtime cost.
+template <typename T>
+inline cusolverStatus_t cusolver_ormqr_buffer_size(cusolverDnHandle_t handle, cublasSideMode_t side, cublasOperation_t trans, int m, int n, int k, const T* A, int lda, const T* tau, const T* C, int ldc, int* lwork) {
+    static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>, "cusolver_ormqr_buffer_size supports float and double only");
+    if constexpr (std::is_same_v<T, double>)
+        return cusolverDnDormqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork);
+    else
+        return cusolverDnSormqr_bufferSize(handle, side, trans, m, n, k, A, lda, tau, C, ldc, lwork);
+}
+template <typename T>
+inline cusolverStatus_t cusolver_ormqr(cusolverDnHandle_t handle, cublasSideMode_t side, cublasOperation_t trans, int m, int n, int k, const T* A, int lda, const T* tau, T* C, int ldc, T* work, int lwork, int* dev_info) {
+    static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>, "cusolver_ormqr supports float and double only");
+    if constexpr (std::is_same_v<T, double>)
+        return cusolverDnDormqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, dev_info);
+    else
+        return cusolverDnSormqr(handle, side, trans, m, n, k, A, lda, tau, C, ldc, work, lwork, dev_info);
+}
 
 /** Given the dimensions of a matrix decompose the work for CUDA.
  * @param[in] m number of rows

--- a/RandLAPACK/misc/rl_util.hh
+++ b/RandLAPACK/misc/rl_util.hh
@@ -141,8 +141,13 @@ bool diag_is_nonzero(int64_t n, const T* R, int64_t ldr) {
     return true;
 }
 
-/// Positions columns of A in accordance with idx vector of length k.
-/// idx array modified ONLY within the scope of this function.
+/// Positions columns of A in accordance with the 1-based permutation idx
+/// (GEQP3 style, full length n): on exit, column i of A holds what was
+/// column idx[i] - 1. The first k columns are the caller's contract;
+/// k <= n is enforced. Delegates to LAPACK's LAPMT (forward pass), which
+/// uses in-place cycle-following: no per-step search, no copy of the
+/// pivot vector. LAPMT uses idx as sign-marking scratch internally and
+/// restores it on exit.
 template <typename T>
 void col_swap(
     int64_t m,
@@ -150,46 +155,46 @@ void col_swap(
     int64_t k,
     T* A,
     int64_t lda,
-    std::vector<int64_t> idx
+    int64_t* idx
 ) {
-    if(k > n) 
+    if(k > n)
         throw std::runtime_error("Invalid rank parameter.");
 
-    int64_t i, j; //, l;
-    for (i = 0, j = 0; i < k; ++i) {
-        j = idx[i] - 1;
-        blas::swap(m, &A[i * lda], 1, &A[j * lda], 1);
-
-        // swap idx array elements
-        // Find idx element with value i and assign it to j
-        auto it = std::find(idx.begin() + i, idx.begin() + k, i + 1);
-        idx[it - (idx.begin())] = j + 1;
-    }
+    lapack::lapmt(true, m, n, A, lda, idx);
 }
 
-/// A version of the above function to be used on a vector of integers
-template <typename T>
-void col_swap(
+/// A version of the above function to be used on a vector of integers.
+/// LAPMT itself only handles real matrices, so this overload implements
+/// the same forward cycle-following directly; idx serves as sign-marking
+/// scratch internally and is restored on exit. Unlike the matrix overload,
+/// idx here is a 1-based permutation of 1..k (not 1..n), and entries of A
+/// beyond the first k are left untouched; the GPU counterpart
+/// (vec_ell_swap_gpu) and its subvector use in the tests rely on exactly
+/// this prefix-only contract.
+inline void col_swap(
     int64_t n,
     int64_t k,
     int64_t* A,
-    std::vector<int64_t> idx
+    int64_t* idx
 ) {
-    if(k > n) 
+    if(k > n)
         throw std::runtime_error("Incorrect rank parameter.");
 
-    int64_t* idx_dat = idx.data();
-
-    int64_t i, j;
-    for (i = 0, j = 0; i < k; ++i) {
-        j = idx_dat[i] - 1;
-        std::swap(A[i], A[j]);
-
-        // swap idx array elements
-        // Find idx element with value i and assign it to j
-        auto it = std::find(idx.begin() + i, idx.begin() + k, i + 1);
-        idx[it - (idx.begin())] = j + 1;
+    for (int64_t i = 0; i < k; ++i) {
+        if (idx[i] < 0)
+            continue;
+        int64_t j = i;
+        while (true) {
+            int64_t src = idx[j] - 1;
+            idx[j] = -idx[j];
+            if (src == i)
+                break;
+            std::swap(A[j], A[src]);
+            j = src;
+        }
     }
+    for (int64_t i = 0; i < k; ++i)
+        idx[i] = std::abs(idx[i]);
 }
 
 /// Checks if the given size is larger than available. 

--- a/RandLAPACK/misc/rl_util.hh
+++ b/RandLAPACK/misc/rl_util.hh
@@ -95,7 +95,9 @@ void diag(
     blas::copy(k, s, 1, S, m + 1);
 }
 
-/// Zeros-out the upper-triangular portion of A
+/// Zeros-out the strictly upper-triangular portion of A (lda == m),
+/// optionally overwriting the diagonal with ones. Implemented via
+/// LAPACK's laset.
 template <typename T>
 void get_L(
     int64_t m,
@@ -103,15 +105,17 @@ void get_L(
     T* A,
     int overwrite_diagonal
 ) {
-    for(int i = 0; i < n; ++i) {
-        std::fill(&A[m * i], &A[i + m * i], 0.0);
-        
-        if(overwrite_diagonal)
-            A[i + m * i] = 1.0;
+    if (overwrite_diagonal) {
+        lapack::laset(lapack::MatrixType::Upper, m, n, (T) 0.0, (T) 1.0, A, m);
+    } else if (n > 1) {
+        // The strictly upper triangle of A is the upper triangle, diagonal
+        // included, of the m by (n - 1) submatrix starting at A(0, 1).
+        lapack::laset(lapack::MatrixType::Upper, m, n - 1, (T) 0.0, (T) 0.0, &A[m], m);
     }
 }
 
-/// Zeros-out the lower-triangular portion of A
+/// Zeros-out the strictly lower-triangular portion of A. Implemented via
+/// LAPACK's laset.
 template <typename T>
 void get_U(
     int64_t m,
@@ -119,8 +123,10 @@ void get_U(
     T* A,
     int64_t lda
 ) {
-    for(int i = 0; i < n - 1; ++i) {
-        std::fill(&A[i * (lda + 1) + 1], &A[(i * lda) + m], 0.0);
+    if (m > 1) {
+        // The strictly lower triangle of A is the lower triangle, diagonal
+        // included, of the (m - 1) by n submatrix starting at A(1, 0).
+        lapack::laset(lapack::MatrixType::Lower, m - 1, n, (T) 0.0, (T) 0.0, &A[1], lda);
     }
 }
 

--- a/RandLAPACK/misc/rl_util.hh
+++ b/RandLAPACK/misc/rl_util.hh
@@ -369,7 +369,7 @@ void rl_orhr_col(
         for(i = 0; i < n; ++i) {
             blas::scal(i + 1, -D[i], &T_dat[n * i], 1);
         }
-        blas::trsm(Layout::ColMajor, Side::Right, Uplo::Lower, Op::Trans, Diag::Unit, n, n, 1.0, A, lda, T_dat, n);	
+        blas::trsm(Layout::ColMajor, Side::Right, Uplo::Lower, Op::Trans, Diag::Unit, n, n, (T) 1.0, A, lda, T_dat, n);	
     }
 }
 

--- a/RandLAPACK/testing/rl_gen.hh
+++ b/RandLAPACK/testing/rl_gen.hh
@@ -349,7 +349,7 @@ void gen_oleg_adversarial_mat(
     for(int i = 11; i < n; ++i)
         V[n * i + i] *= scaling_factor_V;
 
-    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, n, 1.0, U, m, V, n, 0.0, A, m);
+    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, n, n, (T) 1.0, U, m, V, n, (T) 0.0, A, m);
 
     delete[] U;
     delete[] V;
@@ -427,7 +427,7 @@ void gen_kahan_mat(
         C[m * i + i] = 1.0;
     }
 
-    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, m, m, 1.0, S, m, C, m, 1.0, A, m);
+    blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, m, m, m, (T) 1.0, S, m, C, m, (T) 1.0, A, m);
 
     delete[] S;
     delete[] C;

--- a/benchmark/bench_BQRRP/BQRRP_error_analysis.cc
+++ b/benchmark/bench_BQRRP/BQRRP_error_analysis.cc
@@ -1,5 +1,9 @@
 #if defined(__APPLE__)
-int main() {return 0;}
+#include <iostream>
+int main() {
+    std::cout << "This benchmark cannot run on Apple machines." << std::endl;
+    return 1;
+}
 #else
 /*
 Performs computations in order to assess the pivot quality of BQRRP.

--- a/benchmark/bench_BQRRP/BQRRP_error_analysis.cc
+++ b/benchmark/bench_BQRRP/BQRRP_error_analysis.cc
@@ -171,8 +171,8 @@ static void BQRRP_benchmark_run(
         // Extracting an explicit Q-factor 
         lapack::ungqr(m, std::min(m, n), std::min(m, n), all_data.A.data(), m, all_data.tau.data());
         // Permuting the columns of the copies of the original matrix A
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J);
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J);
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J.data());
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J.data());
         
         error_check<T>(all_data, atol, error_output);
     }

--- a/benchmark/bench_BQRRP/BQRRP_pivot_quality.cc
+++ b/benchmark/bench_BQRRP/BQRRP_pivot_quality.cc
@@ -1,5 +1,9 @@
 #if defined(__APPLE__)
-int main() {return 0;}
+#include <iostream>
+int main() {
+    std::cout << "This benchmark cannot run on Apple machines." << std::endl;
+    return 1;
+}
 #else
 /*
 Performs computations in order to assess the pivot quality of BQRRP.

--- a/benchmark/bench_BQRRP/BQRRP_runtime_breakdown.cc
+++ b/benchmark/bench_BQRRP/BQRRP_runtime_breakdown.cc
@@ -1,5 +1,9 @@
 #if defined(__APPLE__)
-int main() {return 0;}
+#include <iostream>
+int main() {
+    std::cout << "This benchmark cannot run on Apple machines." << std::endl;
+    return 1;
+}
 #else
 /*
 IBQRRP runtime breakdown benchmark - assesses the time taken by each subcomponent of IBQRRP.

--- a/benchmark/bench_BQRRP/BQRRP_speed_comparisons_block_size.cc
+++ b/benchmark/bench_BQRRP/BQRRP_speed_comparisons_block_size.cc
@@ -1,5 +1,9 @@
 #if defined(__APPLE__)
-int main() {return 0;}
+#include <iostream>
+int main() {
+    std::cout << "This benchmark cannot run on Apple machines." << std::endl;
+    return 1;
+}
 #else
 /*
 BQRRP speed comparison benchmark - runs:

--- a/benchmark/bench_BQRRP/BQRRP_speed_comparisons_mat_size.cc
+++ b/benchmark/bench_BQRRP/BQRRP_speed_comparisons_mat_size.cc
@@ -1,5 +1,9 @@
 #if defined(__APPLE__)
-int main() {return 0;}
+#include <iostream>
+int main() {
+    std::cout << "This benchmark cannot run on Apple machines." << std::endl;
+    return 1;
+}
 #else
 /*
 BQRRP speed comparison benchmark - runs:

--- a/benchmark/bench_BQRRP/BQRRP_subroutines_speed.cc
+++ b/benchmark/bench_BQRRP/BQRRP_subroutines_speed.cc
@@ -1,5 +1,9 @@
 #if defined(__APPLE__)
-int main() {return 0;}
+#include <iostream>
+int main() {
+    std::cout << "This benchmark cannot run on Apple machines." << std::endl;
+    return 1;
+}
 #else
 /*
 QR speed comparison benchmark - runs:

--- a/benchmark/bench_BQRRP/BQRRP_subroutines_speed.cc
+++ b/benchmark/bench_BQRRP/BQRRP_subroutines_speed.cc
@@ -174,7 +174,7 @@ static void call_wide_qrcp(
             all_data.J[j] = tmp;
         }
         // Apply pivots to A_sk
-        RandLAPACK::util::col_swap(n, m, m, all_data.A.data(), n, all_data.J);
+        RandLAPACK::util::col_swap(n, m, m, all_data.A.data(), n, all_data.J.data());
         // Perform an unpivoted QR on A_sk
         lapack::geqrf(n, m, all_data.A.data(), n, all_data.tau.data());
         auto stop_luqr = steady_clock::now();

--- a/benchmark/bench_BQRRP/HQRRP_runtime_breakdown.cc
+++ b/benchmark/bench_BQRRP/HQRRP_runtime_breakdown.cc
@@ -1,5 +1,9 @@
 #if defined(__APPLE__)
-int main() {return 0;}
+#include <iostream>
+int main() {
+    std::cout << "This benchmark cannot run on Apple machines." << std::endl;
+    return 1;
+}
 #else
 /*
 HQRRP runtime breakdown benchmark - assesses the time taken by each subcomponent of HQRRP.

--- a/benchmark/bench_BQRRP/HQRRP_sanity_check.cc
+++ b/benchmark/bench_BQRRP/HQRRP_sanity_check.cc
@@ -1,7 +1,11 @@
 
 
 #if defined(__APPLE__)
-int main() {return 0;}
+#include <iostream>
+int main() {
+    std::cout << "This benchmark cannot run on Apple machines." << std::endl;
+    return 1;
+}
 #else
 
 // Making sure that HQRRP's performance instability is specific to HQRRP and not related to the flaws in behcnmarking logic

--- a/benchmark/bench_CQRRPT/CQRRPT_error_analysis.cc
+++ b/benchmark/bench_CQRRPT/CQRRPT_error_analysis.cc
@@ -1,5 +1,9 @@
 #if defined(__APPLE__)
-int main() {return 0;}
+#include <iostream>
+int main() {
+    std::cout << "This benchmark cannot run on Apple machines." << std::endl;
+    return 1;
+}
 #else
 /*
 Performs computations in order to assess the pivot quality of BQRRP.

--- a/benchmark/bench_CQRRPT/CQRRPT_error_analysis.cc
+++ b/benchmark/bench_CQRRPT/CQRRPT_error_analysis.cc
@@ -166,8 +166,8 @@ static void CQRRPT_benchmark_run(
         }
 
         // Permuting the columns of the copies of the original matrix A
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J);
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J);
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J.data());
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J.data());
     
         error_check<T>(all_data, col_sz, atol, error_output);
     }

--- a/benchmark/bench_CQRRPT/CQRRPT_speed_comparisons.cc
+++ b/benchmark/bench_CQRRPT/CQRRPT_speed_comparisons.cc
@@ -1,3 +1,10 @@
+#if defined(__APPLE__)
+#include <iostream>
+int main() {
+    std::cout << "This benchmark cannot run on Apple machines." << std::endl;
+    return 1;
+}
+#else
 /*
 CQRRPT speed comparison benchmark - runs:
     1. CQRRPT
@@ -176,7 +183,6 @@ static void call_all_algs(
         data_regen(m_info, all_data, state_gen);
 
         // Testing GEQR + GEQPT
-#if !defined(__APPLE__)
         auto start_geqpt = steady_clock::now();
         auto start_geqr  = steady_clock::now();
         // GEQR(A) part
@@ -198,7 +204,6 @@ static void call_all_algs(
 
         state_gen = state;
         data_regen(m_info, all_data, state_gen);
-#endif
 
         std::ofstream file(output_filename, std::ios::app);
         file << dur_cqrrpt_default << ",  " << dur_cqrrpt_hqrrp << ",  " << dur_cqrrpt_bqrrp << ",  " << dur_geqpt <<  ",  " 
@@ -269,3 +274,4 @@ int main(int argc, char *argv[]) {
     file << "Total benchmark execution time:" +  std::to_string(dur_time_all) + "\n";
     file.flush();   
 }
+#endif

--- a/test/comps/test_orth.cc
+++ b/test/comps/test_orth.cc
@@ -99,6 +99,39 @@ class TestOrth : public ::testing::Test
     }
 };
 
+// PLUL is a range-stabilization option inside the rangefinder/QB pipeline,
+// where the sketches it receives can legitimately be numerically rank
+// deficient. GETRF then reports a singular U through a positive exit code,
+// but PLUL discards the U-factor and keeps only the (still valid)
+// row-permuted unit-lower L, so treating that exit code as a failure would
+// abort perfectly recoverable runs. PLUL used to do exactly that; this test
+// pins the corrected contract so the failure branch does not come back.
+TEST_F(TestOrth, Test_PLUL_singular_input_is_not_an_error)
+{
+    int64_t m = 8;
+    int64_t n = 4;
+    std::vector<double> A(m * n);
+    RandBLAS::RNGState state;
+    RandBLAS::DenseDist D(m, n);
+    RandBLAS::fill_dense(D, A.data(), state);
+    // Column 2 := 0 exactly, so GETRF hits an exactly-zero pivot and
+    // returns info = 3 (duplicating a column is not enough: the update
+    // x - (x/y)*y leaves a tiny nonzero rounding residual as the pivot).
+    std::fill(&A[2 * m], &A[3 * m], 0.0);
+
+    RandLAPACK::PLUL<double> Stab(false, false);
+    int ret = Stab.call(m, n, A.data());
+    EXPECT_EQ(ret, 0);
+
+    // The output (a row-permuted unit-lower-triangular L from partial
+    // pivoting) must be fully populated with finite entries of magnitude
+    // at most 1.
+    for (int64_t i = 0; i < m * n; ++i) {
+        ASSERT_TRUE(std::isfinite(A[i]));
+        ASSERT_LE(std::abs(A[i]), 1.0 + std::numeric_limits<double>::epsilon());
+    }
+}
+
 TEST_F(TestOrth, Test_CholQRQ)
 {
     int64_t m = 1000;

--- a/test/comps/test_util_gpu.cu
+++ b/test/comps/test_util_gpu.cu
@@ -187,7 +187,7 @@ class TestUtil_GPU : public ::testing::Test
         RandLAPACK::cuda_kernels::col_swap_gpu(strm, m, n, n, all_data.A_device, m, all_data.J_device);
         cudaMemcpyAsync(all_data.A_host_buffer.data(), all_data.A_device, m * n * sizeof(T), cudaMemcpyDeviceToHost, strm);
         cudaMemcpyAsync(all_data.J_host_buffer.data(), all_data.J_device, n * sizeof(int64_t), cudaMemcpyDeviceToHost, strm);
-        RandLAPACK::util::col_swap(m, n, n, all_data.A.data(), m, all_data.J);
+        RandLAPACK::util::col_swap(m, n, n, all_data.A.data(), m, all_data.J.data());
         cudaStreamSynchronize(strm);
 
         for(int i = 0; i < m*n; ++i)
@@ -230,7 +230,7 @@ class TestUtil_GPU : public ::testing::Test
 
         T* A = all_data.A.data();
         T* A_submat = all_data.A.data() + (col_offset * m + offset);
-        RandLAPACK::util::col_swap(m_submat, n_submat, k_submat, A_submat, lda, all_data.J);
+        RandLAPACK::util::col_swap(m_submat, n_submat, k_submat, A_submat, lda, all_data.J.data());
 
         cudaStreamSynchronize(strm);
 
@@ -268,7 +268,7 @@ class TestUtil_GPU : public ::testing::Test
 
         int64_t* J_subvec = all_data.J.data() + offset;
         std::vector<int64_t> buf;
-        RandLAPACK::util::col_swap<T>(m, k, J_subvec, all_data.idx);
+        RandLAPACK::util::col_swap(m, k, J_subvec, all_data.idx.data());
         cudaStreamSynchronize(strm);
 
         for(int i = 0; i < m; ++i){

--- a/test/drivers/test_bqrrp.cc
+++ b/test/drivers/test_bqrrp.cc
@@ -139,8 +139,8 @@ class TestBQRRP : public ::testing::Test
             
             lapack::lacpy(MatrixType::General, m, all_data.rank, all_data.A.data(), m, all_data.Q.data(), m);
 
-            RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J);
-            RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J);
+            RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J.data());
+            RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J.data());
 
             error_check(norm_A, all_data, atol);
         }

--- a/test/drivers/test_bqrrp_gpu.cu
+++ b/test/drivers/test_bqrrp_gpu.cu
@@ -196,8 +196,8 @@ class TestBQRRP : public ::testing::TestWithParam<int64_t>
             RandLAPACK::util::upsize(all_data.rank * n, all_data.R);
             lapack::lacpy(MatrixType::Upper, all_data.rank, n, all_data.R_full.data(), m, all_data.R.data(), all_data.rank);
 
-            RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J);
-            RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J);
+            RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J.data());
+            RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J.data());
 
             error_check(norm_A, all_data, atol);
         }

--- a/test/drivers/test_bqrrp_gpu.cu
+++ b/test/drivers/test_bqrrp_gpu.cu
@@ -100,9 +100,9 @@ class TestBQRRP : public ::testing::TestWithParam<int64_t>
         RandBLAS::fill_dense(D, S, state_const);
         blas::gemm(Layout::ColMajor, Op::NoTrans, Op::NoTrans, d, n, m, 1.0, S, d, all_data.A.data(), m, 0.0, all_data.A_sk.data(), d);
         delete[] S;
-        cudaMemcpy(all_data.A_sk_device, all_data.A_sk.data(), d * n * sizeof(double), cudaMemcpyHostToDevice);
+        cudaMemcpy(all_data.A_sk_device, all_data.A_sk.data(), d * n * sizeof(T), cudaMemcpyHostToDevice);
 
-        cudaMemcpy(all_data.A_device, all_data.A.data(), m * n * sizeof(double), cudaMemcpyHostToDevice);
+        cudaMemcpy(all_data.A_device, all_data.A.data(), m * n * sizeof(T), cudaMemcpyHostToDevice);
         lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpu.data(), m);
         lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy1.data(), m);
         lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy2.data(), m);
@@ -169,7 +169,12 @@ class TestBQRRP : public ::testing::TestWithParam<int64_t>
 
         auto m = all_data.row;
         auto n = all_data.col;
-        T atol = std::pow(std::numeric_limits<T>::epsilon(), 0.75);
+        // The per-column residual check floors at a few hundred eps in
+        // either precision; eps^0.75 leaves that plenty of headroom in
+        // double but not in float, so single precision uses eps^0.60, the
+        // same exponent test_BQRRP_compare_with_CPU already applies to its
+        // R-factor difference.
+        T atol = std::pow(std::numeric_limits<T>::epsilon(), std::is_same<T, double>::value ? 0.75 : 0.60);
 
         BQRRP_GPU.call(m, n, all_data.A_device, m, all_data.A_sk_device, d, all_data.tau_device, all_data.J_device);
 
@@ -273,6 +278,34 @@ TEST_F(TestBQRRP, BQRRP_GPU_070824) {
 
     norm__sektch_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, d, all_data, state);
     test_BQRRP_general<double, RandLAPACK::BQRRP_GPU<double, r123::Philox4x32>>(d, norm_A, all_data, BQRRP_GPU);
+}
+
+// BQRRP_GPU must support single precision. Mirrors
+// BQRRP_GPU_070824 with T = float; exercises the ormqr path through
+// cuSOLVER's S-typed interface. The problem is smaller than the double
+// test: at 5000 x 2800 the float residual accumulates to ~34 eps, just
+// past the shared eps^0.75 tolerance, so the size is chosen to leave
+// that tolerance a healthy margin in single precision.
+TEST_F(TestBQRRP, BQRRP_GPU_single_precision) {
+    int64_t m = 2000;
+    int64_t n = 1000;
+    int64_t k = 1000;
+    double d_factor = 1;
+    int64_t b_sz = 300;
+    int64_t d = d_factor * b_sz;
+    float norm_A = 0;
+    auto state = RandBLAS::RNGState();
+    bool profile_runtime = true;
+
+    BQRRPTestData<float> all_data(m, n, k, d);
+    RandLAPACK::BQRRP_GPU<float, r123::Philox4x32> BQRRP_GPU(profile_runtime, b_sz);
+    BQRRP_GPU.qr_tall = GPUSubroutines::QRTall::cholqr;
+
+    RandLAPACK::gen::mat_gen_info<float> m_info(m, n, RandLAPACK::gen::gaussian);
+    RandLAPACK::gen::mat_gen<float, r123::Philox4x32>(m_info, all_data.A.data(), state);
+
+    norm__sektch_and_copy_computational_helper<float, r123::Philox4x32>(norm_A, d, all_data, state);
+    test_BQRRP_general<float, RandLAPACK::BQRRP_GPU<float, r123::Philox4x32>>(d, norm_A, all_data, BQRRP_GPU);
 }
 
 // Note: If Subprocess killed exception -> reload vscode

--- a/test/drivers/test_cqrrpt.cc
+++ b/test/drivers/test_cqrrpt.cc
@@ -122,8 +122,8 @@ class TestCQRRPT : public ::testing::Test
         all_data.rank = CQRRPT.rank;
         std::cout << "RANK AS RETURNED BY CQRRPT " << all_data.rank << "\n";
 
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J);
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J);
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J.data());
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J.data());
 
         error_check(norm_A, all_data);
     }

--- a/test/drivers/test_cqrrpt_gpu.cu
+++ b/test/drivers/test_cqrrpt_gpu.cu
@@ -128,8 +128,8 @@ class TestCQRRPT : public ::testing::Test
         all_data.rank = CQRRPT_GPU.rank;
         std::cout << "RANK AS RETURNED BY CQRRPT " << all_data.rank << "\n";
 
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J);
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J);
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J.data());
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J.data());
 
         error_check(norm_A, all_data); 
     }

--- a/test/drivers/test_hqrrp.cc
+++ b/test/drivers/test_hqrrp.cc
@@ -134,8 +134,8 @@ class TestHQRRP : public ::testing::Test
         // I don't think hqrrp actually returns anything.
         //std::cout << "RANK AS RETURNED BY HQRRP " << std::setw(4) << all_data.rank << "\n";
 
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J);
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J);
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy1.data(), m, all_data.J.data());
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy2.data(), m, all_data.J.data());
 
         error_check(norm_A, all_data);
              

--- a/test/misc/test_util.cc
+++ b/test/misc/test_util.cc
@@ -7,6 +7,7 @@
 
 #include <math.h>
 #include <chrono>
+#include <random>
 #include <gtest/gtest.h>
 /*
 TODO #1: Resizing tests.
@@ -169,7 +170,7 @@ class TestUtil : public ::testing::Test
         lapack::geqp3(m, n, all_data.A.data(), m, all_data.J.data(), all_data.tau.data());
 
         // Swap columns in A's copy
-        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy.data(), m, all_data.J);
+        RandLAPACK::util::col_swap(m, n, n, all_data.A_cpy.data(), m, all_data.J.data());
 
         // Create an identity and store Q in it.
         RandLAPACK::util::eye(m, n, all_data.Ident.data());
@@ -185,6 +186,128 @@ class TestUtil : public ::testing::Test
         T norm = lapack::lange(Norm::Fro, m, n, all_data.A_cpy.data(), m);
         std::cout << "||A_piv - QR||_F:  " << std::scientific << norm << "\n";
         ASSERT_NEAR(norm, 0.0, std::pow(std::numeric_limits<T>::epsilon(), 0.625));
+    }
+
+    // Pins the gather contract of col_swap (a delegate to LAPACK's LAPMT):
+    // on exit, column i of A holds what was column idx[i] - 1, and the pivot
+    // vector, which serves as LAPMT's internal scratch, is restored on exit.
+    template <typename T>
+    static void 
+    test_col_swp_gather(ColSwpTestData<T> &all_data, int64_t k) {
+
+        auto m = all_data.row;
+        auto n = all_data.col;
+        std::vector<int64_t> J_copy(all_data.J);
+
+        RandLAPACK::util::col_swap(m, n, k, all_data.A.data(), m, all_data.J.data());
+
+        for (int64_t i = 0; i < n; ++i)
+            ASSERT_EQ(all_data.J[i], J_copy[i]) << "pivot vector not restored at " << i;
+        for (int64_t j = 0; j < k; ++j)
+            for (int64_t i = 0; i < m; ++i)
+                ASSERT_EQ(all_data.A[i + j * m], all_data.A_cpy[i + (all_data.J[j] - 1) * m])
+                    << "col " << j << " row " << i << " m=" << m << " n=" << n << " k=" << k;
+    }
+
+    // Structured permutations that stress the cycle-following logic directly:
+    // identity (no cycles), reversal (n/2 two-cycles), rotation (one n-cycle).
+    template <typename T>
+    static void 
+    test_col_swp_structured(ColSwpTestData<T> &all_data) {
+
+        auto m = all_data.row;
+        auto n = all_data.col;
+        T* A = all_data.A.data();
+        T const* orig = all_data.A_cpy.data();
+        std::vector<int64_t> &J = all_data.J;
+
+        std::iota(J.begin(), J.end(), 1);                       // identity
+        RandLAPACK::util::col_swap(m, n, n, A, m, J.data());
+        for (int64_t i = 0; i < m * n; ++i) ASSERT_EQ(A[i], orig[i]);
+
+        for (int64_t i = 0; i < n; ++i) J[i] = n - i;           // reversal
+        RandLAPACK::util::col_swap(m, n, n, A, m, J.data());
+        for (int64_t j = 0; j < n; ++j)
+            for (int64_t i = 0; i < m; ++i)
+                ASSERT_EQ(A[i + j * m], orig[i + (n - 1 - j) * m]);
+
+        lapack::lacpy(MatrixType::General, m, n, orig, m, A, m);
+        for (int64_t i = 0; i < n; ++i) J[i] = (i + 1) % n + 1; // one n-cycle
+        RandLAPACK::util::col_swap(m, n, n, A, m, J.data());
+        for (int64_t j = 0; j < n; ++j)
+            for (int64_t i = 0; i < m; ++i)
+                ASSERT_EQ(A[i + j * m], orig[i + ((j + 1) % n) * m]);
+    }
+
+    // The matrix overload must respect lda > m (operating on a submatrix of
+    // a taller allocation) and leave the rows below m untouched.
+    template <typename T>
+    static void 
+    test_col_swp_lda(int64_t m, int64_t lda, int64_t n) {
+
+        std::vector<T> A(lda * n);
+        std::iota(A.begin(), A.end(), 0.0);
+        std::vector<T> orig(A);
+        std::vector<int64_t> J = {3, 1, 6, 2, 5, 4};
+
+        RandLAPACK::util::col_swap(m, n, n, A.data(), lda, J.data());
+
+        for (int64_t j = 0; j < n; ++j) {
+            for (int64_t i = 0; i < m; ++i)
+                ASSERT_EQ(A[i + j * lda], orig[i + (J[j] - 1) * lda]);
+            for (int64_t i = m; i < lda; ++i)
+                ASSERT_EQ(A[i + j * lda], orig[i + j * lda]) << "padding row touched";
+        }
+    }
+
+    // The integer-vector overload implements LAPMT-style cycle-following
+    // directly (LAPMT itself only handles real matrices). Its pivot vector
+    // is a permutation of 1..k, and entries of A beyond the first k must
+    // stay untouched: the GPU counterpart and CQRRPT-style subvector use
+    // depend on that prefix-only contract.
+    static void 
+    test_col_swp_int_vector(int64_t n, int64_t k, uint32_t seed) {
+
+        std::vector<int64_t> A(n);
+        std::iota(A.begin(), A.end(), 100);
+        std::vector<int64_t> orig(A);
+        std::vector<int64_t> J(k);
+        std::iota(J.begin(), J.end(), 1);
+        std::mt19937_64 gen(seed);
+        std::shuffle(J.begin(), J.end(), gen);
+        std::vector<int64_t> J_copy(J);
+
+        RandLAPACK::util::col_swap(n, k, A.data(), J.data());
+
+        for (int64_t i = 0; i < k; ++i)
+            ASSERT_EQ(J[i], J_copy[i]) << "pivot vector not restored at " << i;
+        for (int64_t i = 0; i < k; ++i)
+            ASSERT_EQ(A[i], orig[J[i] - 1]) << "entry " << i;
+        for (int64_t i = k; i < n; ++i)
+            ASSERT_EQ(A[i], orig[i]) << "entry beyond k touched at " << i;
+    }
+
+    // Efficiency canary. The pre-LAPMT implementation searched the pivot
+    // vector inside its swap loop, costing O(n^2): about 40 seconds at this
+    // size (measured 35 ms at n = 30,000, quadratic scaling). The LAPMT
+    // path runs in milliseconds, so the generous bound below only trips if
+    // the O(n^2) behavior ever comes back.
+    static void 
+    test_col_swp_speed_canary(int64_t n) {
+
+        std::vector<double> A(n);
+        std::iota(A.begin(), A.end(), 0.0);
+        std::vector<int64_t> J(n);
+        for (int64_t i = 0; i < n; ++i) J[i] = (i + 1) % n + 1; // one n-cycle
+
+        auto t0 = steady_clock::now();
+        RandLAPACK::util::col_swap(1, n, n, A.data(), 1, J.data());
+        double sec = std::chrono::duration<double>(steady_clock::now() - t0).count();
+
+        for (int64_t j = 0; j < n; ++j)
+            ASSERT_EQ(A[j], (double) ((j + 1) % n));
+        std::cout << "col_swap n=" << n << " single-cycle: " << sec * 1e3 << " ms\n";
+        ASSERT_LT(sec, 10.0) << "col_swap has lost its O(n) behavior";
     }
 
     template <typename T>
@@ -382,6 +505,49 @@ TEST_F(TestUtil, test_col_swp) {
     lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
 
     test_col_swp<double>(all_data);
+}
+
+TEST_F(TestUtil, test_col_swp_gather_full_and_truncated) {
+
+    for (auto [m, n, k, seed] : {std::tuple<int64_t, int64_t, int64_t, uint32_t>
+            {10, 7, 7, 0}, {10, 7, 4, 1}, {1000, 200, 200, 2}, {8, 12, 5, 3},
+            {5, 1, 1, 5}, {6, 9, 1, 6}}) {
+        auto state = RandBLAS::RNGState(seed);
+        ColSwpTestData<double> all_data(m, n);
+        RandBLAS::DenseDist D(m, n);
+        RandBLAS::fill_dense(D, all_data.A.data(), state);
+        lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
+        std::iota(all_data.J.begin(), all_data.J.end(), 1);
+        std::mt19937_64 gen(seed);
+        std::shuffle(all_data.J.begin(), all_data.J.end(), gen);
+
+        test_col_swp_gather<double>(all_data, k);
+    }
+}
+
+TEST_F(TestUtil, test_col_swp_structured_permutations) {
+
+    int64_t m = 3;
+    int64_t n = 8;
+    ColSwpTestData<double> all_data(m, n);
+    std::iota(all_data.A.begin(), all_data.A.end(), 0.0);
+    lapack::lacpy(MatrixType::General, m, n, all_data.A.data(), m, all_data.A_cpy.data(), m);
+
+    test_col_swp_structured<double>(all_data);
+}
+
+TEST_F(TestUtil, test_col_swp_respects_lda) {
+    test_col_swp_lda<double>(4, 7, 6);
+}
+
+TEST_F(TestUtil, test_col_swp_int_vector) {
+    test_col_swp_int_vector(7, 7, 0);
+    test_col_swp_int_vector(200, 200, 1);
+    test_col_swp_int_vector(2800, 100, 2); // subvector pattern, k << n
+}
+
+TEST_F(TestUtil, test_col_swp_large_permutation_is_fast) {
+    test_col_swp_speed_canary(1000000);
 }
 
 #if !defined(__APPLE__)


### PR DESCRIPTION
Fixes six verified quick-win issues in one reviewable batch (release-plan item A1). One commit per issue:

1. **#109** PLUL no longer treats a singular U-factor as failure. GETRF's positive exit codes leave the factorization valid, and PLUL discards U anyway; LAPACK++ already throws on invalid arguments. New test drives an exactly-zero column through PLUL (an exact zero pivot; a duplicated column is not enough, since the update `x - (x/y)*y` leaves a rounding residual as the pivot).
2. **#118** `get_L`/`get_U` are now one `lapack::laset` call each, on shifted submatrices. This also fixed two latent defects the old loops carried: `get_U` skipped its final column (harmless today only because every call site passes square blocks), and `get_L` wrote out of bounds for wide inputs. laset's own correctness is covered upstream, so no dedicated tests are added.
3. **#110** `col_swap` is made efficient. The old implementation (verified correct first, including the truncated `k < n` case CQRRPT uses: 10,000 randomized trials against a gather reference) copied its pivot vector by value and ran a `std::find` inside the swap loop, costing O(n^2) in bookkeeping. The matrix overload is now a one-line delegate to `lapack::lapmt` (forward pass: in-place cycle-following, no search, pivot vector used as scratch and restored on exit); the integer-vector overload implements the same cycle-following directly, since LAPMT only handles real matrices, and is a plain function now (its template parameter was never deducible). The two overloads' pivot contracts, previously implicit, are now documented: the matrix overload takes a full 1..n permutation, while the integer overload takes a 1..k prefix permutation and leaves entries beyond k untouched (the GPU kernel and subvector usage rely on this). Both overloads take the pivot vector as a raw `int64_t*`: the old by-value `std::vector` signature existed only to protect the caller's vector from mutation, which LAPMT's restore-on-exit makes unnecessary; BQRRP's and CQRRPT's pivot buffers accordingly become raw allocations per the workspace conventions, with all exit paths freeing them (this also fixes a pre-existing leak of `A_hat`/`tau` on CQRRPT's all-zeros early return). Note for downstream callers: `col_swap` now takes `idx.data()`-style pointers. Measured: 25x / 143x / 418x faster at n = 1k / 10k / 30k on worst-case permutations with identical outputs, and MKL's lapmt runs an n = 10^6 permutation in ~2 ms where the old loop extrapolates to ~40 s. New tests, following the existing TestUtil harness structure, pin the gather contract (full/truncated/wide shapes, structured permutations, lda > m, the integer overload), pivot-vector restoration, and an efficiency canary; float coverage of the delegate comes with lapackpp's own lapmt instantiations.
4. **#143** BQRRP_GPU supports single precision. The `apply_trans_q` step hardcoded `cusolverDnDormqr` (and sized its workspace with `sizeof(double)`); templated `cusolver_ormqr` dispatchers in `RandLAPACK::cuda_kernels` (`rl_cuda_kernels.cuh`) infer the element type from the arguments and select the S or D symbol with `if constexpr`, so the indirection has no runtime cost. Driver call sites stay one-liners; the workspace is sized by `sizeof(T)`. New float GPU test runs the full driver end to end. Its tolerance uses `eps^0.60` for float on the per-column residual check, the exponent this test file already applies to the R-factor difference: that metric floors at a few hundred eps in either precision, and `eps^0.75` leaves only tens-of-eps headroom in single precision.
5. **#120** 69 BLAS scalar constants (`1.0`/`-1.0`/`0.0` alpha/beta arguments) across 16 headers now pass as `(T)`-cast values, avoiding inefficient mixed-type dispatch in templated code.
6. **#63** All ten Apple-guarded benchmarks now use the whole-file stub pattern the issue requests (message + `return 1`). `CQRRPT_speed_comparisons` was the remaining offender with the guard buried inside its run loop; nine others returned 0 silently.

Verification: full test suite on Linux (CUDA build, RTX 5070 Ti) passes with the addition of 7 new tests; the single failure is `TestBQRRP.BQRRP_GPU_wide_aspect`, which fails identically on unmodified `main` on this hardware (pre-existing, documented). All benchmark executables compile against the branch headers.
