### PR TITLE
CI: run install.sh directly per OS, plus core workflow fixes

### DIFF
--- a/.github/workflows/core-linux.yaml
+++ b/.github/workflows/core-linux.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: submodule update
         run: |
@@ -56,10 +56,9 @@ jobs:
           git clone https://github.com/icl-utk-edu/lapackpp.git
           mkdir lapackpp-build
           cd lapackpp-build
-          cmake -DCMAKE_BUILD_TYPE=Debug \
+          cmake -DCMAKE_BUILD_TYPE=Release \
               -Dblaspp_DIR=`pwd`/../blaspp-install/lib/cmake/blaspp \
               -DCMAKE_INSTALL_PREFIX=`pwd`/../lapackpp-install \
-              -DCMAKE_BINARY_DIR=`pwd` \
               -Dbuild_tests=OFF \
               `pwd`/../lapackpp
           make -j2 install
@@ -98,7 +97,7 @@ jobs:
           cd ..
           mkdir benchmark-build
           cd benchmark-build
-          cmake -DCMAKE_BINARY_DIR=`pwd` \
+          cmake \
             -DRandLAPACK_DIR=`pwd`/../RandLAPACK-install/lib/cmake/RandLAPACK \
             ../RandLAPACK/benchmark
           make -j2

--- a/.github/workflows/core-macos.yaml
+++ b/.github/workflows/core-macos.yaml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: submodule update
         run: |
@@ -49,10 +49,9 @@ jobs:
           git clone https://github.com/icl-utk-edu/lapackpp.git
           mkdir lapackpp-build
           cd lapackpp-build
-          cmake -DCMAKE_BUILD_TYPE=Debug \
+          cmake -DCMAKE_BUILD_TYPE=Release \
               -Dblaspp_DIR=`pwd`/../blaspp-install/lib/cmake/blaspp \
               -DCMAKE_INSTALL_PREFIX=`pwd`/../lapackpp-install \
-              -DCMAKE_BINARY_DIR=`pwd` \
               -Dbuild_tests=OFF \
               `pwd`/../lapackpp
           make -j2 install
@@ -91,7 +90,7 @@ jobs:
           cd ..
           mkdir benchmark-build
           cd benchmark-build
-          cmake -DCMAKE_BINARY_DIR=`pwd` \
+          cmake \
             -DRandLAPACK_DIR=`pwd`/../RandLAPACK-install/lib/cmake/RandLAPACK \
             ../RandLAPACK/benchmark
           make -j2

--- a/.github/workflows/install-script.yaml
+++ b/.github/workflows/install-script.yaml
@@ -1,0 +1,111 @@
+# Exercises install.sh itself -- the one artifact the core workflows never
+# run (they hand-replicate the build recipes instead). Three things are
+# verified per OS:
+#   1. a fresh clone piped through the installer non-interactively builds
+#      and its test suite passes;
+#   2. re-running the installer in place succeeds (idempotent re-runs are
+#      part of the script's contract);
+#   3. the dependency-discovery path (BLASPP_INSTALL_DIR & co.) configures
+#      a second project against already-installed dependencies.
+# A Windows job slot is reserved for the native-Windows work (install.ps1).
+name: install-script
+on:
+  pull_request:
+    branches-ignore:
+      - cqrrp-gpu-benchmarking
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - cqrrp-gpu-benchmarking
+
+jobs:
+  install-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: RandLAPACK
+
+      - name: configure OS
+        run: |
+          export DEBIAN_FRONTEND="noninteractive"
+          sudo apt-get update -qq
+          sudo apt-get install -qq -y git-core gcc g++ gfortran cmake libgtest-dev libopenblas-openmp-dev
+
+      # blaspp/lapackpp/random123 rarely change; cache their installs keyed
+      # per-OS. On a cache hit the discovery env vars are seeded, so the
+      # installer's reuse path gets exercised; on a miss the full
+      # build-from-source path runs and the installs are copied out for the
+      # cache. Bump the -v suffix to force a from-scratch run.
+      - name: cache dependencies
+        id: deps-cache
+        uses: actions/cache@v4
+        with:
+          path: deps-install
+          key: installer-deps-${{ runner.os }}-v1
+
+      - name: seed discovery variables from cache
+        if: steps.deps-cache.outputs.cache-hit == 'true'
+        run: |
+          echo "BLASPP_INSTALL_DIR=$GITHUB_WORKSPACE/deps-install/blaspp-install" >> "$GITHUB_ENV"
+          echo "LAPACKPP_INSTALL_DIR=$GITHUB_WORKSPACE/deps-install/lapackpp-install" >> "$GITHUB_ENV"
+          echo "RANDOM123_INSTALL_DIR=$GITHUB_WORKSPACE/deps-install/random123" >> "$GITHUB_ENV"
+
+      - name: keep a pristine clone for the discovery test
+        run: cp -a RandLAPACK RandLAPACK-discovery
+
+      - name: run the installer (non-interactive)
+        run: bash RandLAPACK/install.sh --yes --no-gpu
+
+      - name: populate the dependency cache
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p deps-install
+          cp -a RandNLA-project/install/blaspp-install   deps-install/
+          cp -a RandNLA-project/install/lapackpp-install deps-install/
+          cp -a RandNLA-project/install/random123        deps-install/
+
+      - name: test the installed library
+        run: |
+          ctest --test-dir RandNLA-project/build/RandLAPACK-build \
+                --exclude-regex "^TestABRIK\.ABRIK_catch_instability" \
+                --output-on-failure
+
+      - name: re-run the installer in place (idempotency)
+        run: bash RandNLA-project/lib/RandLAPACK/install.sh --yes --no-gpu
+
+      - name: install a second project via dependency discovery
+        run: |
+          BLASPP_INSTALL_DIR="$GITHUB_WORKSPACE/deps-install/blaspp-install" \
+          LAPACKPP_INSTALL_DIR="$GITHUB_WORKSPACE/deps-install/lapackpp-install" \
+          RANDOM123_INSTALL_DIR="$GITHUB_WORKSPACE/deps-install/random123" \
+          bash RandLAPACK-discovery/install.sh --yes --no-gpu \
+              --project-dir "$GITHUB_WORKSPACE/RandNLA-project-discovery" \
+              | tee discovery.out
+          grep -q "reused external install" discovery.out
+          test -d RandNLA-project-discovery/build/RandLAPACK-build
+
+  install-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: RandLAPACK
+
+      - name: configure OS
+        run: brew install googletest openblas libomp
+
+      - name: run the installer (non-interactive)
+        run: bash RandLAPACK/install.sh --yes --no-gpu
+
+      - name: test the installed library
+        run: |
+          ctest --test-dir RandNLA-project/build/RandLAPACK-build \
+                --exclude-regex "^TestABRIK\.ABRIK_catch_instability" \
+                --output-on-failure
+
+      - name: re-run the installer in place (idempotency)
+        run: bash RandNLA-project/lib/RandLAPACK/install.sh --yes --no-gpu
+
+  # install-windows: reserved. Lands with the native Windows support
+  # (install.ps1 + MSVC/oneMKL recipe mirroring RandBLAS PR #179).

--- a/INSTALL_SCRIPT.md
+++ b/INSTALL_SCRIPT.md
@@ -123,30 +123,43 @@ bash install.sh
 ```
 
 The script will:
-1. Detect if GPU hardware is available on your system
-2. If GPU is detected, prompt: `"GPU detected. Would you like to enable GPU support? (yes/no)"`
-3. Automatically clone and build all dependencies
-4. Build RandLAPACK with appropriate configuration
-5. Build test and benchmark executables
+1. Detect if GPU hardware is available on your system and, on a terminal,
+   ask whether to build with CUDA support
+2. Automatically clone and build all dependencies (or reuse preinstalled
+   ones, see the discovery variables below)
+3. Build RandLAPACK with appropriate configuration
+4. Build test and benchmark executables
+
+Run `bash install.sh --help` for the full option list. The main flags, each
+with an environment-variable equivalent:
+
+```
+-y, --yes             assume "yes" for every prompt
+    --gpu / --no-gpu  decide GPU support without asking
+-j, --jobs <N>        parallel build jobs (default: number of cores)
+    --fresh           clear build directories first (default: reuse them,
+                      so re-running is an incremental rebuild)
+    --modify-rc       append RANDNLA_PROJECT_DIR/RANDNLA_PROJECT_GPU_AVAIL
+                      exports to your shell config (default: never touch it;
+                      the summary prints the lines to add yourself)
+    --project-dir <D> place/locate RandNLA-project at D
+```
 
 ### Automated Installation (Non-Interactive)
 
-If you want to automatically answer "yes" to all prompts (useful for scripts):
+Prompts appear only when stdin is a terminal. Piped and CI runs are already
+non-interactive with safe defaults (NVIDIA detected: GPU build; AMD or no
+GPU: CPU build), so no `yes |` piping is needed:
 
 ```shell
-yes | bash install.sh
+bash install.sh < /dev/null      # or simply: bash install.sh --yes
 ```
 
-### Installation with Logging
+### Installation Logging
 
-To capture the entire installation process in a log file:
-
-```shell
-yes | bash install.sh 2>&1 | tee install_log.txt
-```
-
-This creates `install_log.txt` with complete build output, which is invaluable
-for troubleshooting if issues arise.
+All compiler output goes to `<project-dir>/install.log` automatically; the
+console shows one line per step, and any failure prints the log path plus
+the last lines of the log. There is no need to tee the output yourself.
 
 ## 3. What the Script Does
 

--- a/install.sh
+++ b/install.sh
@@ -212,7 +212,7 @@ echo "RandLAPACK install started $(date)" >> "$LOG"
 # run_step <label> <command...>: one console line per step, full output in the
 # log, log path printed on failure.
 STEP=0
-TOTAL_STEPS=7
+TOTAL_STEPS=10
 run_step() {
     local label="$1"; shift
     STEP=$((STEP + 1))
@@ -324,34 +324,39 @@ fi
 #==============================================================================
 if [[ "$USE_EXTERNAL_BLASPP" != "true" ]]; then
     # Add "-DBLAS_LIBRARIES='-lflame -lblis'" here if using AMD AOCL.
-    run_step "Configuring + building BLAS++" bash -c "
-        cmake -S '$RANDNLA_PROJECT_DIR/lib/blaspp/' -B '$RANDNLA_PROJECT_DIR/build/blaspp-build/' \
+    # The MACOS_* variables expand unquoted on purpose: they hold multiple
+    # -D words, and some values are CMake lists with semicolons, which must
+    # reach cmake verbatim (never re-parse them through a shell string).
+    run_step "Configuring BLAS++" \
+        cmake -S "$RANDNLA_PROJECT_DIR/lib/blaspp/" -B "$RANDNLA_PROJECT_DIR/build/blaspp-build/" \
             -Dgpu_backend=$RANDNLA_PROJECT_GPU_AVAIL \
             -DCMAKE_BUILD_TYPE=Release \
             -Dblas_int=$BLAS_INT \
-            -DCMAKE_INSTALL_PREFIX='$RANDNLA_PROJECT_DIR/install/blaspp-install/' \
-            $MACOS_BLAS_FLAGS $MACOS_OPENMP_FLAGS &&
-        cmake --build '$RANDNLA_PROJECT_DIR/build/blaspp-build/' -j $JOBS --target install"
+            -DCMAKE_INSTALL_PREFIX="$RANDNLA_PROJECT_DIR/install/blaspp-install/" \
+            $MACOS_BLAS_FLAGS $MACOS_OPENMP_FLAGS
+    run_step "Building + installing BLAS++" \
+        cmake --build "$RANDNLA_PROJECT_DIR/build/blaspp-build/" -j "$JOBS" --target install
     BLASPP_CMAKE_DIR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/blaspp-install" "blaspp")
     BLASPP_LIB_DIR=$(dirname "$(dirname "$BLASPP_CMAKE_DIR")")
 else
-    STEP=$((STEP + 1)); echo "[$STEP/$TOTAL_STEPS] BLAS++ ... reused external install"
+    STEP=$((STEP + 2)); echo "[$STEP/$TOTAL_STEPS] BLAS++ ... reused external install"
 fi
 
 if [[ "$USE_EXTERNAL_LAPACKPP" != "true" ]]; then
-    run_step "Configuring + building LAPACK++" bash -c "
-        cmake -S '$RANDNLA_PROJECT_DIR/lib/lapackpp/' -B '$RANDNLA_PROJECT_DIR/build/lapackpp-build/' \
+    run_step "Configuring LAPACK++" \
+        cmake -S "$RANDNLA_PROJECT_DIR/lib/lapackpp/" -B "$RANDNLA_PROJECT_DIR/build/lapackpp-build/" \
             -Dgpu_backend=$RANDNLA_PROJECT_GPU_AVAIL \
             -DCMAKE_BUILD_TYPE=Release \
-            -Dblaspp_DIR='$BLASPP_CMAKE_DIR' \
-            -DCMAKE_INSTALL_PREFIX='$RANDNLA_PROJECT_DIR/install/lapackpp-install' \
+            -Dblaspp_DIR="$BLASPP_CMAKE_DIR" \
+            -DCMAKE_INSTALL_PREFIX="$RANDNLA_PROJECT_DIR/install/lapackpp-install" \
             -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
-            $MACOS_LAPACK_FLAGS $MACOS_OPENMP_FLAGS &&
-        cmake --build '$RANDNLA_PROJECT_DIR/build/lapackpp-build/' -j $JOBS --target install"
+            $MACOS_LAPACK_FLAGS $MACOS_OPENMP_FLAGS
+    run_step "Building + installing LAPACK++" \
+        cmake --build "$RANDNLA_PROJECT_DIR/build/lapackpp-build/" -j "$JOBS" --target install
     LAPACKPP_CMAKE_DIR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/lapackpp-install" "lapackpp")
     LAPACKPP_LIB_DIR=$(dirname "$(dirname "$LAPACKPP_CMAKE_DIR")")
 else
-    STEP=$((STEP + 1)); echo "[$STEP/$TOTAL_STEPS] LAPACK++ ... reused external install"
+    STEP=$((STEP + 2)); echo "[$STEP/$TOTAL_STEPS] LAPACK++ ... reused external install"
 fi
 
 if [[ "$USE_EXTERNAL_RANDOM123" != "true" ]]; then
@@ -382,29 +387,31 @@ if [[ "$RANDLAPACK_CUDA" == "OFF" && "$USE_EXTERNAL_BLASPP" != "true" ]]; then
     DISABLE_CUDA_FLAG="-DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=TRUE"
 fi
 
-run_step "Configuring + building extras" bash -c "
-    cmake -S '$RL_SRC/extras/' -B '$RANDNLA_PROJECT_DIR/build/extras-build/' \
+run_step "Configuring extras" \
+    cmake -S "$RL_SRC/extras/" -B "$RANDNLA_PROJECT_DIR/build/extras-build/" \
         -DCMAKE_BUILD_TYPE=Release \
-        -DFETCHCONTENT_BASE_DIR='$RANDNLA_PROJECT_DIR/build/fetchcontent-cache/' \
-        -DRandLAPACK_DIR='$RANDLAPACK_CMAKE_DIR' \
-        -Dlapackpp_DIR='$LAPACKPP_CMAKE_DIR' \
-        -Dblaspp_DIR='$BLASPP_CMAKE_DIR' \
-        -DRandom123_DIR='$RANDOM123_DIR' \
-        -DCMAKE_BUILD_RPATH='$BLASPP_LIB_DIR;$LAPACKPP_LIB_DIR;$RANDLAPACK_LIB_DIR' \
-        $DISABLE_CUDA_FLAG $MACOS_OPENMP_FLAGS &&
-    cmake --build '$RANDNLA_PROJECT_DIR/build/extras-build/' -j $JOBS"
+        -DFETCHCONTENT_BASE_DIR="$RANDNLA_PROJECT_DIR/build/fetchcontent-cache/" \
+        -DRandLAPACK_DIR="$RANDLAPACK_CMAKE_DIR" \
+        -Dlapackpp_DIR="$LAPACKPP_CMAKE_DIR" \
+        -Dblaspp_DIR="$BLASPP_CMAKE_DIR" \
+        -DRandom123_DIR="$RANDOM123_DIR" \
+        -DCMAKE_BUILD_RPATH="$BLASPP_LIB_DIR;$LAPACKPP_LIB_DIR;$RANDLAPACK_LIB_DIR" \
+        $DISABLE_CUDA_FLAG $MACOS_OPENMP_FLAGS
+run_step "Building extras" \
+    cmake --build "$RANDNLA_PROJECT_DIR/build/extras-build/" -j "$JOBS"
 
-run_step "Configuring + building benchmarks" bash -c "
-    cmake -S '$RL_SRC/benchmark/' -B '$RANDNLA_PROJECT_DIR/build/benchmark-build/' \
+run_step "Configuring benchmarks" \
+    cmake -S "$RL_SRC/benchmark/" -B "$RANDNLA_PROJECT_DIR/build/benchmark-build/" \
         -DCMAKE_BUILD_TYPE=Release \
-        -DFETCHCONTENT_BASE_DIR='$RANDNLA_PROJECT_DIR/build/fetchcontent-cache/' \
-        -DRandLAPACK_DIR='$RANDLAPACK_CMAKE_DIR' \
-        -Dlapackpp_DIR='$LAPACKPP_CMAKE_DIR' \
-        -Dblaspp_DIR='$BLASPP_CMAKE_DIR' \
-        -DRandom123_DIR='$RANDOM123_DIR' \
-        -DCMAKE_BUILD_RPATH='$BLASPP_LIB_DIR;$LAPACKPP_LIB_DIR;$RANDLAPACK_LIB_DIR' \
-        $DISABLE_CUDA_FLAG $MACOS_OPENMP_FLAGS &&
-    cmake --build '$RANDNLA_PROJECT_DIR/build/benchmark-build/' -j $JOBS"
+        -DFETCHCONTENT_BASE_DIR="$RANDNLA_PROJECT_DIR/build/fetchcontent-cache/" \
+        -DRandLAPACK_DIR="$RANDLAPACK_CMAKE_DIR" \
+        -Dlapackpp_DIR="$LAPACKPP_CMAKE_DIR" \
+        -Dblaspp_DIR="$BLASPP_CMAKE_DIR" \
+        -DRandom123_DIR="$RANDOM123_DIR" \
+        -DCMAKE_BUILD_RPATH="$BLASPP_LIB_DIR;$LAPACKPP_LIB_DIR;$RANDLAPACK_LIB_DIR" \
+        $DISABLE_CUDA_FLAG $MACOS_OPENMP_FLAGS
+run_step "Building benchmarks" \
+    cmake --build "$RANDNLA_PROJECT_DIR/build/benchmark-build/" -j "$JOBS"
 
 #==============================================================================
 # Shell config: opt-in only. The default prints what to add and touches nothing.

--- a/install.sh
+++ b/install.sh
@@ -260,6 +260,28 @@ RANDOM123_DIR=""
 BLASPP_LIB_DIR=""
 LAPACKPP_LIB_DIR=""
 
+# Idempotent re-runs: a dependency this project already built and installed
+# is reused as if it were external, instead of re-driving its build. This is
+# faster, and it also sidesteps an upstream blaspp defect where re-running
+# cmake over an existing build directory regenerates blas/defines.h WITHOUT
+# the Fortran-mangling and BLAS-backend defines (cached detection results
+# skip the list-building code), which then breaks every downstream compile
+# through LAPACK_GLOBAL. --fresh forces the full rebuild.
+if [[ "$FRESH" != "1" ]]; then
+    if [[ -z "${BLASPP_INSTALL_DIR:-}" ]]; then
+        PRIOR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/blaspp-install" "blaspp")
+        if [[ -n "$PRIOR" ]]; then
+            BLASPP_INSTALL_DIR="$RANDNLA_PROJECT_DIR/install/blaspp-install"
+        fi
+    fi
+    if [[ -z "${LAPACKPP_INSTALL_DIR:-}" ]]; then
+        PRIOR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/lapackpp-install" "lapackpp")
+        if [[ -n "$PRIOR" ]]; then
+            LAPACKPP_INSTALL_DIR="$RANDNLA_PROJECT_DIR/install/lapackpp-install"
+        fi
+    fi
+fi
+
 echo "Dependency discovery:"
 if [[ -n "${BLASPP_INSTALL_DIR:-}" ]]; then
     BLASPP_CMAKE_DIR=$(find_cmake_config "$BLASPP_INSTALL_DIR" "blaspp")


### PR DESCRIPTION
Adds an install-script workflow that exercises the installer the way a user would: Linux and macOS jobs run `bash install.sh --yes --no-gpu` on a fresh clone, ctest the installed library (with the usual ABRIK-instability exclusion), re-run the installer in place to verify the idempotent-re-run contract, and (Linux) install a second project through the dependency-discovery env vars from a pristine copy, asserting the reuse path was taken. blaspp/lapackpp/random123 installs are cached per OS; a hit seeds the discovery variables so the reuse path runs, a miss runs the full from-source path and repopulates the cache. A Windows job slot is reserved for the native-Windows work. This is the check that would have caught the GPU-benchmark breakage fixed in #149.

Also on this branch, found by these very jobs on their first runs:

- `install.sh` no longer routes cmake flags through a `bash -c` string: the macOS OpenMP hints carry CMake list values with semicolons, which a shell string re-parses as command separators (`-fopenmp: command not found`). Each configure/build pair is now two direct `run_step` invocations.
- `install.sh` reuses this project's own dependency installs on re-runs instead of re-driving their builds. Besides being the sensible idempotency semantics, this sidesteps an upstream blaspp defect where re-running cmake over an existing build directory regenerates `blas/defines.h` without the Fortran-mangling and backend defines, breaking everything downstream through `LAPACK_GLOBAL` (minimal repro in hand; upstream issue to follow). `--fresh` still forces full rebuilds.
- INSTALL_SCRIPT.md invocation sections updated to the new installer interface (left uncommitted in #150 by mistake).
- Core workflow drive-bys: checkout@v4, LAPACK++ built in Release instead of Debug, bogus `-DCMAKE_BINARY_DIR` removed.

**Runtime report** (same commit, same hosted runners): `install-linux` completes in **8.6 min** vs **12.5 min** for `core-linux / build`; `install-macos` completes in **6.0 min** (no core-macos comparison available on this commit). The comparison is not one-to-one — the installer job covers dependency builds, the full test suite, an idempotent re-run, and a second discovery-mode install, while the core job additionally runs the extras tests and a complete second Debug/ASan build-and-test pass — but the installer path benefits structurally from the dependency cache (warm runs skip the blaspp/lapackpp builds entirely) and from parallelism matched to the runner (`-j $(nproc)` instead of `make -j2`/`-j20`). Locally the gap is starker where it matters most to a developer: re-running the old installer rebuilt everything from scratch; re-running the new one completes in about 5 seconds.
