### PR TITLE
Packager-only external RandBLAS with a hard commit gate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,72 @@ find_package(lapackpp REQUIRED)
 # Cache lapackpp location for downstream consumers
 set(RandLAPACK_lapackpp_DIR "${lapackpp_DIR}" CACHE INTERNAL "Location of lapackpp for RandLAPACK consumers")
 
-# Configure RandBLAS subproject
-add_subdirectory(RandBLAS)
+# Configure RandBLAS.
+#
+# RandBLAS ships as a git submodule pinned to an exact commit, and that pinned
+# copy is the only RandBLAS configuration RandLAPACK is developed and tested
+# against. Do not point RandLAPACK at a RandBLAS working copy, and do not
+# develop RandBLAS inside the submodule checkout; clone RandBLAS separately
+# for that (see INSTALL.md, section "RandBLAS is a pinned submodule").
+#
+# RandLAPACK_EXTERNAL_RandBLAS exists for package maintainers only (Spack,
+# conda-forge, ...), whose recipes build RandBLAS as its own package. The
+# commit gate below makes version skew impossible: the external install must
+# have been built from exactly the commit the submodule pins.
+option(RandLAPACK_EXTERNAL_RandBLAS
+    "Packager-only: consume an installed RandBLAS instead of the pinned submodule" OFF)
+
+# The submodule pin, recorded as a variable so configure-time checks also work
+# in tarball builds (no .git directory). Update alongside every submodule
+# bump; with a git checkout present, the cross-check below enforces that.
+set(RandLAPACK_RandBLAS_PIN "8417f4bb911c6ca3aa83b157a594758d2d4fab8c")
+
+find_package(Git QUIET)
+if (Git_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_CURRENT_SOURCE_DIR} ls-tree HEAD RandBLAS
+        OUTPUT_VARIABLE randblas_pin_lstree
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET)
+    if (randblas_pin_lstree MATCHES "commit ([0-9a-f]+)")
+        set(randblas_pin_actual "${CMAKE_MATCH_1}")
+        if (NOT randblas_pin_actual STREQUAL RandLAPACK_RandBLAS_PIN)
+            message(FATAL_ERROR
+                "RandLAPACK_RandBLAS_PIN is stale: CMakeLists.txt records "
+                "${RandLAPACK_RandBLAS_PIN} but the RandBLAS submodule pins "
+                "${randblas_pin_actual}. Update the pin variable in the same "
+                "commit as the submodule bump.")
+        endif()
+    endif()
+endif()
+
+if (RandLAPACK_EXTERNAL_RandBLAS)
+    find_package(RandBLAS REQUIRED)
+    if (NOT DEFINED RandBLAS_COMMIT_HASH OR RandBLAS_COMMIT_HASH STREQUAL ""
+        OR RandBLAS_COMMIT_HASH MATCHES "see version tag")
+        message(FATAL_ERROR
+            "RandLAPACK_EXTERNAL_RandBLAS=ON, but the RandBLAS install at "
+            "RandBLAS_DIR=${RandBLAS_DIR} does not record a commit hash, so "
+            "it cannot be checked against the pinned submodule commit. Build "
+            "RandBLAS from a git checkout of commit ${RandLAPACK_RandBLAS_PIN}.")
+    endif()
+    string(FIND "${RandLAPACK_RandBLAS_PIN}" "${RandBLAS_COMMIT_HASH}" randblas_pin_prefix)
+    if (NOT randblas_pin_prefix EQUAL 0)
+        message(FATAL_ERROR
+            "RandLAPACK_EXTERNAL_RandBLAS=ON, but the RandBLAS install at "
+            "RandBLAS_DIR=${RandBLAS_DIR} was built from commit "
+            "${RandBLAS_COMMIT_HASH}, while this RandLAPACK is developed and "
+            "tested against RandBLAS ${RandLAPACK_RandBLAS_PIN} (the submodule "
+            "pin). Version skew between the two is not supported. Build the "
+            "external RandBLAS from exactly the pinned commit, or drop "
+            "RandLAPACK_EXTERNAL_RandBLAS to use the submodule. This option "
+            "is intended for package maintainers; see INSTALL.md, section "
+            "\"RandBLAS is a pinned submodule\".")
+    endif()
+    message(STATUS "RandBLAS: external install at ${RandBLAS_DIR} (commit ${RandBLAS_COMMIT_HASH}, matches the submodule pin)")
+else()
+    add_subdirectory(RandBLAS)
+endif()
 
 # Compile sources
 add_subdirectory(RandLAPACK)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -72,6 +72,28 @@ build system, *and RandLAPACK requires that they be installed via CMake.*
 RandLAPACK's git repository includes a C++ project called *RandBLAS* as a git submodule.
 RandBLAS has BLAS++ and Random123 as dependencies.
 
+### RandBLAS is a pinned submodule
+
+The RandBLAS copy inside this repository is pinned to an exact commit, and
+that pinned copy is the only RandBLAS configuration RandLAPACK is developed
+and tested against. Two rules follow:
+
+1. **Do not develop RandBLAS inside the submodule checkout.** If you want to
+   work on RandBLAS itself, clone it separately
+   (`git clone https://github.com/BallisticLA/RandBLAS.git`) and build and
+   install it as its own project. An installed RandBLAS is not consumed by
+   RandLAPACK, and nothing you install can leak into RandLAPACK builds: the
+   submodule stays authoritative.
+2. **Do not point RandLAPACK at your own RandBLAS working copy.** Version
+   skew between RandLAPACK and RandBLAS is not a supported configuration.
+
+The one sanctioned exception is for *package maintainers* (Spack,
+conda-forge, and similar), whose recipes must build RandBLAS as its own
+package: configuring RandLAPACK with `-DRandLAPACK_EXTERNAL_RandBLAS=ON`
+consumes an installed RandBLAS instead of the submodule, and a configure-time
+gate hard-fails unless that install was built from exactly the commit the
+submodule pins, so skew remains impossible by construction.
+
 We give recipes for installing BLAS++, LAPACK++, and Random123 below.
 Later on, we'll assume these recipes were executed from a directory
 that contains (or will contain) the ``RandLAPACK`` project directory as a subdirectory.


### PR DESCRIPTION
RandBLAS stays a commit-pinned submodule and the submodule remains the only supported developer configuration; INSTALL.md now says so explicitly. For package maintainers whose recipes build RandBLAS as its own package (Spack, conda-forge), -DRandLAPACK_EXTERNAL_RandBLAS=ON consumes an installed RandBLAS behind a configure-time gate: the install must record the commit it was built from (RandBLAS_COMMIT_HASH in its CMake config) and that commit must be exactly the submodule pin, else a fatal error explains the policy. The pin is recorded as a CMake variable so the gate works in tarball builds; with a git checkout present, a cross-check fails configure if the variable drifts from the actual submodule pin. Verified locally: default path unchanged; external install built from the pinned commit configures, builds the full test suite, and passes; a mismatched commit and a stale pin both fail with the intended messages. Groundwork for the Spack/conda packaging.