### PR TITLE
TEMPORARY: quarantine the macOS Accelerate gesdd test (revert after Mark's BLAS++/LAPACK++ review)

### DIFF
--- a/.github/workflows/core-macos.yaml
+++ b/.github/workflows/core-macos.yaml
@@ -86,7 +86,27 @@ jobs:
               `pwd`/../RandLAPACK
           make -j$(sysctl -n hw.ncpu)
           make -j$(sysctl -n hw.ncpu) install
-          ctest --exclude-regex "^TestABRIK\.ABRIK_catch_instability" --output-on-failure
+          #####################################################################
+          ## TEMPORARY -- REVERT THIS ENTIRE BLOCK                            ##
+          ##                                                                  ##
+          ## TestQB.Polynomial_Decay_general1 fails on Apple Silicon because  ##
+          ## Apple's OLD Accelerate LAPACK has a broken divide-and-conquer    ##
+          ## gesdd. It is quarantined here ONLY to stop core-macos being      ##
+          ## permanently red, which trained everyone to ignore this job.      ##
+          ##                                                                  ##
+          ## REVERT AS SOON AS Mark has reviewed the BLAS++ / LAPACK++ work   ##
+          ## that migrates to the new Accelerate interface. The test is still ##
+          ## RUN below, so its result is not lost: if it starts PASSING, the  ##
+          ## job prints a loud warning telling you to delete this block.      ##
+          #####################################################################
+          ctest --exclude-regex "^TestABRIK\.ABRIK_catch_instability|^TestQB\.Polynomial_Decay_general1" \
+                --output-on-failure
+          echo "::warning title=TEMPORARY macOS suppression is ACTIVE::TestQB.Polynomial_Decay_general1 is quarantined (Apple Accelerate gesdd bug). REVERT once Mark has reviewed the BLAS++/LAPACK++ Accelerate migration. See docs/CI.md."
+          if ctest --tests-regex "^TestQB\.Polynomial_Decay_general1" --output-on-failure; then
+            echo "::warning title=DELETE THE macOS SUPPRESSION::TestQB.Polynomial_Decay_general1 now PASSES. The Accelerate gesdd bug appears fixed -- remove the quarantine block in .github/workflows/core-macos.yaml and the note in docs/CI.md."
+          else
+            echo "::notice title=Quarantined test still failing (expected)::TestQB.Polynomial_Decay_general1 still fails, as expected while Apple's old Accelerate gesdd is in use. The suppression is still needed."
+          fi
 
       - name: build and test extras
         run: |
@@ -185,4 +205,24 @@ jobs:
               `pwd`/../RandLAPACK
           make -j$(sysctl -n hw.ncpu)
           make -j$(sysctl -n hw.ncpu) install
-          ctest --exclude-regex "^TestABRIK\.ABRIK_catch_instability" --output-on-failure
+          #####################################################################
+          ## TEMPORARY -- REVERT THIS ENTIRE BLOCK                            ##
+          ##                                                                  ##
+          ## TestQB.Polynomial_Decay_general1 fails on Apple Silicon because  ##
+          ## Apple's OLD Accelerate LAPACK has a broken divide-and-conquer    ##
+          ## gesdd. It is quarantined here ONLY to stop core-macos being      ##
+          ## permanently red, which trained everyone to ignore this job.      ##
+          ##                                                                  ##
+          ## REVERT AS SOON AS Mark has reviewed the BLAS++ / LAPACK++ work   ##
+          ## that migrates to the new Accelerate interface. The test is still ##
+          ## RUN below, so its result is not lost: if it starts PASSING, the  ##
+          ## job prints a loud warning telling you to delete this block.      ##
+          #####################################################################
+          ctest --exclude-regex "^TestABRIK\.ABRIK_catch_instability|^TestQB\.Polynomial_Decay_general1" \
+                --output-on-failure
+          echo "::warning title=TEMPORARY macOS suppression is ACTIVE::TestQB.Polynomial_Decay_general1 is quarantined (Apple Accelerate gesdd bug). REVERT once Mark has reviewed the BLAS++/LAPACK++ Accelerate migration. See docs/CI.md."
+          if ctest --tests-regex "^TestQB\.Polynomial_Decay_general1" --output-on-failure; then
+            echo "::warning title=DELETE THE macOS SUPPRESSION::TestQB.Polynomial_Decay_general1 now PASSES. The Accelerate gesdd bug appears fixed -- remove the quarantine block in .github/workflows/core-macos.yaml and the note in docs/CI.md."
+          else
+            echo "::notice title=Quarantined test still failing (expected)::TestQB.Polynomial_Decay_general1 still fails, as expected while Apple's old Accelerate gesdd is in use. The suppression is still needed."
+          fi

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -24,12 +24,24 @@ candidates once they have a green track record.
 
 ## Things that are deliberate (do not "fix" without reading this)
 
-- **core-macos is red on purpose.** `TestQB.Polynomial_Decay_general1` fails
-  on Apple Silicon because Apple's default (old) Accelerate LAPACK has a
-  broken divide-and-conquer `gesdd`. The failure is kept as a canary: when
-  the planned migration to the new Accelerate interface happens, this test
-  flipping green is the evidence the bug is gone. A local fix exists
-  (reference SVD via `gesvd`) but is intentionally unmerged.
+- **`TestQB.Polynomial_Decay_general1` is QUARANTINED on macOS -- THIS IS
+  TEMPORARY AND MUST BE REVERTED.** The test fails on Apple Silicon because
+  Apple's default (old) Accelerate LAPACK has a broken divide-and-conquer
+  `gesdd`. It was previously left failing as a canary, which made core-macos
+  permanently red and trained everyone to ignore the job -- a red CI lane that
+  is always red reports nothing.
+
+  **Revert as soon as Mark has reviewed the BLAS++ / LAPACK++ work migrating
+  to the new Accelerate interface.** Delete the marked block in
+  `.github/workflows/core-macos.yaml` (both `build` and `build-asan`) and this
+  entry.
+
+  The canary is deliberately preserved: the test is still *run*, separately,
+  and cannot fail the job. Every macOS run prints a warning that the
+  suppression is active, and if the test ever **passes** the job prints a
+  louder one telling you to delete the quarantine -- which is exactly the
+  signal the old always-red arrangement was supposed to provide. A local fix
+  exists (reference SVD via `gesvd`) but is intentionally unmerged.
 - **The RandBLAS submodule's own tests do not run here**
   (`-DBUILD_TESTS=OFF` in the core recipes). The pinned commit is already
   tested by RandBLAS's CI; rebuilding its ~450 tests in every RandLAPACK job

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -31,10 +31,20 @@ candidates once they have a green track record.
   permanently red and trained everyone to ignore the job -- a red CI lane that
   is always red reports nothing.
 
-  **Revert as soon as Mark has reviewed the BLAS++ / LAPACK++ work migrating
-  to the new Accelerate interface.** Delete the marked block in
-  `.github/workflows/core-macos.yaml` (both `build` and `build-asan`) and this
-  entry.
+  **Revert once Apple's new Accelerate interface is in use**, i.e. when both
+  of these land (order matters -- lapackpp#88 needs the `defines.h` from
+  blaspp#134):
+    - <https://github.com/icl-utk-edu/blaspp/pull/134> -- New Apple Accelerate
+      support, a rebased and completed continuation of the stalled
+      <https://github.com/icl-utk-edu/blaspp/pull/74>
+    - <https://github.com/icl-utk-edu/lapackpp/pull/88> -- Support Apple's new
+      Accelerate interface
+
+  Then RandLAPACK PR #155 (retire legacy-Accelerate accommodations) becomes
+  mergeable, `TestQB.Polynomial_Decay_general1` should pass on its own, and
+  the "DELETE THE macOS SUPPRESSION" warning below will fire. Delete the
+  marked block in `.github/workflows/core-macos.yaml` (both `build` and
+  `build-asan`) and this entry.
 
   The canary is deliberately preserved: the test is still *run*, separately,
   and cannot fail the job. Every macOS run prints a warning that the


### PR DESCRIPTION
> [!WARNING]
> **This is a temporary change and is meant to be reverted.**
> It is one clean `git revert` of a single commit.

### Revert when these land

The quarantine exists only until Apple's new Accelerate interface is in use. Both are open and awaiting review:

| PR | Status |
|---|---|
| [icl-utk-edu/blaspp#134](https://github.com/icl-utk-edu/blaspp/pull/134) — New Apple Accelerate support (#74, rebased and completed) | open |
| [icl-utk-edu/lapackpp#88](https://github.com/icl-utk-edu/lapackpp/pull/88) — Support Apple's new Accelerate interface (closes #43) | open |

**Order matters:** lapackpp#88 depends on the `defines.h` from blaspp#134, so #134 merges first. blaspp#134 is a rebased and completed continuation of the stalled [blaspp#74](https://github.com/icl-utk-edu/blaspp/pull/74).

Once both are merged, [RandLAPACK#155](https://github.com/BallisticLA/RandLAPACK/pull/155) (retire legacy-Accelerate accommodations) becomes mergeable and `TestQB.Polynomial_Decay_general1` should pass on its own — at which point the warning added here fires and tells you to delete this quarantine.

## Why

`TestQB.Polynomial_Decay_general1` fails on Apple Silicon because Apple's old Accelerate LAPACK has a broken divide-and-conquer `gesdd`. It has been left failing deliberately, as a canary for the planned migration.

The side effect is that **`core-macos` has been permanently red** — `build` and `build-asan`, on `main` and on every branch. A lane that is always red carries no information: you cannot distinguish a new macOS regression from the known one, so the job gets ignored and the canary signals to nobody.

## What this does

Quarantines the test without discarding the signal:

- The main `ctest` run excludes it, so the job reflects real macOS health.
- The test is then **still run**, separately, and cannot fail the job.
- Every macOS run prints a warning that the suppression is active and names the condition for removing it.
- If the test ever **passes**, the job prints a louder warning saying to delete the quarantine.

That last point matters: the migration signal is preserved and actually improved. Previously it was "a red job turns green", which nobody was watching because the job was always red. Now it is an explicit annotation telling you what to delete.

## Scope

Deliberately surgical — `core-macos.yaml` (both jobs) and the corresponding `docs/CI.md` entry, nothing else, so the revert stays clean. The dead `TestABRIK.ABRIK_catch_instability` exclusion in these same lines is left alone for that reason.
