### PR TITLE
CI: stop running every job twice, and supersede in-flight pull-request runs

### DIFF
--- a/.github/workflows/core-linux.yaml
+++ b/.github/workflows/core-linux.yaml
@@ -4,9 +4,19 @@ on:
     branches-ignore:
       - cqrrp-gpu-benchmarking
   workflow_dispatch:
+  # Only main. A branch with an open pull request is already covered by the
+  # pull_request event above, and firing on both ran every job twice per
+  # commit -- same SHA, same result.
   push:
-    branches-ignore:
-      - cqrrp-gpu-benchmarking
+    branches:
+      - main
+
+# One run per ref at a time. Pushing a fix used to leave the superseded run
+# going to completion. Superseding is only safe for pull requests: on main we
+# want every commit validated, not just the newest.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # BLAS++/LAPACK++/Random123 track their upstream default branches but change
 # rarely; their installs are cached below. Bump the -v suffix in the cache key

--- a/.github/workflows/core-macos.yaml
+++ b/.github/workflows/core-macos.yaml
@@ -4,9 +4,19 @@ on:
     branches-ignore:
       - cqrrp-gpu-benchmarking
   workflow_dispatch:
+  # Only main. A branch with an open pull request is already covered by the
+  # pull_request event above, and firing on both ran every job twice per
+  # commit -- same SHA, same result.
   push:
-    branches-ignore:
-      - cqrrp-gpu-benchmarking
+    branches:
+      - main
+
+# One run per ref at a time. Pushing a fix used to leave the superseded run
+# going to completion. Superseding is only safe for pull requests: on main we
+# want every commit validated, not just the newest.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Dependency installs are cached and the RandBLAS submodule's own test suite
 # is disabled; see core-linux.yaml for the reasoning.

--- a/.github/workflows/core-windows.yaml
+++ b/.github/workflows/core-windows.yaml
@@ -4,9 +4,19 @@ on:
     branches-ignore:
       - cqrrp-gpu-benchmarking
   workflow_dispatch:
+  # Only main. A branch with an open pull request is already covered by the
+  # pull_request event above, and firing on both ran every job twice per
+  # commit -- same SHA, same result.
   push:
-    branches-ignore:
-      - cqrrp-gpu-benchmarking
+    branches:
+      - main
+
+# One run per ref at a time. Pushing a fix used to leave the superseded run
+# going to completion. Superseding is only safe for pull requests: on main we
+# want every commit validated, not just the newest.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-windows:

--- a/.github/workflows/install-script.yaml
+++ b/.github/workflows/install-script.yaml
@@ -16,9 +16,19 @@ on:
     branches-ignore:
       - cqrrp-gpu-benchmarking
   workflow_dispatch:
+  # Only main. A branch with an open pull request is already covered by the
+  # pull_request event above, and firing on both ran every job twice per
+  # commit -- same SHA, same result.
   push:
-    branches-ignore:
-      - cqrrp-gpu-benchmarking
+    branches:
+      - main
+
+# One run per ref at a time. Pushing a fix used to leave the superseded run
+# going to completion. Superseding is only safe for pull requests: on main we
+# want every commit validated, not just the newest.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   install-linux:

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -24,6 +24,19 @@ candidates once they have a green track record.
 
 ## Things that are deliberate (do not "fix" without reading this)
 
+- **Workflows fire on `pull_request`, and on `push` only for `main`.** They
+  used to fire on `push` for every branch as well, so each commit on a pull
+  request ran every job twice -- same SHA, same result, double the minutes.
+  A branch with an open pull request is covered by the `pull_request` event;
+  `main` still gets a run of its own. The one thing this drops is CI for a
+  branch with no pull request open, which `workflow_dispatch` covers on
+  demand.
+- **`concurrency` supersedes in-flight runs, for pull requests only.** Pushing
+  a fix used to leave the previous run going to completion. On `main`,
+  `cancel-in-progress` is deliberately false: every commit there should be
+  validated, not just the newest.
+
+
 - **`TestQB.Polynomial_Decay_general1` is QUARANTINED on macOS -- THIS IS
   TEMPORARY AND MUST BE REVERTED.** The test fails on Apple Silicon because
   Apple's default (old) Accelerate LAPACK has a broken divide-and-conquer


### PR DESCRIPTION
Two independent sources of wasted CI. Both repo-wide, both pre-existing, one line each.

## Every job ran twice

All four workflows fired on `pull_request` **and** on `push` for every branch. On a pull request that means each commit runs every job twice — same SHA, same result:

```
1  pull_request  core-linux        1  push  core-linux
1  pull_request  core-macos        1  push  core-macos
1  pull_request  core-windows      1  push  core-windows
1  pull_request  install-script    1  push  install-script
```

11 jobs across the four workflows, so **22 check runs per commit, half of them redundant**.

`push` is now restricted to `main`. A branch with an open pull request is covered by the `pull_request` event; `main` still gets a run of its own.

## Nothing cancelled superseded runs

Pushing a fix while CI was in flight left the previous run going to completion, including a full Windows matrix. A `concurrency` group now supersedes in-flight runs — **for pull requests only**. On `main`, `cancel-in-progress` is deliberately `false`: every commit there should be validated, not just the newest.

## What this removes

Automatic CI for a branch with **no pull request open**. `workflow_dispatch` covers that on demand and is already declared in all four workflows. That is the only behaviour change; if anyone relies on push-triggered CI for branchless work, this is the line to object to.

## Not included

The remaining idea worth doing separately: `windows-toolchain-guards`'s decision-table step needs no MSVC and could run on a Linux runner under `pwsh`, which bills at half the Windows rate. It needs path-separator fixes first, and it touches a file another PR is currently changing.

Rationale is recorded in `docs/CI.md` so neither change gets "tidied" back.