### PR TITLE
CI: fix the broken oneMKL cache path and drop a dead ctest exclusion

### DIFF
--- a/.github/actions/setup-randlapack-deps-windows/action.yml
+++ b/.github/actions/setup-randlapack-deps-windows/action.yml
@@ -26,11 +26,17 @@ runs:
     # install-script workflow checks this repo out under RandLAPACK\, where
     # the glob matches nothing and hashFiles() silently returns "" -- the two
     # workflows then read/write DIFFERENT caches while appearing to share.
+    # The version in `path` must match $mklVersion in setup.ps1, which is what
+    # names the directory it creates. It did not: the path still said
+    # 2025.2.0.627 after the bump to 2026.1.0.226, so it pointed at a directory
+    # that never exists. That fails quietly in the worst way -- every MKL leg
+    # re-downloaded 155 MB and then saved a cache entry for a missing path, so
+    # the cache could never hit and nothing ever reported an error.
     - name: cache oneMKL (NuGet)
       if: inputs.blas-backend == 'mkl'
       uses: actions/cache@v4
       with:
-        path: ${{ github.workspace }}\..\windows-deps\onemkl-2025.2.0.627
+        path: ${{ github.workspace }}\..\windows-deps\onemkl-2026.1.0.226
         key: windows-nuget-intel-mkl-2026.1.0.226-r1
 
     - name: cache OpenBLAS (release binaries)

--- a/.github/workflows/core-linux.yaml
+++ b/.github/workflows/core-linux.yaml
@@ -108,7 +108,7 @@ jobs:
               `pwd`/../RandLAPACK
           make -j$(nproc)
           make -j$(nproc) install
-          ctest --exclude-regex "^TestABRIK\.ABRIK_catch_instability" --output-on-failure
+          ctest --output-on-failure
 
       - name: build and test extras
         run: |
@@ -208,4 +208,4 @@ jobs:
               `pwd`/../RandLAPACK
           make -j$(nproc)
           make -j$(nproc) install
-          ctest --exclude-regex "^TestABRIK\.ABRIK_catch_instability" --output-on-failure
+          ctest --output-on-failure

--- a/.github/workflows/core-macos.yaml
+++ b/.github/workflows/core-macos.yaml
@@ -109,7 +109,7 @@ jobs:
           ## RUN below, so its result is not lost: if it starts PASSING, the  ##
           ## job prints a loud warning telling you to delete this block.      ##
           #####################################################################
-          ctest --exclude-regex "^TestABRIK\.ABRIK_catch_instability|^TestQB\.Polynomial_Decay_general1" \
+          ctest --exclude-regex "^TestQB\.Polynomial_Decay_general1" \
                 --output-on-failure
           echo "::warning title=TEMPORARY macOS suppression is ACTIVE::TestQB.Polynomial_Decay_general1 is quarantined (Apple Accelerate gesdd bug). REVERT once Mark has reviewed the BLAS++/LAPACK++ Accelerate migration. See docs/CI.md."
           if ctest --tests-regex "^TestQB\.Polynomial_Decay_general1" --output-on-failure; then
@@ -228,7 +228,7 @@ jobs:
           ## RUN below, so its result is not lost: if it starts PASSING, the  ##
           ## job prints a loud warning telling you to delete this block.      ##
           #####################################################################
-          ctest --exclude-regex "^TestABRIK\.ABRIK_catch_instability|^TestQB\.Polynomial_Decay_general1" \
+          ctest --exclude-regex "^TestQB\.Polynomial_Decay_general1" \
                 --output-on-failure
           echo "::warning title=TEMPORARY macOS suppression is ACTIVE::TestQB.Polynomial_Decay_general1 is quarantined (Apple Accelerate gesdd bug). REVERT once Mark has reviewed the BLAS++/LAPACK++ Accelerate migration. See docs/CI.md."
           if ctest --tests-regex "^TestQB\.Polynomial_Decay_general1" --output-on-failure; then

--- a/.github/workflows/install-script.yaml
+++ b/.github/workflows/install-script.yaml
@@ -80,7 +80,6 @@ jobs:
       - name: test the installed library
         run: |
           ctest --test-dir RandNLA-project/build/RandLAPACK-build \
-                --exclude-regex "^TestABRIK\.ABRIK_catch_instability" \
                 --output-on-failure
 
       - name: re-run the installer in place (idempotency)
@@ -113,7 +112,6 @@ jobs:
       - name: test the installed library
         run: |
           ctest --test-dir RandNLA-project/build/RandLAPACK-build \
-                --exclude-regex "^TestABRIK\.ABRIK_catch_instability" \
                 --output-on-failure
 
       - name: re-run the installer in place (idempotency)


### PR DESCRIPTION
## Problem

Two unrelated CI defects, both of which fail quietly rather than loudly.

**The Windows oneMKL cache has never hit.** `action.yml` pointed `path` at `windows-deps\onemkl-2025.2.0.627`, while `setup.ps1` creates `onemkl-$mklVersion` with `$mklVersion = "2026.1.0.226"` (`setup.ps1:384,390`). The path was left behind when the version was bumped, so it names a directory that does not exist.

Nothing reports an error. `actions/cache` looks up a key, misses, the job re-downloads **155 MB** of oneMKL, and then the post-job step saves a cache entry for a path that isn't there. So the cache can never hit, on every MKL leg, indefinitely. The key already said `2026.1.0.226` — only the path was stale.

**A `ctest` exclusion for a test that does not exist.** `--exclude-regex "^TestABRIK\.ABRIK_catch_instability"` appears at six sites. That test is nowhere in `test/` or `RandLAPACK/`, and `git log -S` finds no history of it there under that name, so it has always been excluding nothing.

The cost isn't the wasted filter. It's the misdirection: a `ctest` line carrying an exclusion reads as though a known failure is being suppressed, which invites exactly the wrong conclusion when someone audits what the suite actually covers.

## What this PR does

1. **Corrects the cache path** to `onemkl-2026.1.0.226`, and adds a comment recording that the version there must track `$mklVersion` in `setup.ps1`. Every other path/key pair in that file was checked and is consistent — OpenBLAS, GoogleTest, GoogleTest-ASan, Random123, BLAS++ and LAPACK++ all agree.
2. **Removes the dead exclusion** from all six sites: `core-linux.yaml` (×2), `install-script.yaml` (×2), `core-macos.yaml` (×2).

## Notes for reviewers

- **The macOS change is deliberately partial.** There the regex was an alternation with `TestQB.Polynomial_Decay_general1`, which is the *real* Apple Accelerate `gesdd` quarantine from #157. Only the dead ABRIK half is removed; the quarantine, its "suppression is ACTIVE" warning, and the check that shouts if the test starts passing are all untouched.
- Expect the first Windows MKL leg after this merges to still be slow — it has to populate the cache once. Subsequent runs are where the 155 MB comes back.
- This is the first of a short series bringing RandLAPACK's `install.sh` up to the standard `install.ps1` reached in #156, mirroring the RandBLAS installer work. It is independent of the rest and useful on its own.
