### PR TITLE
Installer overhaul: pins, provenance, a run-not-just-link BLAS check, backend selection, and docs

### DIFF
--- a/.github/workflows/install-script.yaml
+++ b/.github/workflows/install-script.yaml
@@ -56,26 +56,47 @@ jobs:
           path: deps-install
           key: installer-deps-${{ runner.os }}-v1
 
+      # Globbed rather than spelled out: dependency install directories carry
+      # the backend and GPU configuration in their names (blaspp-openblas-cpu-install),
+      # so hardcoding them here would couple CI to that naming and break the
+      # moment it changes.
       - name: seed discovery variables from cache
         if: steps.deps-cache.outputs.cache-hit == 'true'
         run: |
-          echo "BLASPP_INSTALL_DIR=$GITHUB_WORKSPACE/deps-install/blaspp-install" >> "$GITHUB_ENV"
-          echo "LAPACKPP_INSTALL_DIR=$GITHUB_WORKSPACE/deps-install/lapackpp-install" >> "$GITHUB_ENV"
+          set -euo pipefail
+          echo "BLASPP_INSTALL_DIR=$(echo "$GITHUB_WORKSPACE"/deps-install/blaspp-*-install)" >> "$GITHUB_ENV"
+          echo "LAPACKPP_INSTALL_DIR=$(echo "$GITHUB_WORKSPACE"/deps-install/lapackpp-*-install)" >> "$GITHUB_ENV"
           echo "RANDOM123_INSTALL_DIR=$GITHUB_WORKSPACE/deps-install/random123" >> "$GITHUB_ENV"
 
       - name: keep a pristine clone for the discovery test
         run: cp -a RandLAPACK RandLAPACK-discovery
 
       - name: run the installer (non-interactive)
-        run: bash RandLAPACK/install.sh --yes --no-gpu
+        run: |
+          set -euo pipefail
+          bash RandLAPACK/install.sh --yes --no-gpu 2>&1 | tee installer.out
+
+      # Redirected output must carry no ANSI escapes and no carriage returns.
+      # The installer draws a progress bar on a terminal; without this check,
+      # that bar could start filling install.log and every CI transcript with
+      # control characters and nobody would notice until a log was unreadable.
+      - name: piped output is free of terminal control sequences
+        run: |
+          if LC_ALL=C grep -qP '\x1b\[|\r' installer.out; then
+            echo "Found terminal control sequences in non-TTY output:"
+            LC_ALL=C grep -nP '\x1b\[|\r' installer.out | head -20
+            exit 1
+          fi
+          echo "OK: no escape sequences in redirected output."
 
       - name: populate the dependency cache
         if: steps.deps-cache.outputs.cache-hit != 'true'
         run: |
+          set -euo pipefail
           mkdir -p deps-install
-          cp -a RandNLA-project/install/blaspp-install   deps-install/
-          cp -a RandNLA-project/install/lapackpp-install deps-install/
-          cp -a RandNLA-project/install/random123        deps-install/
+          cp -a RandNLA-project/install/blaspp-*-install   deps-install/
+          cp -a RandNLA-project/install/lapackpp-*-install deps-install/
+          cp -a RandNLA-project/install/random123          deps-install/
 
       - name: test the installed library
         run: |
@@ -87,13 +108,14 @@ jobs:
 
       - name: install a second project via dependency discovery
         run: |
-          BLASPP_INSTALL_DIR="$GITHUB_WORKSPACE/deps-install/blaspp-install" \
-          LAPACKPP_INSTALL_DIR="$GITHUB_WORKSPACE/deps-install/lapackpp-install" \
+          set -euo pipefail
+          BLASPP_INSTALL_DIR="$(echo "$GITHUB_WORKSPACE"/deps-install/blaspp-*-install)" \
+          LAPACKPP_INSTALL_DIR="$(echo "$GITHUB_WORKSPACE"/deps-install/lapackpp-*-install)" \
           RANDOM123_INSTALL_DIR="$GITHUB_WORKSPACE/deps-install/random123" \
           bash RandLAPACK-discovery/install.sh --yes --no-gpu \
               --project-dir "$GITHUB_WORKSPACE/RandNLA-project-discovery" \
               | tee discovery.out
-          grep -q "reused external install" discovery.out
+          grep -q "external install" discovery.out
           test -d RandNLA-project-discovery/build/RandLAPACK-build
 
   install-macos:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ option(RandLAPACK_EXTERNAL_RandBLAS
 # The submodule pin, recorded as a variable so configure-time checks also work
 # in tarball builds (no .git directory). Update alongside every submodule
 # bump; with a git checkout present, the cross-check below enforces that.
-set(RandLAPACK_RandBLAS_PIN "04f2018afdb29a9478ae70cb1a52b36a9156146f")
+set(RandLAPACK_RandBLAS_PIN "952251cf9dd386452ea9a88e553c9966513e85d1")
 
 find_package(Git QUIET)
 if (Git_FOUND AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")

--- a/INSTALL_SCRIPT.md
+++ b/INSTALL_SCRIPT.md
@@ -90,15 +90,26 @@ The install script expects a specific directory structure:
 
 ```
 ~/RandNLA/
-├── RandLAPACK/          # Clone RandLAPACK here (script will move it)
-└── RandNLA-project/     # Created automatically by script
+├── RandLAPACK/               # Your clone. The script does NOT move it.
+└── RandNLA-project/          # Created automatically
     ├── lib/
-    │   ├── blaspp/      # Built by script
-    │   ├── lapackpp/    # Built by script
-    │   ├── random123/   # Built by script
-    │   └── RandLAPACK/  # Moved here by script
-    └── build/           # Build artifacts
+    │   ├── blaspp/           # Source, fetched at a pinned commit
+    │   ├── lapackpp/         # Source, fetched at a pinned commit
+    │   └── RandLAPACK -> ../../RandLAPACK   # Symlink to your clone
+    ├── install/
+    │   ├── blaspp-<backend>-<cpu|cuda>-install
+    │   ├── lapackpp-<backend>-<cpu|cuda>-install
+    │   ├── random123/
+    │   └── RandLAPACK-install
+    └── build/                # One build directory per project above
 ```
+
+Two things worth noting. **Your clone stays where you put it** — earlier
+versions of this script relocated it into `lib/`, which broke git worktrees;
+`lib/RandLAPACK` is now a symlink. And the dependency install directories carry
+the backend and GPU configuration in their names, so an ILP64 MKL build and an
+LP64 OpenBLAS build, or a CUDA and a CPU build, cannot be mistaken for each
+other or silently reused for one another.
 
 ### Initial Setup
 
@@ -144,16 +155,57 @@ Run `bash install.sh --help` for the full option list. The main flags, each
 with an environment-variable equivalent:
 
 ```
--y, --yes             assume "yes" for every prompt
+--blas=BACKEND        auto | openblas | mkl | accelerate | custom
+                      (default: auto -- OpenBLAS on macOS, MKL on Linux when
+                      MKLROOT is set, otherwise OpenBLAS)
+--blas-int=WIDTH      ilp64 | lp64 (default: ilp64 where the backend can
+                      provide it; see section 6)
+--blas-libraries=L    link line for --blas=custom, used for BLAS and LAPACK
     --gpu / --no-gpu  decide GPU support without asking
--j, --jobs <N>        parallel build jobs (default: number of cores)
+--project-dir=DIR     place/locate RandNLA-project at DIR (default:
+                      $RANDNLA_PROJECT_DIR if set, else ../RandNLA-project)
+--prefix=DIR          install RandLAPACK itself here instead of
+                      <project-dir>/install/RandLAPACK-install
+-j, --jobs N          parallel build jobs (default: number of cores)
     --fresh           clear build directories first (default: reuse them,
                       so re-running is an incremental rebuild)
+    --no-extras       skip the extras project
+    --no-benchmarks   skip the benchmark project
+    --no-openmp       configure without OpenMP
+-y, --yes             assume "yes" for every prompt
     --modify-rc       append RANDNLA_PROJECT_DIR/RANDNLA_PROJECT_GPU_AVAIL
                       exports to your shell config (default: never touch it;
                       the summary prints the lines to add yourself)
-    --project-dir <D> place/locate RandNLA-project at D
+    --no-progress     plain one-line-per-step output, no redrawing
 ```
+
+Extras and benchmarks are built **by default**; `--no-extras` and
+`--no-benchmarks` opt out. They need nothing the script has not already built,
+so leaving them on costs only time. (RandBLAS's installer makes its `examples/`
+opt-in instead, because those pull in dependencies RandBLAS itself does not.)
+
+### Sharing one dependency tree with RandBLAS
+
+Both installers use the same `RandNLA-project` layout and both honour
+`RANDNLA_PROJECT_DIR`, so setting it once keeps everything in one place:
+
+```shell
+export RANDNLA_PROJECT_DIR=$HOME/RandNLA-project
+```
+
+That shares the *location*, not the artifacts. Each project builds its own
+BLAS++ into a separately named directory — `blaspp-mkl-cpu-install` here versus
+`blaspp-mkl-install` for RandBLAS — deliberately, so neither can overwrite the
+other's dependency while its provenance stamp still describes the original.
+
+To genuinely reuse one BLAS++ across both, name it:
+
+```shell
+BLASPP_INSTALL_DIR=$RANDNLA_PROJECT_DIR/install/blaspp-mkl-install bash install.sh
+```
+
+The install then verifies that choice by compiling, linking and running against
+it rather than trusting it.
 
 ### Automated Installation (Non-Interactive)
 
@@ -175,32 +227,39 @@ the last lines of the log. There is no need to tee the output yourself.
 
 The `install.sh` script performs the following steps automatically:
 
-1. **Creates Project Structure**
-   - Creates `~/RandNLA/RandNLA-project/` directory tree
-   - Sets up subdirectories for libraries and build artifacts
+1. **Creates the project structure** shown in section 1, and initialises the
+   RandBLAS submodule. RandBLAS stays a pinned submodule and is not installed
+   separately; its own installer exists for people who want RandBLAS alone.
 
-2. **Builds BLAS++**
-   - Clones BLAS++ from official repository
-   - Configures with appropriate BLAS backend (MKL if available)
-   - Builds with GPU support if requested
-   - Installs to `~/RandNLA/RandNLA-project/lib/blaspp/`
+2. **Checks the toolchain** — compiler, CMake 3.21+, Git — reporting everything
+   missing at once rather than failing on the first item.
 
-3. **Builds LAPACK++**
-   - Clones LAPACK++ from official repository
-   - Configures to use previously built BLAS++
-   - Builds with GPU support if requested
-   - Installs to `~/RandNLA/RandNLA-project/lib/lapackpp/`
+3. **Builds BLAS++** at a pinned commit, with the selected backend and integer
+   width, then **reads back the width it actually built** (section 6).
 
-4. **Installs Random123**
-   - Clones Random123 header-only library
-   - Installs headers to `~/RandNLA/RandNLA-project/lib/random123/`
+4. **Builds LAPACK++** at a pinned commit against that BLAS++.
 
-5. **Moves and Builds RandLAPACK**
-   - Moves `RandLAPACK` directory to `~/RandNLA/RandNLA-project/lib/`
-   - Configures CMake with all dependency paths
-   - Builds RandLAPACK library
-   - Builds test suite and benchmarks
-   - Creates executables in `~/RandNLA/RandNLA-project/build/RandLAPACK-build/bin/`
+5. **Installs Random123** (header-only) at a pinned tag.
+
+6. **Builds and installs RandLAPACK**, then **verifies the result by running
+   it**: a small program is compiled, linked and executed against the finished
+   install, checking a BLAS++ `gemm` and a LAPACK++ `gesdd` numerically.
+
+   This step is not ceremony. A configuration that merely *configures* can
+   still be broken in ways nothing catches by inspection — most importantly, if
+   BLAS++'s headers were built for one integer width while the library actually
+   loaded uses another, the guards inside BLAS++ compile out and the symptom is
+   an absurd workspace size and a run that never finishes rather than an error.
+   Only executing something finds that.
+
+7. **Builds the extras and benchmark projects**, unless `--no-extras` or
+   `--no-benchmarks`.
+
+Every dependency is fetched at an immutable ref and stamped with its
+provenance, so it is reused only when it came from the same source *in the same
+configuration* — backend, integer width and GPU setting all count. Switching
+`--no-gpu` to `--gpu` therefore rebuilds BLAS++ rather than silently reusing a
+CPU-only one.
 
 ## 4. Verifying the Installation
 
@@ -269,6 +328,95 @@ CMake projects. You'll need to specify:
 -DRandBLAS_DIR=~/RandNLA/RandNLA-project/build/RandLAPACK-build/RandBLAS
 -DRandLAPACK_DIR=~/RandNLA/RandNLA-project/build/RandLAPACK-build
 ```
+
+---
+
+## 6. Integer width, backends, and tested configurations
+
+### 6.1 What we test
+
+Every row below corresponds to a CI lane, so this is a statement about what is
+exercised on each commit rather than what ought to work. Anything absent may
+well work; it is simply untested.
+
+| OS | Compiler | BLAS backend | Integer width | GPU | OpenMP |
+|---|---|---|---|---|---|
+| Ubuntu (latest) | gcc | OpenBLAS | LP64 | none | yes |
+| Ubuntu (latest) | gcc | oneMKL | ILP64 | none | yes |
+| Ubuntu (latest) | clang | OpenBLAS | LP64 | none | yes |
+| macOS 14/15 | Apple Clang | Accelerate | LP64 | none | no (see below) |
+| Windows | MSVC | oneMKL | ILP64 | none | yes (`/openmp:llvm`) |
+
+The installer lanes additionally cover a fresh install, an idempotent re-run,
+and dependency discovery through `BLASPP_INSTALL_DIR` and friends.
+
+Compiler floor: **gcc >= 13**, because RandBLAS (vendored as a submodule) uses
+C++20 concepts. CMake 3.21 or later on every platform. Apple Clang ships no
+OpenMP runtime, so a macOS build is single-threaded unless you install
+Homebrew's `libomp`, which the installer will use when present.
+
+CUDA builds are not covered by CI — there is no GPU runner — so `--gpu` is
+exercised locally only. CUDA 12.9 with gcc 13.3 is the reference combination.
+
+### 6.2 Which integer width you get, and why
+
+A BLAS comes in one of two flavours: **LP64** uses 32-bit integers for matrix
+dimensions, **ILP64** uses 64-bit. The installer prefers ILP64 wherever the
+backend can genuinely provide it:
+
+| `--blas=` | Width you get | Why |
+|---|---|---|
+| `mkl` | ILP64 | `mkl_intel_ilp64` is a separate library, so requesting it actually selects it |
+| `openblas` | LP64, with a warning | there is only `-lopenblas`, so the request selects nothing |
+| `accelerate` | LP64 | BLAS++ implements only Apple's legacy interface (upstream `icl-utk-edu/lapackpp#43`) |
+| `custom` | whatever you pass | you named the library, so its width is yours to state |
+
+The OpenBLAS row deserves explaining, because it is counter-intuitive. BLAS++
+probes `int32` before `int64`, and `blas_int` only filters which *library names*
+to consider. With one candidate name, a plain LP64 OpenBLAS passes the `int32`
+probe and is accepted — so a successful `blas_int=int64` configure proves
+nothing. The installer therefore reads the width back out of BLAS++'s generated
+`blas/defines.h` after building, and reports what was actually produced.
+
+ILP64 OpenBLAS **does** exist (`libopenblas64`, from Debian/Ubuntu's
+`libopenblas64-dev` or Fedora's `openblas64`); BLAS++ just never looks for it.
+Until that is fixed upstream, name it explicitly:
+
+```shell
+bash install.sh --blas=custom --blas-int=ilp64 \
+  --blas-libraries=/usr/lib/x86_64-linux-gnu/libopenblas64.so
+```
+
+### 6.3 Does LP64 limit RandLAPACK?
+
+Rarely, and it fails loudly rather than silently. RandLAPACK is `int64_t`
+throughout, and BLAS++/LAPACK++ **throw** rather than truncate when a value
+exceeds the BLAS's range (`to_blas_int`, `to_lapack_int`), naming the offending
+argument. The guard is on individual dimensions and leading dimensions, not
+element counts — the BLAS never receives `m*n` — so a 100,000 x 100,000 matrix
+is fine under LP64. The limit bites only past roughly 2.1 billion in a *single*
+dimension, and for sparse work with `nnz > 2^31`.
+
+The case that *is* silent is different, and it is why this installer runs a
+program rather than only linking one: if BLAS++'s headers were built for one
+width while the library actually loaded uses the other, the guard compiles out
+entirely and 64-bit values reach routines reading 32 bits. The symptom is not
+wrong numbers but nonsense control values — a misread workspace query becomes an
+absurd `lwork`, and the run dies in allocation or never finishes. The
+verification step exists to catch that at install time.
+
+### 6.4 macOS: why OpenBLAS rather than Accelerate
+
+The macOS default is Homebrew OpenBLAS, and that is a correctness decision, not
+an oversight. Apple's legacy Accelerate has a broken divide-and-conquer `gesdd`,
+and RandLAPACK calls `gesdd` in `rl_rsvd.hh`, `rl_abrik.hh`, `rl_revd2.hh`,
+`rl_preconditioners.hh` and `rl_util.hh` — so on Accelerate most of the
+SVD-based drivers can return wrong results. This is why `core-macos` quarantines
+`TestQB.Polynomial_Decay_general1` (issue #159).
+
+`--blas=accelerate` is allowed and warns. The default will move to Accelerate
+once BLAS++ adopts Apple's new interface, which carries both the `gesdd` fix and
+ILP64.
 
 ---
 

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -10,8 +10,13 @@
 # Windows yet.
 #
 # Options:
-#   -ProjectDir <path>  Where dependencies/builds/installs go
-#                       (default: ..\RandNLA-project next to the clone).
+#   -ProjectDir <path>  Where dependencies/builds/installs go. Defaults to
+#                       $env:RANDNLA_PROJECT_DIR when set, otherwise
+#                       ..\RandNLA-project next to the clone.
+#   -Prefix <path>      Install RandLAPACK itself here instead of
+#                       <ProjectDir>\install\RandLAPACK-install.
+#   -ModifyEnvironment  Persist RANDNLA_PROJECT_DIR for your user account. The
+#                       default touches nothing and prints the setx command.
 #   -Backend <name>     mkl (default) | openblas | custom. See setup.ps1.
 #   -MklRoot <path>     Use this oneMKL install instead of discovery.
 #   -NoDownload         Fail rather than download a backend that was not
@@ -46,6 +51,13 @@ param(
     # Where the dependency stack lives (default: <ProjectDir>\install). CI
     # points this at its shared, cached dependency directory.
     [string]$DependencyRoot = "",
+    # Install RandLAPACK itself here instead of <ProjectDir>\install\RandLAPACK-install.
+    # Dependencies still go in the project directory. For an HPC module tree or
+    # any other prefix a site wants to own.
+    [string]$Prefix = "",
+    # Persist RANDNLA_PROJECT_DIR for this user. Opt-in, mirroring install.sh's
+    # --modify-rc: the default touches nothing and prints the setx line instead.
+    [switch]$ModifyEnvironment,
     [switch]$Fresh,
     [switch]$SkipTests
 )
@@ -107,26 +119,41 @@ if ($preflightProblems.Count -gt 0) {
     $preflightProblems | ForEach-Object { Write-Host "PREREQUISITE MISSING: $_`n" }
     throw "Missing prerequisites ($($preflightProblems.Count)); see the messages above."
 }
-if ($ProjectDir -ne "" -and $ProjectDir.Length -gt 150) {
-    Write-Warning ("-ProjectDir is $($ProjectDir.Length) characters long; deep dependency build " +
-        "paths may exceed Windows' 260-character limit. Prefer a shorter location.")
-}
-
 if (-not (Test-Path (Join-Path $sourceRoot "RandBLAS\CMakeLists.txt"))) {
     Write-Host "Initializing the RandBLAS submodule..."
     Invoke-Checked "git" @("-C", $sourceRoot, "submodule", "update", "--init", "--recursive")
 }
 
+# Precedence matches install.sh exactly: the flag, then RANDNLA_PROJECT_DIR,
+# then a sibling of this clone. Honouring the environment variable is what lets
+# this installer and RandBLAS's use the same project directory, so a machine
+# that has already installed one does not scatter a second tree elsewhere.
 if ($ProjectDir -eq "") {
-    $ProjectDir = Join-Path (Split-Path $sourceRoot -Parent) "RandNLA-project"
+    if ($env:RANDNLA_PROJECT_DIR) {
+        $ProjectDir = $env:RANDNLA_PROJECT_DIR
+    } else {
+        $ProjectDir = Join-Path (Split-Path $sourceRoot -Parent) "RandNLA-project"
+    }
 }
 $ProjectDir = [System.IO.Path]::GetFullPath($ProjectDir)
 if ($DependencyRoot -eq "") {
     $DependencyRoot = Join-Path $ProjectDir "install"
 }
+# Checked after resolution rather than before: previously this only fired for an
+# explicitly-passed -ProjectDir, so a long *default* path -- the common case,
+# since it is derived from wherever the clone happens to sit -- went unwarned.
+if ($ProjectDir.Length -gt 150) {
+    Write-Warning ("The project directory path is $($ProjectDir.Length) characters long; deep " +
+        "dependency build paths may exceed Windows' 260-character limit. Prefer a shorter " +
+        "location, such as C:\RandNLA, via -ProjectDir.")
+}
 $dependencyRoot = [System.IO.Path]::GetFullPath($DependencyRoot)
 $buildDir = Join-Path $ProjectDir "build\RandLAPACK-build"
-$installDir = Join-Path $ProjectDir "install\RandLAPACK-install"
+$installDir = if ($Prefix) {
+    [System.IO.Path]::GetFullPath($Prefix)
+} else {
+    Join-Path $ProjectDir "install\RandLAPACK-install"
+}
 
 Write-Host ""
 Write-Host "RandLAPACK Windows install"
@@ -172,6 +199,17 @@ if (-not $SkipTests) {
         "--output-on-failure")
 }
 
+# Opt-in, mirroring install.sh's --modify-rc. SetEnvironmentVariable at User
+# scope is the Windows equivalent of appending to a shell profile, and the only
+# mechanism that survives opening a new shell -- setting $env: alone would last
+# only for this process.
+if ($ModifyEnvironment) {
+    [Environment]::SetEnvironmentVariable("RANDNLA_PROJECT_DIR", $ProjectDir, "User")
+    Write-Host ""
+    Write-Host "Set RANDNLA_PROJECT_DIR=$ProjectDir for your user account."
+    Write-Host "Open a new shell to pick it up."
+}
+
 Write-Host ""
 Write-Host "RandLAPACK is installed."
 Write-Host "  RandLAPACK_DIR: $installDir\lib\cmake\RandLAPACK"
@@ -179,6 +217,12 @@ Write-Host "  blaspp_DIR:     $env:blaspp_DIR"
 Write-Host "  lapackpp_DIR:   $env:lapackpp_DIR"
 Write-Host "  Random123_DIR:  $env:Random123_DIR"
 Write-Host ""
+if (-not $ModifyEnvironment) {
+    Write-Host "To have RandNLA installers reuse this project directory by default, set:"
+    Write-Host "    setx RANDNLA_PROJECT_DIR `"$ProjectDir`""
+    Write-Host "(or re-run with -ModifyEnvironment)"
+    Write-Host ""
+}
 if ($env:RANDNLA_BLAS_BIN) {
     Write-Host "Runtime DLLs from $env:RANDNLA_BLAS_BIN are staged next to RandLAPACK's"
     Write-Host "test and benchmark executables automatically -- no PATH changes needed."

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,77 +1,176 @@
 #!/bin/bash
-# RandLAPACK autoinstaller.
+# RandLAPACK autoinstaller for Linux and macOS.
 #
-# Installs RandLAPACK with all of its dependencies and builds the extras and
-# benchmark projects. The directory that contains the RandLAPACK clone ends up
-# with a top-level "RandNLA-project" directory:
+# Builds RandLAPACK, its dependencies, the extras and the benchmark projects
+# into a self-contained "RandNLA-project" directory laid out as:
 #   lib:     RandLAPACK, blaspp, lapackpp sources
-#   install: RandLAPACK-install, blaspp-install, lapackpp-install, random123
+#   install: RandLAPACK-install, blaspp-*-install, lapackpp-*-install, random123
 #   build:   one build directory per project above
 #
-# Usage: bash install.sh [options]
+# Nothing is installed system-wide, and your shell configuration is untouched
+# unless you pass --modify-rc.
 #
-#   -y, --yes             Assume "yes" for every prompt (also the behavior when
-#                         stdin is not a terminal, e.g. curl | bash or CI).
-#       --gpu             Build with CUDA support without asking.
-#       --no-gpu          Build without GPU support without asking.
-#   -j, --jobs <N>        Parallel build jobs (default: number of cores).
-#       --fresh           Clear all build directories first. The default reuses
-#                         them, so re-running after a failure or a source
-#                         update is an incremental rebuild.
-#       --modify-rc       Append RANDNLA_PROJECT_DIR / RANDNLA_PROJECT_GPU_AVAIL
-#                         exports to your shell config. The default never
-#                         touches your shell config; the final summary prints
-#                         the export lines to add yourself if you want them.
-#       --project-dir <D> Place/locate RandNLA-project at D instead of next to
-#                         this clone.
-#   -h, --help            Show this help and exit.
+# You bring a C++20 compiler, CMake 3.21+, Git and a BLAS/LAPACK. This script
+# does not install compilers or package managers; when something is missing it
+# says so and tells you the usual way to get it.
 #
-# Every option has an environment-variable equivalent (flags win):
-#   RANDLAPACK_INSTALL_YES=1, RANDLAPACK_INSTALL_GPU=on|off,
-#   RANDLAPACK_INSTALL_JOBS=N, RANDLAPACK_INSTALL_FRESH=1,
-#   RANDLAPACK_INSTALL_MODIFY_RC=1, RANDLAPACK_INSTALL_PROJECT_DIR=D
+# RandBLAS is intentionally not covered here: RandLAPACK vendors it as a git
+# submodule pinned to an exact commit, and that pinned copy stays authoritative.
+# RandBLAS's own installer is for people who want RandBLAS on its own.
 #
-# Already-installed dependencies are discovered through:
-#   BLASPP_INSTALL_DIR, LAPACKPP_INSTALL_DIR, RANDOM123_INSTALL_DIR
-# (RandBLAS is intentionally not covered: it stays a git submodule.)
-#
-# All compiler output goes to <project-dir>/install.log; the console shows one
-# line per step. On failure the log path is printed.
-#
-# Prerequisites are listed in INSTALL.md.
+# Prerequisites and tested configurations are listed in INSTALL_SCRIPT.md.
+
 set -euo pipefail
+
+usage() {
+    # A heredoc rather than a line-range sed over this file's own comment block:
+    # the latter starts printing unrelated code the moment anyone adds a line
+    # above it.
+    cat <<'USAGE'
+Usage: bash install.sh [options]
+
+Backend selection:
+  --blas=BACKEND        auto | openblas | mkl | accelerate | custom
+                        (default: auto -- OpenBLAS on macOS, MKL on Linux when
+                        MKLROOT is set, otherwise OpenBLAS)
+  --blas-int=WIDTH      ilp64 | lp64. Defaults to ilp64 wherever the backend
+                        can actually provide it, falling back to lp64 with a
+                        warning. Accelerate is lp64-only and rejects ilp64.
+  --blas-libraries=L    Link line for --blas=custom, used for both BLAS and
+                        LAPACK, e.g. "/opt/aocl/lib/libflame.so;/opt/aocl/lib/libblis.so"
+
+GPU:
+      --gpu             Build with CUDA support without asking
+      --no-gpu          Build without GPU support without asking
+
+Locations:
+  --project-dir=DIR     Where dependencies, builds and installs go.
+                        Default: $RANDNLA_PROJECT_DIR if set, otherwise
+                        ../RandNLA-project next to this clone.
+  --prefix=DIR          Install RandLAPACK itself here instead of
+                        <project-dir>/install/RandLAPACK-install. Dependencies
+                        still go in the project directory.
+
+Build:
+  -j, --jobs N          Parallel build jobs (default: number of cores)
+      --fresh           Clear build directories and rebuild dependencies
+      --no-extras       Skip the extras project
+      --no-benchmarks   Skip the benchmark project
+      --no-openmp       Configure without OpenMP
+
+Output:
+  -y, --yes             Assume "yes" at every prompt. Also the behavior when
+                        stdin is not a terminal (CI, pipes).
+      --modify-rc       Append RANDNLA_PROJECT_DIR / RANDNLA_PROJECT_GPU_AVAIL
+                        exports to your shell config. The default touches
+                        nothing and prints the lines to add yourself.
+      --no-progress     Plain one-line-per-step output, no redrawing
+  -h, --help            Show this help and exit
+
+Every option has an environment-variable equivalent (flags win):
+  RANDLAPACK_INSTALL_BLAS, RANDLAPACK_INSTALL_BLAS_INT,
+  RANDLAPACK_INSTALL_BLAS_LIBRARIES, RANDLAPACK_INSTALL_GPU,
+  RANDLAPACK_INSTALL_PROJECT_DIR, RANDLAPACK_INSTALL_PREFIX,
+  RANDLAPACK_INSTALL_JOBS, RANDLAPACK_INSTALL_FRESH,
+  RANDLAPACK_INSTALL_EXTRAS, RANDLAPACK_INSTALL_BENCHMARKS,
+  RANDLAPACK_INSTALL_OPENMP, RANDLAPACK_INSTALL_YES,
+  RANDLAPACK_INSTALL_MODIFY_RC, RANDLAPACK_INSTALL_PROGRESS
+
+Already-installed dependencies are reused when pointed at by:
+  BLASPP_INSTALL_DIR, LAPACKPP_INSTALL_DIR, RANDOM123_INSTALL_DIR
+
+All compiler output goes to <project-dir>/install.log; the console shows one
+line per step. On failure the log path is printed.
+USAGE
+}
 
 #==============================================================================
 # Option parsing. Environment variables provide defaults; flags override.
 #==============================================================================
-ASSUME_YES="${RANDLAPACK_INSTALL_YES:-0}"
-GPU_CHOICE="${RANDLAPACK_INSTALL_GPU:-ask}"       # ask | on | off
+BLAS_BACKEND="${RANDLAPACK_INSTALL_BLAS:-auto}"
+BLAS_INT_CHOICE="${RANDLAPACK_INSTALL_BLAS_INT:-auto}"      # auto | ilp64 | lp64
+BLAS_LIBRARIES_ARG="${RANDLAPACK_INSTALL_BLAS_LIBRARIES:-}"
+GPU_CHOICE="${RANDLAPACK_INSTALL_GPU:-ask}"                 # ask | on | off
+PROJECT_DIR_OVERRIDE="${RANDLAPACK_INSTALL_PROJECT_DIR:-}"
+PREFIX_OVERRIDE="${RANDLAPACK_INSTALL_PREFIX:-}"
 JOBS="${RANDLAPACK_INSTALL_JOBS:-}"
 FRESH="${RANDLAPACK_INSTALL_FRESH:-0}"
+WANT_EXTRAS="${RANDLAPACK_INSTALL_EXTRAS:-1}"
+WANT_BENCHMARKS="${RANDLAPACK_INSTALL_BENCHMARKS:-1}"
+WANT_OPENMP="${RANDLAPACK_INSTALL_OPENMP:-1}"
+ASSUME_YES="${RANDLAPACK_INSTALL_YES:-0}"
 MODIFY_RC="${RANDLAPACK_INSTALL_MODIFY_RC:-0}"
-PROJECT_DIR_OVERRIDE="${RANDLAPACK_INSTALL_PROJECT_DIR:-}"
+WANT_PROGRESS="${RANDLAPACK_INSTALL_PROGRESS:-1}"
 
-usage() { sed -n '2,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -y|--yes)        ASSUME_YES=1 ;;
-        --gpu)           GPU_CHOICE="on" ;;
-        --no-gpu)        GPU_CHOICE="off" ;;
-        -j|--jobs)       JOBS="${2:?--jobs requires a number}"; shift ;;
-        --jobs=*)        JOBS="${1#*=}" ;;
-        --fresh)         FRESH=1 ;;
-        --modify-rc)     MODIFY_RC=1 ;;
-        --project-dir)   PROJECT_DIR_OVERRIDE="${2:?--project-dir requires a path}"; shift ;;
-        --project-dir=*) PROJECT_DIR_OVERRIDE="${1#*=}" ;;
-        -h|--help)       usage; exit 0 ;;
-        *) echo "Unknown option: $1 (see --help)" >&2; exit 2 ;;
+        --blas)             BLAS_BACKEND="${2:?--blas requires a backend}"; shift ;;
+        --blas=*)           BLAS_BACKEND="${1#*=}" ;;
+        --blas-int)         BLAS_INT_CHOICE="${2:?--blas-int requires a width}"; shift ;;
+        --blas-int=*)       BLAS_INT_CHOICE="${1#*=}" ;;
+        --blas-libraries)   BLAS_LIBRARIES_ARG="${2:?--blas-libraries requires a value}"; shift ;;
+        --blas-libraries=*) BLAS_LIBRARIES_ARG="${1#*=}" ;;
+        --gpu)              GPU_CHOICE="on" ;;
+        --no-gpu)           GPU_CHOICE="off" ;;
+        --project-dir)      PROJECT_DIR_OVERRIDE="${2:?--project-dir requires a path}"; shift ;;
+        --project-dir=*)    PROJECT_DIR_OVERRIDE="${1#*=}" ;;
+        --prefix)           PREFIX_OVERRIDE="${2:?--prefix requires a path}"; shift ;;
+        --prefix=*)         PREFIX_OVERRIDE="${1#*=}" ;;
+        -j|--jobs)          JOBS="${2:?--jobs requires a number}"; shift ;;
+        --jobs=*)           JOBS="${1#*=}" ;;
+        -j*)                JOBS="${1#-j}" ;;   # attached form, as in -j8
+        --fresh)            FRESH=1 ;;
+        --no-extras)        WANT_EXTRAS=0 ;;
+        --no-benchmarks)    WANT_BENCHMARKS=0 ;;
+        --no-openmp)        WANT_OPENMP=0 ;;
+        -y|--yes)           ASSUME_YES=1 ;;
+        --modify-rc)        MODIFY_RC=1 ;;
+        --no-progress)      WANT_PROGRESS=0 ;;
+        -h|--help)          usage; exit 0 ;;
+        *) printf 'Unknown option: %s (see --help)\n' "$1" >&2; exit 2 ;;
     esac
     shift
 done
 
-# Prompts happen only on a terminal and only without --yes. When stdin is not
-# a terminal (piped/CI), every prompt silently takes its default.
+case "$BLAS_BACKEND" in
+    auto|openblas|mkl|accelerate|custom) ;;
+    *) die "--blas must be auto, openblas, mkl, accelerate or custom (got '$BLAS_BACKEND')" ;;
+esac
+case "$BLAS_INT_CHOICE" in
+    auto|ilp64|lp64) ;;
+    *) die "--blas-int must be ilp64 or lp64 (got '$BLAS_INT_CHOICE')" ;;
+esac
+case "$GPU_CHOICE" in
+    ask|on|off) ;;
+    *) die "RANDLAPACK_INSTALL_GPU must be 'on' or 'off' (got '$GPU_CHOICE')" ;;
+esac
+if [[ "$BLAS_BACKEND" == "custom" && -z "$BLAS_LIBRARIES_ARG" ]]; then
+    die "--blas=custom needs --blas-libraries=<semicolon-separated link line>"
+fi
+if [[ -n "$BLAS_LIBRARIES_ARG" && "$BLAS_BACKEND" != "custom" ]]; then
+    die "--blas-libraries only applies to --blas=custom (backend is '$BLAS_BACKEND')"
+fi
+# Checked here rather than during backend resolution, which happens after GPU
+# detection: a contradiction between two flags should be reported before the
+# user is asked anything. "auto" never resolves to accelerate, so testing the
+# literal value is sufficient.
+if [[ "$BLAS_BACKEND" == "accelerate" && "$BLAS_INT_CHOICE" == "ilp64" ]]; then
+    die "--blas-int=ilp64 is not available with Accelerate: BLAS++ implements only Apple's legacy LP64 interface (upstream icl-utk-edu/lapackpp#43). Use --blas=openblas or --blas=mkl for ILP64."
+fi
+
+if [[ -z "$JOBS" ]]; then
+    JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)
+fi
+
+#==============================================================================
+# Interactivity and output style.
+#
+# Prompts happen only on a terminal and only without --yes. When stdin is not a
+# terminal (piped, CI) every prompt silently takes its default, so this script
+# can never hang waiting for input nobody is there to give.
+#==============================================================================
 INTERACTIVE=0
 if [[ -t 0 && "$ASSUME_YES" != "1" ]]; then
     INTERACTIVE=1
@@ -89,35 +188,91 @@ ask() {
     [[ "$reply" == "y" || "$reply" == "Y" || "$reply" == "yes" ]]
 }
 
-if [[ -z "$JOBS" ]]; then
-    JOBS=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 8)
-fi
-
-# Plain output when not on a terminal or when NO_COLOR/TERM=dumb ask for it.
-if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != "dumb" ]]; then
-    C_OK=$'\033[32m'; C_ERR=$'\033[31m'; C_BOLD=$'\033[1m'; C_OFF=$'\033[0m'
+if [[ -t 1 && -z "${NO_COLOR:-}" && "${TERM:-}" != "dumb" && "$WANT_PROGRESS" == "1" ]]; then
+    C_OK=$'\033[32m'; C_ERR=$'\033[31m'; C_WARN=$'\033[33m'; C_BOLD=$'\033[1m'; C_OFF=$'\033[0m'
 else
-    C_OK=""; C_ERR=""; C_BOLD=""; C_OFF=""
+    C_OK=""; C_ERR=""; C_WARN=""; C_BOLD=""; C_OFF=""
 fi
 
+# Progress rendering tier.
+#   2  a terminal that can draw: redraw a bar in place, with block characters
+#   1  a terminal without colour or UTF-8: same bar, ASCII, still redrawn
+#   0  not a terminal: one line per step, no escapes, no carriage returns
+#
+# Tier 0 is a requirement, not a fallback. Redirected output ends up in
+# install.log, in CI transcripts and in bug reports, and control characters make
+# all three unreadable.
+PROGRESS_TIER=0
+if [[ -t 1 && "$WANT_PROGRESS" == "1" && "${TERM:-}" != "dumb" ]]; then
+    if [[ -z "${NO_COLOR:-}" && "${LC_ALL:-${LC_CTYPE:-${LANG:-}}}" == *[Uu][Tt][Ff]* ]]; then
+        PROGRESS_TIER=2
+    else
+        PROGRESS_TIER=1
+    fi
+fi
+if (( PROGRESS_TIER >= 2 )); then
+    BAR_FULL="━"; BAR_EMPTY="─"
+else
+    BAR_FULL="#"; BAR_EMPTY="-"
+fi
+
+note() { printf '%s\n' "$*"; }
+warn() { printf '%swarning:%s %s\n' "$C_WARN" "$C_OFF" "$*" >&2; }
+
+# Collected and reprinted in the final summary. A warning emitted twenty minutes
+# and several thousand log lines before the summary is a warning nobody reads.
+WARNINGS=()
+record_warning() { WARNINGS+=("$1"); warn "$1"; }
+
 #==============================================================================
-# Toolchain checks. Warn always; abort only if the user says so at a prompt.
+# Toolchain preflight. Report everything missing at once rather than failing on
+# the first one, so a bare machine takes one round trip instead of three.
 #==============================================================================
+UNAME_S="$(uname -s)"
+MISSING=()
+command -v cmake >/dev/null 2>&1 || MISSING+=("cmake")
+command -v git   >/dev/null 2>&1 || MISSING+=("git")
+if ! command -v c++ >/dev/null 2>&1 && ! command -v g++ >/dev/null 2>&1 && \
+   ! command -v clang++ >/dev/null 2>&1; then
+    MISSING+=("a C++ compiler")
+fi
+if (( ${#MISSING[@]} )); then
+    printf 'ERROR: missing prerequisites: %s\n\n' "${MISSING[*]}" >&2
+    if [[ "$UNAME_S" == "Darwin" ]]; then
+        printf '  xcode-select --install    # Apple Clang and git\n' >&2
+        printf '  brew install cmake\n\n' >&2
+    else
+        printf '  sudo apt install g++ gfortran cmake git      # Debian, Ubuntu\n' >&2
+        printf '  sudo dnf install gcc-c++ gcc-gfortran cmake git  # Fedora, RHEL\n\n' >&2
+    fi
+    printf 'See INSTALL_SCRIPT.md for the full prerequisite list.\n' >&2
+    exit 1
+fi
+
+CMAKE_VERSION="$(cmake --version | head -n1 | awk '{print $3}')"
+if [[ "$(printf '%s\n3.21\n' "$CMAKE_VERSION" | sort -V | head -n1)" != "3.21" ]]; then
+    die "CMake 3.21 or later is required (found $CMAKE_VERSION). See INSTALL_SCRIPT.md."
+fi
+
+# GCC 13.3.0 is the reference version. Warn rather than block: newer usually
+# works, and the C++20 concepts RandBLAS uses need at least 13.
 PREFERRED_GCC_VERSION="13.3.0"
 CURRENT_GCC_VERSION=$(gcc --version 2>/dev/null | head -n 1 | awk '{print $NF}')
-if [[ "$CURRENT_GCC_VERSION" != "$PREFERRED_GCC_VERSION" ]]; then
-    echo "Note: GCC $PREFERRED_GCC_VERSION is the reference version; found ${CURRENT_GCC_VERSION:-none}."
-    if ! ask "Continue with the current GCC?" y; then
-        echo "Stopping at your request. Install GCC $PREFERRED_GCC_VERSION and re-run."
-        exit 1
+if [[ -n "$CURRENT_GCC_VERSION" && "$CURRENT_GCC_VERSION" != "$PREFERRED_GCC_VERSION" ]]; then
+    GCC_MAJOR="${CURRENT_GCC_VERSION%%.*}"
+    if [[ "$GCC_MAJOR" =~ ^[0-9]+$ ]] && (( GCC_MAJOR < 13 )); then
+        record_warning "gcc $CURRENT_GCC_VERSION is older than 13; RandBLAS uses C++20 concepts and may not compile."
+    else
+        note "Note: gcc $PREFERRED_GCC_VERSION is the reference version; found $CURRENT_GCC_VERSION."
     fi
 fi
 
 #==============================================================================
 # GPU decision. --gpu/--no-gpu (or RANDLAPACK_INSTALL_GPU) decide outright;
-# otherwise detection + prompt. Non-interactive defaults: NVIDIA detected ->
-# GPU on; AMD or nothing detected -> GPU off (the CUDA-only build cannot
-# succeed on AMD, so saying yes for the user would guarantee a failure).
+# otherwise detection plus a prompt. Non-interactive defaults: NVIDIA detected
+# means GPU on; AMD or nothing detected means GPU off, because the CUDA-only
+# build cannot succeed on AMD and saying yes for the user would guarantee a
+# failure.
 #==============================================================================
 RANDLAPACK_CUDA="OFF"
 RANDNLA_PROJECT_GPU_AVAIL="none"
@@ -130,302 +285,772 @@ case "$GPU_CHOICE" in
                 RANDLAPACK_CUDA="ON"; RANDNLA_PROJECT_GPU_AVAIL="auto"
             fi
         elif { command -v lspci &>/dev/null && lspci | grep -i "VGA" | grep -qi "AMD"; } || \
-             { [[ "$(uname)" == "Darwin" ]] && system_profiler SPDisplaysDataType 2>/dev/null | grep -qi "AMD"; }; then
+             { [[ "$UNAME_S" == "Darwin" ]] && system_profiler SPDisplaysDataType 2>/dev/null | grep -qi "AMD"; }; then
             if ask "AMD GPU detected, but only a CUDA build is available for now. Attempt a CUDA build anyway?" n; then
                 RANDLAPACK_CUDA="ON"; RANDNLA_PROJECT_GPU_AVAIL="auto"
             fi
         else
-            echo "No GPU detected; building without GPU support."
+            note "No GPU detected; building without GPU support."
         fi
         ;;
-    *) echo "RANDLAPACK_INSTALL_GPU must be 'on' or 'off' (got '$GPU_CHOICE')" >&2; exit 2 ;;
 esac
 
 if [[ "$RANDNLA_PROJECT_GPU_AVAIL" == "auto" ]]; then
     PREFERRED_NVCC_VERSION="12.9"
     CURRENT_NVCC_VERSION=$(nvcc --version 2>/dev/null | grep "release" | awk '{print $5}' | cut -d',' -f1)
     if [[ "$CURRENT_NVCC_VERSION" != "$PREFERRED_NVCC_VERSION" ]]; then
-        echo "Note: NVCC $PREFERRED_NVCC_VERSION is the reference version; found ${CURRENT_NVCC_VERSION:-none}."
+        note "Note: NVCC $PREFERRED_NVCC_VERSION is the reference version; found ${CURRENT_NVCC_VERSION:-none}."
         if ! ask "Continue with the current NVCC?" y; then
-            echo "Stopping at your request. Install NVCC $PREFERRED_NVCC_VERSION and re-run."
-            exit 1
+            die "Stopping at your request. Install NVCC $PREFERRED_NVCC_VERSION and re-run."
         fi
     fi
 fi
 
 #==============================================================================
-# macOS preflight: Homebrew OpenBLAS + libomp, SDK C++ headers, OpenMP hints.
+# Project layout.
+#
+# Precedence: --project-dir, then RANDNLA_PROJECT_DIR, then a sibling of this
+# clone. Honouring the environment variable is what lets this installer and
+# RandBLAS's share one dependency tree -- whichever runs second finds the
+# first one's BLAS++ and reuses it.
+#
+# This script no longer moves your clone. The previous version relocated the
+# repository into <project>/lib/RandLAPACK on first run, which breaks git
+# worktrees and surprises anyone who cloned deliberately. The layout below is
+# created regardless of where the clone lives, and lib/RandLAPACK is a symlink
+# so the tree still reads as complete.
 #==============================================================================
-BLAS_INT="int64"
-MACOS_BLAS_FLAGS=""
-MACOS_LAPACK_FLAGS=""
-MACOS_OPENMP_FLAGS=""
-if [[ "$(uname)" == "Darwin" ]]; then
-    if [[ ! -f /opt/homebrew/opt/openblas/lib/libopenblas.dylib ]]; then
-        echo "ERROR: OpenBLAS not found. Install it first: brew install openblas" >&2
-        exit 1
-    fi
-    if [[ ! -f /opt/homebrew/opt/libomp/lib/libomp.dylib ]]; then
-        echo "ERROR: libomp not found. Install it first: brew install libomp" >&2
-        exit 1
-    fi
-    BLAS_INT="int32"
-    MACOS_SDK_PATH=$(xcrun --show-sdk-path)
-    # SDK C++ headers + Apple Clang OpenMP flags (no native OpenMP; Homebrew
-    # libomp). Appending to CXXFLAGS/CFLAGS lets cmake pick them up via
-    # CMAKE_<LANG>_FLAGS_INIT for all try_compile tests, including FindOpenMP.
-    export CXXFLAGS="-isystem ${MACOS_SDK_PATH}/usr/include/c++/v1 -Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include"
-    export CFLAGS="-Xpreprocessor -fopenmp -I/opt/homebrew/opt/libomp/include"
-    export LDFLAGS="-L/opt/homebrew/opt/libomp/lib"
-    MACOS_BLAS_FLAGS="-DBLAS_LIBRARIES=/opt/homebrew/opt/openblas/lib/libopenblas.dylib -Dblas_fortran=add"
-    MACOS_LAPACK_FLAGS="-DLAPACK_LIBRARIES=/opt/homebrew/opt/openblas/lib/libopenblas.dylib"
-    MACOS_OPENMP_FLAGS="-DOpenMP_C_LIB_NAMES=omp -DOpenMP_CXX_LIB_NAMES=omp -DOpenMP_omp_LIBRARY=/opt/homebrew/opt/libomp/lib/libomp.dylib -DOpenMP_C_FLAGS=-Xpreprocessor;-fopenmp -DOpenMP_CXX_FLAGS=-Xpreprocessor;-fopenmp"
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
 
-#==============================================================================
-# Project layout. The clone moves itself into <parent>/RandNLA-project/lib/
-# on first run; on re-runs (script already under lib/) the layout is detected.
-#==============================================================================
-# This script lives in <repo>/install/; REPO_DIR is the RandLAPACK clone.
-SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
-REPO_DIR=$(dirname "$SCRIPT_DIR")
-PARENT_DIR=$(dirname "$REPO_DIR")
-PARENT_BASE=$(basename "$PARENT_DIR")
 if [[ -n "$PROJECT_DIR_OVERRIDE" ]]; then
     RANDNLA_PROJECT_DIR="$PROJECT_DIR_OVERRIDE"
-elif [[ "$PARENT_BASE" == "lib" ]]; then
-    RANDNLA_PROJECT_DIR=$(dirname "$PARENT_DIR")
+elif [[ -n "${RANDNLA_PROJECT_DIR:-}" ]]; then
+    :   # already set in the environment; use it as-is
 else
-    RANDNLA_PROJECT_DIR="$PARENT_DIR/RandNLA-project"
+    RANDNLA_PROJECT_DIR="$(dirname "$REPO_DIR")/RandNLA-project"
 fi
-
+mkdir -p "$RANDNLA_PROJECT_DIR"
+RANDNLA_PROJECT_DIR="$(cd "$RANDNLA_PROJECT_DIR" && pwd)"
 mkdir -p "$RANDNLA_PROJECT_DIR"/{install,lib,build}
-for d in blaspp-build lapackpp-build RandLAPACK-build extras-build benchmark-build; do
-    if [[ "$FRESH" == "1" ]]; then
-        rm -rf "$RANDNLA_PROJECT_DIR/build/$d"
-    fi
-    mkdir -p "$RANDNLA_PROJECT_DIR/build/$d"
-done
+
+# A symlink, not a move: the clone stays where the user put it.
+if [[ ! -e "$RANDNLA_PROJECT_DIR/lib/RandLAPACK" ]]; then
+    ln -s "$REPO_DIR" "$RANDNLA_PROJECT_DIR/lib/RandLAPACK"
+fi
+RL_SRC="$REPO_DIR"
+
+RANDLAPACK_INSTALL_DIR="${PREFIX_OVERRIDE:-$RANDNLA_PROJECT_DIR/install/RandLAPACK-install}"
 
 LOG="$RANDNLA_PROJECT_DIR/install.log"
-: > "$LOG"
-echo "RandLAPACK install started $(date)" >> "$LOG"
+# Appended, not truncated: the previous run's output is exactly what you want
+# when the current run fails the same way.
+{
+    printf '\n===============================================================\n'
+    printf 'RandLAPACK install started %s\n' "$(date)"
+    printf '===============================================================\n'
+} >> "$LOG"
 
-# run_step <label> <command...>: one console line per step, full output in the
-# log, log path printed on failure.
 STEP=0
-TOTAL_STEPS=10
+TOTAL_STEPS=0
+
 run_step() {
     local label="$1"; shift
     STEP=$((STEP + 1))
-    printf "%s[%d/%d]%s %s ... " "$C_BOLD" "$STEP" "$TOTAL_STEPS" "$C_OFF" "$label"
+    printf '%s[%d/%d]%s %s ... ' "$C_BOLD" "$STEP" "$TOTAL_STEPS" "$C_OFF" "$label"
     local t0 t1
     t0=$(date +%s)
     {
-        echo ""
-        echo "===== [$STEP/$TOTAL_STEPS] $label ====="
-        echo "\$ $*"
+        printf '\n===== [%d/%d] %s =====\n' "$STEP" "$TOTAL_STEPS" "$label"
+        printf '$ %s\n' "$*"
     } >> "$LOG"
     if "$@" >> "$LOG" 2>&1; then
         t1=$(date +%s)
-        printf "%sdone%s (%ds)\n" "$C_OK" "$C_OFF" "$((t1 - t0))"
+        printf '%sdone%s (%ds)\n' "$C_OK" "$C_OFF" "$((t1 - t0))"
     else
-        printf "%sFAILED%s\n" "$C_ERR" "$C_OFF" >&2
-        echo "" >&2
-        echo "Step '$label' failed. Full output: $LOG" >&2
-        echo "The last 20 log lines:" >&2
+        printf '%sFAILED%s\n' "$C_ERR" "$C_OFF" >&2
+        printf '\nStep "%s" failed. Full output: %s\n' "$label" "$LOG" >&2
+        printf 'The last 20 log lines:\n' >&2
         tail -20 "$LOG" >&2
         exit 1
     fi
 }
 
+draw_bar() {
+    local pct="$1" label="$2" width=28 filled i bar=""
+    (( pct > 100 )) && pct=100
+    filled=$(( pct * width / 100 ))
+    for ((i = 0; i < width; i++)); do
+        if (( i < filled )); then bar+="$BAR_FULL"; else bar+="$BAR_EMPTY"; fi
+    done
+    printf '\r%s[%d/%d]%s %s %s %3d%%\033[K' \
+        "$C_BOLD" "$STEP" "$TOTAL_STEPS" "$C_OFF" "$label" "$bar" "$pct"
+}
+
+# run_build_step: like run_step, but drives a real progress bar from the build
+# tool's own output. Both tools already report progress on the stream being
+# captured anyway -- Ninja writes "[12/34]", Make writes "[ 42%]" -- so the bar
+# tracks actual work rather than elapsed time. Falls through to run_step at
+# tier 0 so redirected output is byte-identical to the plain form.
+run_build_step() {
+    local label="$1"; shift
+    if (( PROGRESS_TIER == 0 )); then
+        run_step "$label" "$@"
+        return
+    fi
+    STEP=$((STEP + 1))
+    local t0 t1 status statusfile
+    t0=$(date +%s)
+    {
+        printf '\n===== [%d/%d] %s =====\n' "$STEP" "$TOTAL_STEPS" "$label"
+        printf '$ %s\n' "$*"
+    } >> "$LOG"
+    draw_bar 0 "$label"
+    # The while loop runs in a subshell, so the command's exit status cannot
+    # come back through a variable; pass it through a file instead.
+    statusfile="$(mktemp)"
+    {
+        "$@" 2>&1
+        printf '%d\n' "$?" > "$statusfile"
+    } | while IFS= read -r line; do
+        printf '%s\n' "$line" >> "$LOG"
+        if [[ "$line" =~ ^\[([0-9]+)/([0-9]+)\] ]]; then
+            draw_bar $(( 100 * ${BASH_REMATCH[1]} / ${BASH_REMATCH[2]} )) "$label"
+        elif [[ "$line" =~ ^\[[[:space:]]*([0-9]+)%\] ]]; then
+            draw_bar "${BASH_REMATCH[1]}" "$label"
+        fi
+    done
+    status="$(cat "$statusfile" 2>/dev/null || echo 1)"
+    rm -f "$statusfile"
+    if [[ "$status" == "0" ]]; then
+        t1=$(date +%s)
+        printf '\r%s[%d/%d]%s %s ... %sdone%s (%ds)\033[K\n' \
+            "$C_BOLD" "$STEP" "$TOTAL_STEPS" "$C_OFF" "$label" "$C_OK" "$C_OFF" "$((t1 - t0))"
+    else
+        printf '\r%s[%d/%d]%s %s ... %sFAILED%s\033[K\n' \
+            "$C_BOLD" "$STEP" "$TOTAL_STEPS" "$C_OFF" "$label" "$C_ERR" "$C_OFF" >&2
+        printf '\nStep "%s" failed. Full output: %s\n' "$label" "$LOG" >&2
+        printf 'The last 20 log lines:\n' >&2
+        tail -20 "$LOG" >&2
+        exit 1
+    fi
+}
+
+skip_step() {
+    STEP=$((STEP + 1))
+    printf '%s[%d/%d]%s %s\n' "$C_BOLD" "$STEP" "$TOTAL_STEPS" "$C_OFF" "$1"
+}
+
 #==============================================================================
-# Dependency discovery: reuse preinstalled deps pointed at by env vars.
+# Provenance stamps.
+#
+# A dependency is reused only when it was built from the source we would build
+# from now, in the configuration we want now. Reuse keyed on mere presence means
+# changing a pin, switching BLAS backend, or toggling --gpu is a silent no-op
+# for anyone who already ran this script: they keep the old artifact and the new
+# setting never takes effect.
 #==============================================================================
-find_cmake_config() {
+stamp_file() { printf '%s/.randlapack-provenance' "$1"; }
+
+stamp_matches() {  # <install-dir> <expected-stamp>
+    [[ -f "$(stamp_file "$1")" ]] || return 1
+    [[ "$(cat "$(stamp_file "$1")")" == "$2" ]]
+}
+
+write_stamp() { printf '%s\n' "$2" > "$(stamp_file "$1")"; }
+
+# Shallow-fetch exactly one commit or tag, so the pin cannot drift the way a
+# branch name would. The source tree gets its own stamp because a shallow
+# checkout of a tag does not keep the tag ref locally, so git cannot be asked
+# afterwards whether a tree is at the pin -- and without it, a source tree left
+# from an older pin would be reused as if current.
+clone_pinned() {  # <url> <dest> <ref>
+    local url="$1" dest="$2" ref="$3"
+    rm -rf "$dest"
+    mkdir -p "$dest"
+    git -C "$dest" init --quiet
+    git -C "$dest" remote add origin "$url"
+    git -C "$dest" fetch --quiet --depth 1 origin "$ref"
+    git -C "$dest" checkout --quiet FETCH_HEAD
+    write_stamp "$dest" "$url@$ref"
+}
+
+source_is_current() { stamp_matches "$1" "$2@$3"; }
+
+#==============================================================================
+# Dependency pins. Immutable refs only: a tag or a full commit hash, never a
+# branch name. These match the refs this repository's own Windows provisioner
+# already validated, so the two halves of the project stop disagreeing about
+# what they build.
+#==============================================================================
+BLASPP_URL="https://github.com/icl-utk-edu/blaspp.git"
+# The commit that merged the MSVC portability fix (blaspp PR #132, 2026-08-06).
+# Not in a release yet -- the latest tag, v2025.05.28, predates it.
+BLASPP_REF="30571853f980d3a2a1737124ea4789e025a5e045"
+LAPACKPP_URL="https://github.com/icl-utk-edu/lapackpp.git"
+LAPACKPP_REF="40b9d0daf29b6f1f3fa58bc3f22bd6cfb2c67fe4"
+RANDOM123_URL="https://github.com/DEShawResearch/Random123.git"
+RANDOM123_REF="v1.14.0"
+
+#==============================================================================
+# Backend resolution.
+#
+# "auto" picks OpenBLAS on macOS and MKL on Linux when MKLROOT says it is
+# installed, OpenBLAS otherwise. The choice is always printed, because a silent
+# default is the thing people later cannot explain.
+#
+# macOS deliberately defaults to Homebrew OpenBLAS rather than Accelerate.
+# Apple's legacy Accelerate has a broken divide-and-conquer gesdd, and
+# RandLAPACK calls gesdd in rl_rsvd, rl_abrik, rl_revd2, rl_preconditioners and
+# rl_util -- so Accelerate would quietly return wrong singular values across
+# most of the SVD-based drivers. This is why core-macos quarantines
+# TestQB.Polynomial_Decay_general1 (see issue #159). --blas=accelerate is
+# allowed, with a warning.
+#==============================================================================
+BREW_PREFIX=""
+if [[ "$UNAME_S" == "Darwin" ]] && command -v brew >/dev/null 2>&1; then
+    # Never hardcode /opt/homebrew: that is Apple Silicon only, and breaks both
+    # Intel Macs (/usr/local) and any custom HOMEBREW_PREFIX.
+    BREW_PREFIX="$(brew --prefix)"
+fi
+
+if [[ "$BLAS_BACKEND" == "auto" ]]; then
+    if [[ "$UNAME_S" == "Darwin" ]]; then
+        BLAS_BACKEND="openblas"
+    elif [[ -n "${MKLROOT:-}" && -d "${MKLROOT:-}" ]]; then
+        BLAS_BACKEND="mkl"
+    else
+        BLAS_BACKEND="openblas"
+    fi
+    note "Selected BLAS backend: $BLAS_BACKEND (from --blas=auto)"
+fi
+
+if [[ "$BLAS_BACKEND" == "accelerate" ]]; then
+    record_warning "Apple's legacy Accelerate has a broken divide-and-conquer gesdd. RandLAPACK calls gesdd in rl_rsvd, rl_abrik, rl_revd2, rl_preconditioners and rl_util, so SVD-based drivers may return wrong results. TestQB.Polynomial_Decay_general1 is expected to fail. Prefer --blas=openblas until BLAS++ adopts Apple's new Accelerate interface (issue #159)."
+fi
+
+# Integer width: prefer ILP64 wherever the backend can genuinely provide it.
+#
+# ILP64 matters because LP64 caps every individual BLAS dimension at 2^31.
+# RandLAPACK is int64_t throughout, and BLAS++/LAPACK++ guard the downcast, so
+# an oversized dimension throws rather than truncating -- but a header/library
+# disagreement is NOT guarded and shows up as an absurd workspace size or a run
+# that never finishes. The conftest below is what catches that.
+WIDTH_ORDER=()
+case "$BLAS_BACKEND" in
+    accelerate)
+        if [[ "$BLAS_INT_CHOICE" == "ilp64" ]]; then
+            die "--blas-int=ilp64 is not available with Accelerate: BLAS++ implements only Apple's legacy LP64 interface (upstream icl-utk-edu/lapackpp#43). Use --blas=openblas or --blas=mkl for ILP64."
+        fi
+        WIDTH_ORDER=(int32)
+        ;;
+    *)
+        case "$BLAS_INT_CHOICE" in
+            ilp64) WIDTH_ORDER=(int64) ;;
+            lp64)  WIDTH_ORDER=(int32) ;;
+            auto)  WIDTH_ORDER=(int64 int32) ;;
+        esac
+        ;;
+esac
+
+# blaspp's own backend selector; its matcher accepts "apple" or "accelerate".
+BLASPP_BACKEND_FLAGS=()
+LAPACKPP_BACKEND_FLAGS=()
+case "$BLAS_BACKEND" in
+    mkl)        BLASPP_BACKEND_FLAGS=(-Dblas=mkl) ;;
+    accelerate) BLASPP_BACKEND_FLAGS=(-Dblas=apple) ;;
+    custom)
+        BLASPP_BACKEND_FLAGS=(-DBLAS_LIBRARIES="$BLAS_LIBRARIES_ARG")
+        LAPACKPP_BACKEND_FLAGS=(-DLAPACK_LIBRARIES="$BLAS_LIBRARIES_ARG")
+        ;;
+    openblas)
+        BLASPP_BACKEND_FLAGS=(-Dblas=openblas)
+        if [[ "$UNAME_S" == "Darwin" ]]; then
+            # Homebrew's OpenBLAS is not on the default search path, and needs
+            # the gfortran name-mangling convention stated explicitly.
+            if [[ -z "$BREW_PREFIX" || ! -f "$BREW_PREFIX/opt/openblas/lib/libopenblas.dylib" ]]; then
+                die "OpenBLAS was not found under Homebrew. Install it with 'brew install openblas', or choose another backend with --blas=."
+            fi
+            BLASPP_BACKEND_FLAGS=(
+                "-DBLAS_LIBRARIES=$BREW_PREFIX/opt/openblas/lib/libopenblas.dylib"
+                "-Dblas_fortran=add"
+            )
+            LAPACKPP_BACKEND_FLAGS=("-DLAPACK_LIBRARIES=$BREW_PREFIX/opt/openblas/lib/libopenblas.dylib")
+        fi
+        ;;
+esac
+
+#==============================================================================
+# OpenMP. Apple Clang ships no OpenMP runtime; Homebrew's libomp supplies one
+# but only via -Xpreprocessor -fopenmp plus explicit paths, so it has to be
+# wired up by hand rather than found by FindOpenMP.
+#==============================================================================
+OPENMP_FLAGS=()
+if [[ "$WANT_OPENMP" != "1" ]]; then
+    OPENMP_FLAGS=(-DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=TRUE)
+elif [[ "$UNAME_S" == "Darwin" ]]; then
+    LIBOMP=""
+    if [[ -n "$BREW_PREFIX" && -f "$BREW_PREFIX/opt/libomp/lib/libomp.dylib" ]]; then
+        LIBOMP="$BREW_PREFIX/opt/libomp"
+    fi
+    if [[ -n "$LIBOMP" ]]; then
+        MACOS_SDK_PATH="$(xcrun --show-sdk-path 2>/dev/null || true)"
+        if [[ -n "$MACOS_SDK_PATH" ]]; then
+            export CXXFLAGS="${CXXFLAGS:-} -isystem ${MACOS_SDK_PATH}/usr/include/c++/v1"
+        fi
+        export CFLAGS="${CFLAGS:-} -Xpreprocessor -fopenmp -I$LIBOMP/include"
+        export CXXFLAGS="${CXXFLAGS:-} -Xpreprocessor -fopenmp -I$LIBOMP/include"
+        export LDFLAGS="${LDFLAGS:-} -L$LIBOMP/lib"
+        # Both C and CXX components must be described: BLAS++'s installed config
+        # calls find_dependency(OpenMP) without restricting components, so a
+        # consumer resolves OpenMP_C too. With only the CXX variables set that
+        # fails with "Could NOT find OpenMP_C" while configuring RandLAPACK,
+        # long after BLAS++ itself built cleanly.
+        OPENMP_FLAGS=(
+            "-DOpenMP_C_LIB_NAMES=omp"
+            "-DOpenMP_CXX_LIB_NAMES=omp"
+            "-DOpenMP_omp_LIBRARY=$LIBOMP/lib/libomp.dylib"
+            "-DOpenMP_C_FLAGS=-Xpreprocessor;-fopenmp"
+            "-DOpenMP_CXX_FLAGS=-Xpreprocessor;-fopenmp"
+        )
+    else
+        OPENMP_FLAGS=(-DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=TRUE)
+        record_warning "OpenMP is unavailable, so RandLAPACK will be single-threaded. Apple Clang has no OpenMP runtime; install one with 'brew install libomp' and re-run."
+        WANT_OPENMP=0
+    fi
+fi
+
+#==============================================================================
+# Dependency discovery. An install pointed at by an environment variable is
+# taken as given: the user knows something we do not, and rebuilding over it
+# would be both slow and rude.
+#==============================================================================
+find_cmake_config() {  # <root> <package> -> prints the config dir, or nothing
     local root="$1" pkg="$2" libdir
-    for libdir in lib lib64 lib/x86_64-linux-gnu; do
+    for libdir in lib lib64 lib/x86_64-linux-gnu lib/aarch64-linux-gnu; do
         if [[ -f "$root/$libdir/cmake/$pkg/${pkg}Config.cmake" ]]; then
-            echo "$root/$libdir/cmake/$pkg/"
+            printf '%s/%s/cmake/%s' "$root" "$libdir" "$pkg"
             return 0
         fi
     done
     return 0
 }
 
-USE_EXTERNAL_BLASPP=false
-USE_EXTERNAL_LAPACKPP=false
-USE_EXTERNAL_RANDOM123=false
+# Dependency installs are per-configuration. A BLAS++ built for MKL is not
+# interchangeable with one built for OpenBLAS, and one built with
+# gpu_backend=auto is not interchangeable with one built "none".
+#
+# The GPU tag is in the directory name, not only in the provenance stamp, and
+# that is deliberate for a reason beyond this project: RandBLAS's installer
+# uses the same RandNLA-project layout and names its own BLAS++ install
+# "blaspp-<backend>-install". If we used that name too, then with a shared
+# RANDNLA_PROJECT_DIR this script would rebuild over RandBLAS's BLAS++ (their
+# provenance stamp is a different file, so it never matches ours), and
+# RandBLAS's next run would then reuse an artifact we had replaced underneath
+# it while its own stamp still claimed the original -- a silent configuration
+# mismatch of exactly the kind the stamps exist to prevent. Distinct names make
+# that collision impossible.
+#
+# Sharing dependencies between the two projects is therefore explicit rather
+# than automatic: point BLASPP_INSTALL_DIR at an existing install and it is
+# reused, with the conftest confirming it actually works.
+BLASPP_GPU_TAG="$( [[ "$RANDNLA_PROJECT_GPU_AVAIL" == "auto" ]] && echo cuda || echo cpu )"
+BLASPP_INSTALL="$RANDNLA_PROJECT_DIR/install/blaspp-$BLAS_BACKEND-$BLASPP_GPU_TAG-install"
+LAPACKPP_INSTALL="$RANDNLA_PROJECT_DIR/install/lapackpp-$BLAS_BACKEND-$BLASPP_GPU_TAG-install"
+RANDOM123_INSTALL="$RANDNLA_PROJECT_DIR/install/random123"
+
+EXTERNAL_BLASPP=0
+EXTERNAL_LAPACKPP=0
+EXTERNAL_RANDOM123=0
 BLASPP_CMAKE_DIR=""
 LAPACKPP_CMAKE_DIR=""
 RANDOM123_DIR=""
 BLASPP_LIB_DIR=""
 LAPACKPP_LIB_DIR=""
 
-# Idempotent re-runs: a dependency this project already built and installed
-# is reused as if it were external, instead of re-driving its build. This is
-# faster, and it also sidesteps an upstream blaspp defect where re-running
-# cmake over an existing build directory regenerates blas/defines.h WITHOUT
-# the Fortran-mangling and BLAS-backend defines (cached detection results
-# skip the list-building code), which then breaks every downstream compile
-# through LAPACK_GLOBAL. --fresh forces the full rebuild.
-if [[ "$FRESH" != "1" ]]; then
-    if [[ -z "${BLASPP_INSTALL_DIR:-}" ]]; then
-        PRIOR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/blaspp-install" "blaspp")
-        if [[ -n "$PRIOR" ]]; then
-            BLASPP_INSTALL_DIR="$RANDNLA_PROJECT_DIR/install/blaspp-install"
-        fi
-    fi
-    if [[ -z "${LAPACKPP_INSTALL_DIR:-}" ]]; then
-        PRIOR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/lapackpp-install" "lapackpp")
-        if [[ -n "$PRIOR" ]]; then
-            LAPACKPP_INSTALL_DIR="$RANDNLA_PROJECT_DIR/install/lapackpp-install"
-        fi
-    fi
-fi
-
-echo "Dependency discovery:"
+note ""
+note "Dependency discovery:"
 if [[ -n "${BLASPP_INSTALL_DIR:-}" ]]; then
-    BLASPP_CMAKE_DIR=$(find_cmake_config "$BLASPP_INSTALL_DIR" "blaspp")
+    BLASPP_CMAKE_DIR="$(find_cmake_config "$BLASPP_INSTALL_DIR" blaspp)"
     if [[ -n "$BLASPP_CMAKE_DIR" ]]; then
-        USE_EXTERNAL_BLASPP=true
-        BLASPP_LIB_DIR=$(dirname "$(dirname "$BLASPP_CMAKE_DIR")")
-        echo "  [blaspp]    external install: $BLASPP_INSTALL_DIR"
+        EXTERNAL_BLASPP=1
+        BLASPP_LIB_DIR="$(dirname "$(dirname "$BLASPP_CMAKE_DIR")")"
+        note "  [blaspp]    external install: $BLASPP_INSTALL_DIR"
     else
-        echo "  [blaspp]    BLASPP_INSTALL_DIR set but blasppConfig.cmake not found; building from source."
+        note "  [blaspp]    BLASPP_INSTALL_DIR is set but holds no blasppConfig.cmake; building from source."
     fi
-else
-    echo "  [blaspp]    building from source (set BLASPP_INSTALL_DIR to reuse an install)."
 fi
 if [[ -n "${LAPACKPP_INSTALL_DIR:-}" ]]; then
-    LAPACKPP_CMAKE_DIR=$(find_cmake_config "$LAPACKPP_INSTALL_DIR" "lapackpp")
+    LAPACKPP_CMAKE_DIR="$(find_cmake_config "$LAPACKPP_INSTALL_DIR" lapackpp)"
     if [[ -n "$LAPACKPP_CMAKE_DIR" ]]; then
-        USE_EXTERNAL_LAPACKPP=true
-        LAPACKPP_LIB_DIR=$(dirname "$(dirname "$LAPACKPP_CMAKE_DIR")")
-        echo "  [lapackpp]  external install: $LAPACKPP_INSTALL_DIR"
+        EXTERNAL_LAPACKPP=1
+        LAPACKPP_LIB_DIR="$(dirname "$(dirname "$LAPACKPP_CMAKE_DIR")")"
+        note "  [lapackpp]  external install: $LAPACKPP_INSTALL_DIR"
     else
-        echo "  [lapackpp]  LAPACKPP_INSTALL_DIR set but lapackppConfig.cmake not found; building from source."
+        note "  [lapackpp]  LAPACKPP_INSTALL_DIR is set but holds no lapackppConfig.cmake; building from source."
     fi
-else
-    echo "  [lapackpp]  building from source (set LAPACKPP_INSTALL_DIR to reuse an install)."
 fi
-if [[ -n "${RANDOM123_INSTALL_DIR:-}" ]]; then
-    if [[ -f "$RANDOM123_INSTALL_DIR/include/Random123/philox.h" ]]; then
-        USE_EXTERNAL_RANDOM123=true
-        RANDOM123_DIR="$RANDOM123_INSTALL_DIR/include/"
-        echo "  [random123] external install: $RANDOM123_INSTALL_DIR"
-    else
-        echo "  [random123] RANDOM123_INSTALL_DIR set but include/Random123/philox.h not found; cloning."
-    fi
-else
-    echo "  [random123] cloning (set RANDOM123_INSTALL_DIR to reuse an install)."
+if [[ -n "${RANDOM123_INSTALL_DIR:-}" && -f "$RANDOM123_INSTALL_DIR/include/Random123/philox.h" ]]; then
+    EXTERNAL_RANDOM123=1
+    RANDOM123_DIR="$RANDOM123_INSTALL_DIR/include/"
+    note "  [random123] external install: $RANDOM123_INSTALL_DIR"
 fi
 
+# What we would build, and therefore what a prior install must match to be
+# reused. The GPU setting is part of the stamp because a CUDA-linked BLAS++
+# cannot stand in for a CPU-only one -- without it, switching --gpu to --no-gpu
+# silently reuses the wrong artifact.
+BLASPP_STAMP_BASE="$BLASPP_URL@$BLASPP_REF backend=$BLAS_BACKEND libs=$BLAS_LIBRARIES_ARG gpu=$RANDNLA_PROJECT_GPU_AVAIL"
+LAPACKPP_STAMP_BASE="$LAPACKPP_URL@$LAPACKPP_REF backend=$BLAS_BACKEND libs=$BLAS_LIBRARIES_ARG gpu=$RANDNLA_PROJECT_GPU_AVAIL"
+RANDOM123_STAMP="$RANDOM123_URL@$RANDOM123_REF"
+
 #==============================================================================
-# Sources: submodule, self-move into the layout, dependency clones.
+# Step accounting, computed up front so "[3/12]" means something.
+#   BLAS++    3 (source, configure, build) -- the reuse path spends 3 skips
+#   LAPACK++  2 (source+configure, build)
+#   Random123 1
+#   RandLAPACK 2, verification 1
+#   extras 2, benchmarks 2
 #==============================================================================
-git -C "$REPO_DIR" submodule init >> "$LOG" 2>&1
+BUILD_BLASPP=$(( EXTERNAL_BLASPP ? 0 : 1 ))
+BUILD_LAPACKPP=$(( EXTERNAL_LAPACKPP ? 0 : 1 ))
+BUILD_RANDOM123=$(( EXTERNAL_RANDOM123 ? 0 : 1 ))
+
+if (( FRESH )); then
+    rm -rf "$RANDNLA_PROJECT_DIR/build"
+fi
+mkdir -p "$RANDNLA_PROJECT_DIR/build"
+
+TOTAL_STEPS=$(( BUILD_BLASPP * 3 + BUILD_LAPACKPP * 2 + BUILD_RANDOM123 + 3 ))
+(( WANT_EXTRAS ))     && TOTAL_STEPS=$(( TOTAL_STEPS + 2 )) || true
+(( WANT_BENCHMARKS )) && TOTAL_STEPS=$(( TOTAL_STEPS + 2 )) || true
+note ""
+
+# RandBLAS is a submodule pinned to an exact commit and stays authoritative.
+git -C "$REPO_DIR" submodule init   >> "$LOG" 2>&1
 git -C "$REPO_DIR" submodule update >> "$LOG" 2>&1
 
-if [[ ! -d "$RANDNLA_PROJECT_DIR/lib/RandLAPACK" ]]; then
-    mv "$REPO_DIR" "$RANDNLA_PROJECT_DIR/lib/RandLAPACK"
-    echo "Moved this clone to $RANDNLA_PROJECT_DIR/lib/RandLAPACK"
-fi
-
-if [[ "$USE_EXTERNAL_LAPACKPP" != "true" && ! -d "$RANDNLA_PROJECT_DIR/lib/lapackpp" ]]; then
-    git clone https://github.com/icl-utk-edu/lapackpp "$RANDNLA_PROJECT_DIR/lib/lapackpp" >> "$LOG" 2>&1
-fi
-if [[ "$USE_EXTERNAL_BLASPP" != "true" && ! -d "$RANDNLA_PROJECT_DIR/lib/blaspp" ]]; then
-    git clone https://github.com/icl-utk-edu/blaspp "$RANDNLA_PROJECT_DIR/lib/blaspp" >> "$LOG" 2>&1
-fi
-if [[ "$USE_EXTERNAL_RANDOM123" != "true" && ! -d "$RANDNLA_PROJECT_DIR/install/random123" ]]; then
-    git clone https://github.com/DEShawResearch/random123.git "$RANDNLA_PROJECT_DIR/install/random123" >> "$LOG" 2>&1
-fi
-
 #==============================================================================
-# Builds. Each pair below is one configure step + one build step; skipped
-# steps still advance the counter so the numbering is stable.
+# BLAS++.
+#
+# The integer width is settled by asking BLAS++ to configure at each width in
+# WIDTH_ORDER until one succeeds, then reading back what it actually built.
+# Each attempt gets a clean build directory: BLAS++ caches its detection
+# results, and re-running cmake over a directory where detection previously
+# failed regenerates blas/defines.h WITHOUT the Fortran-mangling and backend
+# defines, which then breaks every downstream compile through LAPACK_GLOBAL in
+# a way that looks nothing like the original failure.
 #==============================================================================
-if [[ "$USE_EXTERNAL_BLASPP" != "true" ]]; then
-    # Add "-DBLAS_LIBRARIES='-lflame -lblis'" here if using AMD AOCL.
-    # The MACOS_* variables expand unquoted on purpose: they hold multiple
-    # -D words, and some values are CMake lists with semicolons, which must
-    # reach cmake verbatim (never re-parse them through a shell string).
-    run_step "Configuring BLAS++" \
-        cmake -S "$RANDNLA_PROJECT_DIR/lib/blaspp/" -B "$RANDNLA_PROJECT_DIR/build/blaspp-build/" \
-            -Dgpu_backend=$RANDNLA_PROJECT_GPU_AVAIL \
-            -DCMAKE_BUILD_TYPE=Release \
-            -Dblas_int=$BLAS_INT \
-            -DCMAKE_INSTALL_PREFIX="$RANDNLA_PROJECT_DIR/install/blaspp-install/" \
-            $MACOS_BLAS_FLAGS $MACOS_OPENMP_FLAGS
-    run_step "Building + installing BLAS++" \
-        cmake --build "$RANDNLA_PROJECT_DIR/build/blaspp-build/" -j "$JOBS" --target install
-    BLASPP_CMAKE_DIR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/blaspp-install" "blaspp")
-    BLASPP_LIB_DIR=$(dirname "$(dirname "$BLASPP_CMAKE_DIR")")
-else
-    STEP=$((STEP + 2)); echo "[$STEP/$TOTAL_STEPS] BLAS++ ... reused external install"
-fi
+BLASPP_SRC="$RANDNLA_PROJECT_DIR/lib/blaspp"
+BLAS_INT_RESOLVED=""
 
-if [[ "$USE_EXTERNAL_LAPACKPP" != "true" ]]; then
-    run_step "Configuring LAPACK++" \
-        cmake -S "$RANDNLA_PROJECT_DIR/lib/lapackpp/" -B "$RANDNLA_PROJECT_DIR/build/lapackpp-build/" \
-            -Dgpu_backend=$RANDNLA_PROJECT_GPU_AVAIL \
-            -DCMAKE_BUILD_TYPE=Release \
-            -Dblaspp_DIR="$BLASPP_CMAKE_DIR" \
-            -DCMAKE_INSTALL_PREFIX="$RANDNLA_PROJECT_DIR/install/lapackpp-install" \
-            -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
-            $MACOS_LAPACK_FLAGS $MACOS_OPENMP_FLAGS
-    run_step "Building + installing LAPACK++" \
-        cmake --build "$RANDNLA_PROJECT_DIR/build/lapackpp-build/" -j "$JOBS" --target install
-    LAPACKPP_CMAKE_DIR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/lapackpp-install" "lapackpp")
-    LAPACKPP_LIB_DIR=$(dirname "$(dirname "$LAPACKPP_CMAKE_DIR")")
-else
-    STEP=$((STEP + 2)); echo "[$STEP/$TOTAL_STEPS] LAPACK++ ... reused external install"
-fi
-
-if [[ "$USE_EXTERNAL_RANDOM123" != "true" ]]; then
-    RANDOM123_DIR="$RANDNLA_PROJECT_DIR/install/random123/include/"
-fi
-
-RL_SRC="$RANDNLA_PROJECT_DIR/lib/RandLAPACK"
-run_step "Configuring RandLAPACK" \
-    cmake -S "$RL_SRC" -B "$RANDNLA_PROJECT_DIR/build/RandLAPACK-build/" \
+configure_blaspp_at_width() {
+    local width="$1" build="$RANDNLA_PROJECT_DIR/build/blaspp-build-$width"
+    rm -rf "$build"; mkdir -p "$build"
+    cmake -S "$BLASPP_SRC" -B "$build" \
         -DCMAKE_BUILD_TYPE=Release \
-        -DRequireCUDA=$RANDLAPACK_CUDA \
-        -Dlapackpp_DIR="$LAPACKPP_CMAKE_DIR" \
-        -Dblaspp_DIR="$BLASPP_CMAKE_DIR" \
-        -DRandom123_DIR="$RANDOM123_DIR" \
-        -DCMAKE_INSTALL_PREFIX="$RANDNLA_PROJECT_DIR/install/RandLAPACK-install" \
+        -DCMAKE_INSTALL_PREFIX="$BLASPP_INSTALL" \
         -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
-        -DBUILD_TESTS=OFF -DRandLAPACK_BUILD_TESTS=ON $MACOS_OPENMP_FLAGS
-run_step "Building + installing RandLAPACK" \
-    cmake --build "$RANDNLA_PROJECT_DIR/build/RandLAPACK-build/" -j "$JOBS" --target install
-RANDLAPACK_CMAKE_DIR=$(find_cmake_config "$RANDNLA_PROJECT_DIR/install/RandLAPACK-install" "RandLAPACK")
-RANDLAPACK_LIB_DIR=$(dirname "$(dirname "$RANDLAPACK_CMAKE_DIR")")
+        -Dgpu_backend="$RANDNLA_PROJECT_GPU_AVAIL" \
+        -Dblas_int="$width" \
+        -Dbuild_tests=OFF \
+        "${BLASPP_BACKEND_FLAGS[@]}" "${OPENMP_FLAGS[@]}" >> "$LOG" 2>&1
+}
 
-# If GPU support is disabled AND blaspp was built from source, keep extras and
-# benchmarks from auto-detecting CUDA. With an external blaspp, its own config
-# dictates whether CUDAToolkit is required.
-DISABLE_CUDA_FLAG=""
-if [[ "$RANDLAPACK_CUDA" == "OFF" && "$USE_EXTERNAL_BLASPP" != "true" ]]; then
-    DISABLE_CUDA_FLAG="-DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=TRUE"
+if (( BUILD_BLASPP )); then
+    PRIOR_WIDTH="$(cat "$BLASPP_INSTALL/.randlapack-width" 2>/dev/null || true)"
+    REUSABLE=0
+    if (( ! FRESH )) && [[ -n "$PRIOR_WIDTH" ]] && \
+       stamp_matches "$BLASPP_INSTALL" "$BLASPP_STAMP_BASE width=$PRIOR_WIDTH"; then
+        for w in "${WIDTH_ORDER[@]}"; do
+            if [[ "$w" == "$PRIOR_WIDTH" ]]; then REUSABLE=1; break; fi
+        done
+        if (( ! REUSABLE )); then
+            note "  [blaspp] existing install is $PRIOR_WIDTH but this run wants ${WIDTH_ORDER[0]}; rebuilding."
+        fi
+    fi
+
+    if (( REUSABLE )); then
+        BLAS_INT_RESOLVED="$PRIOR_WIDTH"
+        BLASPP_CMAKE_DIR="$(find_cmake_config "$BLASPP_INSTALL" blaspp)"
+        BLASPP_LIB_DIR="$(dirname "$(dirname "$BLASPP_CMAKE_DIR")")"
+        skip_step "BLAS++ source ... already present"
+        skip_step "BLAS++ ... reusing the $BLAS_INT_RESOLVED install"
+        skip_step "BLAS++ ... already built"
+    else
+        if source_is_current "$BLASPP_SRC" "$BLASPP_URL" "$BLASPP_REF"; then
+            skip_step "BLAS++ source ... already at $BLASPP_REF"
+        else
+            run_step "Fetching BLAS++ ($BLASPP_REF)" \
+                clone_pinned "$BLASPP_URL" "$BLASPP_SRC" "$BLASPP_REF"
+        fi
+
+        STEP=$((STEP + 1))
+        printf '%s[%d/%d]%s Configuring BLAS++ ... ' "$C_BOLD" "$STEP" "$TOTAL_STEPS" "$C_OFF"
+        for width in "${WIDTH_ORDER[@]}"; do
+            if configure_blaspp_at_width "$width"; then BLAS_INT_RESOLVED="$width"; break; fi
+        done
+        if [[ -z "$BLAS_INT_RESOLVED" ]]; then
+            printf '%sFAILED%s\n' "$C_ERR" "$C_OFF" >&2
+            printf '\nBLAS++ could not find a usable %s BLAS at any of: %s\nFull output: %s\n' \
+                "$BLAS_BACKEND" "${WIDTH_ORDER[*]}" "$LOG" >&2
+            case "$BLAS_BACKEND" in
+                openblas) printf '\n  sudo apt install libopenblas-dev      # Debian, Ubuntu\n  brew install openblas                 # macOS\n' >&2 ;;
+                mkl)      printf '\n  Set MKLROOT, or source the oneAPI setvars script.\n' >&2 ;;
+            esac
+            exit 1
+        fi
+        printf '%sdone%s (requested %s)\n' "$C_OK" "$C_OFF" "$BLAS_INT_RESOLVED"
+
+        run_build_step "Building and installing BLAS++" \
+            cmake --build "$RANDNLA_PROJECT_DIR/build/blaspp-build-$BLAS_INT_RESOLVED" \
+                -j "$JOBS" --target install
+
+        # The width actually built, read back from BLAS++'s own generated header
+        # rather than inferred from which configure attempt succeeded. Those can
+        # differ: BLAS++ probes int32 before int64, while blas_int only filters
+        # which *library names* to consider. For MKL that is enough, because
+        # mkl_intel_lp64 and mkl_intel_ilp64 are different libraries. For
+        # OpenBLAS there is only -lopenblas, so asking for int64 and getting a
+        # successful configure tells us nothing -- an LP64 OpenBLAS passes the
+        # int32 probe and is accepted. Trusting the request here would stamp an
+        # LP64 install as ILP64, and every later run would reuse it believing
+        # it had ILP64.
+        if grep -q '^#define BLAS_ILP64' "$BLASPP_INSTALL/include/blas/defines.h" 2>/dev/null; then
+            BLAS_INT_BUILT="int64"
+        else
+            BLAS_INT_BUILT="int32"
+        fi
+        if [[ "$BLAS_INT_BUILT" != "$BLAS_INT_RESOLVED" ]]; then
+            note "  [blaspp] requested $BLAS_INT_RESOLVED, BLAS++ selected $BLAS_INT_BUILT"
+        fi
+        BLAS_INT_RESOLVED="$BLAS_INT_BUILT"
+
+        if [[ "$BLAS_INT_RESOLVED" == "int32" && "${WIDTH_ORDER[0]}" == "int64" ]]; then
+            record_warning "No ILP64 $BLAS_BACKEND was available, so BLAS++ was built LP64 (32-bit BLAS integers). RandLAPACK works either way -- BLAS++ and LAPACK++ throw rather than truncate if a dimension exceeds the range -- but individual matrix dimensions are then capped at 2^31. BLAS++ only ever looks for plain -lopenblas, so an ILP64 OpenBLAS has to be named explicitly with --blas=custom --blas-libraries=... --blas-int=ilp64."
+        fi
+
+        write_stamp "$BLASPP_INSTALL" "$BLASPP_STAMP_BASE width=$BLAS_INT_RESOLVED"
+        printf '%s\n' "$BLAS_INT_RESOLVED" > "$BLASPP_INSTALL/.randlapack-width"
+        BLASPP_CMAKE_DIR="$(find_cmake_config "$BLASPP_INSTALL" blaspp)"
+        BLASPP_LIB_DIR="$(dirname "$(dirname "$BLASPP_CMAKE_DIR")")"
+    fi
+fi
+[[ -n "$BLASPP_CMAKE_DIR" ]] || die "BLAS++ was installed but blasppConfig.cmake could not be located under $BLASPP_INSTALL"
+
+#==============================================================================
+# LAPACK++, built against the BLAS++ resolved above.
+#==============================================================================
+LAPACKPP_SRC="$RANDNLA_PROJECT_DIR/lib/lapackpp"
+if (( BUILD_LAPACKPP )); then
+    LAPACKPP_STAMP="$LAPACKPP_STAMP_BASE width=$BLAS_INT_RESOLVED"
+    if (( ! FRESH )) && stamp_matches "$LAPACKPP_INSTALL" "$LAPACKPP_STAMP"; then
+        LAPACKPP_CMAKE_DIR="$(find_cmake_config "$LAPACKPP_INSTALL" lapackpp)"
+        LAPACKPP_LIB_DIR="$(dirname "$(dirname "$LAPACKPP_CMAKE_DIR")")"
+        skip_step "LAPACK++ ... reusing existing install"
+        skip_step "LAPACK++ ... already built"
+    else
+        configure_lapackpp() {
+            local build="$RANDNLA_PROJECT_DIR/build/lapackpp-build"
+            rm -rf "$build"; mkdir -p "$build"
+            if ! source_is_current "$LAPACKPP_SRC" "$LAPACKPP_URL" "$LAPACKPP_REF"; then
+                clone_pinned "$LAPACKPP_URL" "$LAPACKPP_SRC" "$LAPACKPP_REF"
+            fi
+            cmake -S "$LAPACKPP_SRC" -B "$build" \
+                -DCMAKE_BUILD_TYPE=Release \
+                -DCMAKE_INSTALL_PREFIX="$LAPACKPP_INSTALL" \
+                -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
+                -Dgpu_backend="$RANDNLA_PROJECT_GPU_AVAIL" \
+                -Dblaspp_DIR="$BLASPP_CMAKE_DIR" \
+                -Dbuild_tests=OFF \
+                "${LAPACKPP_BACKEND_FLAGS[@]}" "${OPENMP_FLAGS[@]}"
+        }
+        run_step "Fetching and configuring LAPACK++ ($LAPACKPP_REF)" configure_lapackpp
+        run_build_step "Building and installing LAPACK++" \
+            cmake --build "$RANDNLA_PROJECT_DIR/build/lapackpp-build" -j "$JOBS" --target install
+        write_stamp "$LAPACKPP_INSTALL" "$LAPACKPP_STAMP"
+        LAPACKPP_CMAKE_DIR="$(find_cmake_config "$LAPACKPP_INSTALL" lapackpp)"
+        LAPACKPP_LIB_DIR="$(dirname "$(dirname "$LAPACKPP_CMAKE_DIR")")"
+    fi
+fi
+[[ -n "$LAPACKPP_CMAKE_DIR" ]] || die "LAPACK++ was installed but lapackppConfig.cmake could not be located under $LAPACKPP_INSTALL"
+
+#==============================================================================
+# Random123. Header-only: fetch and use in place.
+#==============================================================================
+if (( BUILD_RANDOM123 )); then
+    if (( ! FRESH )) && stamp_matches "$RANDOM123_INSTALL" "$RANDOM123_STAMP"; then
+        skip_step "Random123 ... reusing existing install"
+    else
+        run_step "Fetching Random123 ($RANDOM123_REF)" \
+            clone_pinned "$RANDOM123_URL" "$RANDOM123_INSTALL" "$RANDOM123_REF"
+        write_stamp "$RANDOM123_INSTALL" "$RANDOM123_STAMP"
+    fi
+    RANDOM123_DIR="$RANDOM123_INSTALL/include/"
 fi
 
-run_step "Configuring extras" \
-    cmake -S "$RL_SRC/extras/" -B "$RANDNLA_PROJECT_DIR/build/extras-build/" \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DFETCHCONTENT_BASE_DIR="$RANDNLA_PROJECT_DIR/build/fetchcontent-cache/" \
-        -DRandLAPACK_DIR="$RANDLAPACK_CMAKE_DIR" \
-        -Dlapackpp_DIR="$LAPACKPP_CMAKE_DIR" \
-        -Dblaspp_DIR="$BLASPP_CMAKE_DIR" \
-        -DRandom123_DIR="$RANDOM123_DIR" \
-        -DCMAKE_BUILD_RPATH="$BLASPP_LIB_DIR;$LAPACKPP_LIB_DIR;$RANDLAPACK_LIB_DIR" \
-        $DISABLE_CUDA_FLAG $MACOS_OPENMP_FLAGS
-run_step "Building extras" \
-    cmake --build "$RANDNLA_PROJECT_DIR/build/extras-build/" -j "$JOBS"
+#==============================================================================
+# RandLAPACK.
+#==============================================================================
+RANDLAPACK_BUILD="$RANDNLA_PROJECT_DIR/build/RandLAPACK-build"
+mkdir -p "$RANDLAPACK_BUILD"
 
-run_step "Configuring benchmarks" \
-    cmake -S "$RL_SRC/benchmark/" -B "$RANDNLA_PROJECT_DIR/build/benchmark-build/" \
+run_step "Configuring RandLAPACK" \
+    cmake -S "$RL_SRC" -B "$RANDLAPACK_BUILD" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DRequireCUDA="$RANDLAPACK_CUDA" \
+        -Dlapackpp_DIR="$LAPACKPP_CMAKE_DIR" \
+        -Dblaspp_DIR="$BLASPP_CMAKE_DIR" \
+        -DRandom123_DIR="$RANDOM123_DIR" \
+        -DCMAKE_INSTALL_PREFIX="$RANDLAPACK_INSTALL_DIR" \
+        -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON \
+        -DBUILD_TESTS=OFF -DRandLAPACK_BUILD_TESTS=ON \
+        "${OPENMP_FLAGS[@]}"
+run_build_step "Building and installing RandLAPACK" \
+    cmake --build "$RANDLAPACK_BUILD" -j "$JOBS" --target install
+
+RANDLAPACK_CMAKE_DIR="$(find_cmake_config "$RANDLAPACK_INSTALL_DIR" RandLAPACK)"
+RANDLAPACK_LIB_DIR="$(dirname "$(dirname "$RANDLAPACK_CMAKE_DIR")")"
+
+#==============================================================================
+# Verification.
+#
+# Compile, link and *run* a program against the finished install. Configuring
+# successfully is not the same as producing something that works, and one
+# failure mode here is genuinely silent: BLAS++ and LAPACK++ guard the
+# int64_t -> blas_int downcast, so an oversized dimension throws, but that guard
+# keys off sizeof(blas_int) as declared by the *header*. If the headers say
+# 64-bit while the library actually loaded is LP64, the guard compiles out and
+# 64-bit values reach routines reading 32 bits -- which surfaces not as wrong
+# numbers but as nonsense control values, an absurd workspace size, and a run
+# that dies in allocation or never finishes. Nothing catches that by inspection;
+# only running something does.
+#
+# The test goes through BLAS++ and LAPACK++ rather than raw dgemm_, because that
+# is how RandLAPACK reaches them, and it calls gesdd specifically: that is the
+# routine Apple's legacy Accelerate gets wrong, so a broken SVD shows up here
+# rather than inside somebody's RSVD results.
+#==============================================================================
+CONFTEST_DIR="$RANDNLA_PROJECT_DIR/build/conftest"
+rm -rf "$CONFTEST_DIR"; mkdir -p "$CONFTEST_DIR/src"
+
+cat > "$CONFTEST_DIR/src/CMakeLists.txt" <<'CONFTEST_CMAKE'
+cmake_minimum_required(VERSION 3.21)
+project(randlapack_conftest CXX)
+find_package(RandLAPACK REQUIRED)
+add_executable(conftest conftest.cc)
+# RandLAPACK::RandLAPACK, not the bare name: the namespaced alias is what the
+# installed package exports and what carries the transitive BLAS++/LAPACK++
+# interface, including their include directories. Linking bare "RandLAPACK"
+# compiles until the first #include <blas.hh>. This mirrors what
+# benchmark/CMakeLists.txt links.
+target_link_libraries(conftest RandLAPACK::RandLAPACK)
+CONFTEST_CMAKE
+
+cat > "$CONFTEST_DIR/src/conftest.cc" <<'CONFTEST_CC'
+// Exercise the whole stack the way RandLAPACK does: a BLAS++ gemm and a
+// LAPACK++ gesdd, with the numbers checked. A half-linked BLAS, a
+// header/library integer-width disagreement, or Apple's broken
+// divide-and-conquer gesdd all show up here rather than in a user's results.
+#include <blas.hh>
+#include <lapack.hh>
+#include <blas/defines.h>
+#include <cstdio>
+#include <cmath>
+#include <vector>
+
+int main() {
+#if defined(BLAS_ILP64)
+    std::printf("blas_ilp64=1\n");
+#else
+    std::printf("blas_ilp64=0\n");
+#endif
+
+    // A 6x3 matrix with known singular values: columns scaled 3, 2, 1 from an
+    // orthonormal basis, so the singular values must come back {3, 2, 1}.
+    const int64_t m = 6, n = 3;
+    std::vector<double> A(m * n, 0.0);
+    A[0 + 0 * m] = 3.0;
+    A[1 + 1 * m] = 2.0;
+    A[2 + 2 * m] = 1.0;
+
+    // Round-trip through gemm first: C = A^T A, whose eigenvalues are {9,4,1}.
+    std::vector<double> C(n * n, 0.0);
+    blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
+               n, n, m, 1.0, A.data(), m, A.data(), m, 0.0, C.data(), n);
+    const double expect_diag[3] = {9.0, 4.0, 1.0};
+    for (int64_t i = 0; i < n; ++i) {
+        if (std::fabs(C[i + i * n] - expect_diag[i]) > 1e-10) {
+            std::printf("FAIL: gemm gave C[%lld,%lld] = %f, expected %f\n",
+                        (long long)i, (long long)i, C[i + i * n], expect_diag[i]);
+            return 1;
+        }
+    }
+
+    // Then gesdd, the routine Apple's legacy Accelerate computes incorrectly.
+    std::vector<double> S(n), U(m * n), VT(n * n);
+    int64_t info = lapack::gesdd(lapack::Job::SomeVec, m, n, A.data(), m,
+                                 S.data(), U.data(), m, VT.data(), n);
+    if (info != 0) {
+        std::printf("FAIL: gesdd returned info = %lld\n", (long long)info);
+        return 1;
+    }
+    const double expect_sv[3] = {3.0, 2.0, 1.0};
+    for (int64_t i = 0; i < n; ++i) {
+        if (std::fabs(S[i] - expect_sv[i]) > 1e-9) {
+            std::printf("FAIL: gesdd gave singular value %lld = %f, expected %f\n",
+                        (long long)i, S[i], expect_sv[i]);
+            return 1;
+        }
+    }
+    std::printf("OK\n");
+    return 0;
+}
+CONFTEST_CC
+
+verify_install() {
+    cmake -S "$CONFTEST_DIR/src" -B "$CONFTEST_DIR/build" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_PREFIX_PATH="$RANDLAPACK_INSTALL_DIR" \
+        -DRandLAPACK_DIR="$RANDLAPACK_CMAKE_DIR" \
+        -Dlapackpp_DIR="$LAPACKPP_CMAKE_DIR" \
+        -Dblaspp_DIR="$BLASPP_CMAKE_DIR" \
+        -DRandom123_DIR="$RANDOM123_DIR" \
+        -DCMAKE_BUILD_RPATH="$BLASPP_LIB_DIR;$LAPACKPP_LIB_DIR;$RANDLAPACK_LIB_DIR" \
+        "${OPENMP_FLAGS[@]}" >> "$LOG" 2>&1
+    cmake --build "$CONFTEST_DIR/build" -j "$JOBS" >> "$LOG" 2>&1
+    "$CONFTEST_DIR/build/conftest" > "$CONFTEST_DIR/output.txt" 2>&1
+    grep -q '^OK$' "$CONFTEST_DIR/output.txt"
+}
+run_step "Verifying the install links and runs" verify_install
+cat "$CONFTEST_DIR/output.txt" >> "$LOG"
+
+# Read the width back from what was actually compiled rather than trusting what
+# this script asked for; they differ whenever BLAS++ came from elsewhere.
+case "$(sed -n 's/^blas_ilp64=//p' "$CONFTEST_DIR/output.txt" | head -n1)" in
+    1) OBSERVED_WIDTH="ILP64 (64-bit BLAS integers)" ;;
+    0) OBSERVED_WIDTH="LP64 (32-bit BLAS integers)" ;;
+    *) OBSERVED_WIDTH="unknown" ;;
+esac
+
+#==============================================================================
+# Extras and benchmarks.
+#
+# Built by default, unlike RandBLAS's examples: these need only RandLAPACK,
+# BLAS++, LAPACK++ and Random123, every one of which is already built by this
+# point, so there is nothing extra to fetch and nothing new that can fail.
+#
+# If GPU support is disabled AND blaspp was built from source, keep them from
+# auto-detecting CUDA. With an external blaspp, its own config dictates whether
+# CUDAToolkit is required.
+#==============================================================================
+DISABLE_CUDA_FLAG=()
+if [[ "$RANDLAPACK_CUDA" == "OFF" ]] && (( ! EXTERNAL_BLASPP )); then
+    DISABLE_CUDA_FLAG=(-DCMAKE_DISABLE_FIND_PACKAGE_CUDAToolkit=TRUE)
+fi
+
+configure_subproject() {  # <source-subdir> <build-dir>
+    cmake -S "$RL_SRC/$1" -B "$2" \
         -DCMAKE_BUILD_TYPE=Release \
         -DFETCHCONTENT_BASE_DIR="$RANDNLA_PROJECT_DIR/build/fetchcontent-cache/" \
         -DRandLAPACK_DIR="$RANDLAPACK_CMAKE_DIR" \
@@ -433,16 +1058,28 @@ run_step "Configuring benchmarks" \
         -Dblaspp_DIR="$BLASPP_CMAKE_DIR" \
         -DRandom123_DIR="$RANDOM123_DIR" \
         -DCMAKE_BUILD_RPATH="$BLASPP_LIB_DIR;$LAPACKPP_LIB_DIR;$RANDLAPACK_LIB_DIR" \
-        $DISABLE_CUDA_FLAG $MACOS_OPENMP_FLAGS
-run_step "Building benchmarks" \
-    cmake --build "$RANDNLA_PROJECT_DIR/build/benchmark-build/" -j "$JOBS"
+        "${DISABLE_CUDA_FLAG[@]}" "${OPENMP_FLAGS[@]}"
+}
+
+if (( WANT_EXTRAS )); then
+    run_step "Configuring extras" \
+        configure_subproject "extras" "$RANDNLA_PROJECT_DIR/build/extras-build"
+    run_build_step "Building extras" \
+        cmake --build "$RANDNLA_PROJECT_DIR/build/extras-build" -j "$JOBS"
+fi
+if (( WANT_BENCHMARKS )); then
+    run_step "Configuring benchmarks" \
+        configure_subproject "benchmark" "$RANDNLA_PROJECT_DIR/build/benchmark-build"
+    run_build_step "Building benchmarks" \
+        cmake --build "$RANDNLA_PROJECT_DIR/build/benchmark-build" -j "$JOBS"
+fi
 
 #==============================================================================
 # Shell config: opt-in only. The default prints what to add and touches nothing.
 #==============================================================================
 if [[ "$(basename "${SHELL:-bash}")" == "zsh" ]]; then
     SHELL_RC="$HOME/.zshrc"
-elif [[ "$(uname)" == "Darwin" ]]; then
+elif [[ "$UNAME_S" == "Darwin" ]]; then
     SHELL_RC="$HOME/.bash_profile"
 else
     SHELL_RC="$HOME/.bashrc"
@@ -456,31 +1093,34 @@ if [[ "$MODIFY_RC" == "1" ]]; then
     if ! grep -q "export RANDNLA_PROJECT_GPU_AVAIL=" "$SHELL_RC" 2>/dev/null; then
         echo "$EXPORT_GPU" >> "$SHELL_RC"
     fi
-    echo "Added RANDNLA_PROJECT_DIR and RANDNLA_PROJECT_GPU_AVAIL to $SHELL_RC (open a new shell to pick them up)."
+    note "Added RANDNLA_PROJECT_DIR and RANDNLA_PROJECT_GPU_AVAIL to $SHELL_RC (open a new shell to pick them up)."
 fi
 
 #==============================================================================
-# Success summary.
+# Summary.
 #==============================================================================
-echo ""
-echo "${C_OK}${C_BOLD}RandLAPACK installed successfully.${C_OFF}"
-echo ""
-echo "  Project layout:    $RANDNLA_PROJECT_DIR"
-echo "  Installed library: $RANDNLA_PROJECT_DIR/install/RandLAPACK-install"
-echo "  Extras:            $RANDNLA_PROJECT_DIR/build/extras-build/"
-echo "  Benchmarks:        $RANDNLA_PROJECT_DIR/build/benchmark-build/"
-echo "  Full build log:    $LOG"
-echo ""
-echo "  Smoke test:"
-echo "    ctest --test-dir $RANDNLA_PROJECT_DIR/build/RandLAPACK-build"
-echo ""
-echo "  Consume from CMake with:"
-echo "    -DRandLAPACK_DIR=$RANDLAPACK_CMAKE_DIR"
-if [[ "$MODIFY_RC" != "1" ]]; then
-    echo ""
-    echo "  The benchmark scripts expect two environment variables. This script"
-    echo "  no longer edits your shell config; add them yourself if needed:"
-    echo "    $EXPORT_DIR"
-    echo "    $EXPORT_GPU"
-    echo "  (or re-run with --modify-rc to have them appended to $SHELL_RC)"
+printf '\n%s%sRandLAPACK installed successfully.%s\n\n' "$C_OK" "$C_BOLD" "$C_OFF"
+printf '  Backend            %s, %s\n' "$BLAS_BACKEND" "$OBSERVED_WIDTH"
+printf '  GPU support        %s\n' "$( [[ "$RANDLAPACK_CUDA" == "ON" ]] && echo "CUDA" || echo "disabled" )"
+printf '  OpenMP             %s\n' "$( ((WANT_OPENMP)) && echo enabled || echo disabled )"
+printf '  Project layout     %s\n' "$RANDNLA_PROJECT_DIR"
+printf '  Installed library  %s\n' "$RANDLAPACK_INSTALL_DIR"
+(( WANT_EXTRAS ))     && printf '  Extras             %s\n' "$RANDNLA_PROJECT_DIR/build/extras-build"
+(( WANT_BENCHMARKS )) && printf '  Benchmarks         %s\n' "$RANDNLA_PROJECT_DIR/build/benchmark-build"
+printf '  Full build log     %s\n' "$LOG"
+
+if (( ${#WARNINGS[@]} )); then
+    printf '\n%s%d warning(s) from this run:%s\n' "$C_WARN" "${#WARNINGS[@]}" "$C_OFF"
+    for w in "${WARNINGS[@]}"; do printf '  - %s\n' "$w"; done
 fi
+
+printf '\n  Run the test suite:\n    ctest --test-dir %s\n' "$RANDLAPACK_BUILD"
+printf '\n  Consume from CMake with:\n    -DRandLAPACK_DIR=%s\n' "$RANDLAPACK_CMAKE_DIR"
+
+if [[ "$MODIFY_RC" != "1" ]]; then
+    printf '\n  The benchmark scripts expect two environment variables. This script\n'
+    printf '  does not edit your shell config; add them yourself if needed:\n'
+    printf '    %s\n    %s\n' "$EXPORT_DIR" "$EXPORT_GPU"
+    printf '  (or re-run with --modify-rc)\n'
+fi
+printf '\n'


### PR DESCRIPTION
## Problem

RandLAPACK's two installers had drifted apart. `install/install.ps1` was rebuilt in #156 and pins every dependency, checksums downloads, records provenance and link-and-run validates the BLAS before building anything. `install/install.sh` did none of that, and the documentation described a script that no longer existed in several respects.

Eleven defects, all verified against `main` before touching anything:

| Where | Defect |
|---|---|
| `install.sh:336,339,342` | three `git clone` with **no ref** — blaspp, lapackpp, random123 all tracked upstream default branches |
| — | **no BLAS validation at all** |
| — | `/opt/homebrew` hardcoded, **8 places** — hard-fails on Intel macOS and custom `HOMEBREW_PREFIX` |
| `install.sh:331` | `mv "$REPO_DIR"` relocated the user's own clone, breaking git worktrees |
| `install.sh:211` | `: > "$LOG"` truncated the log, destroying the previous run's output |
| `install.sh:247` | libdir search omitted `lib/aarch64-linux-gnu` |
| — | no `--prefix`; extras and benchmarks unconditional with no way to skip |
| `install.ps1` | **zero** references to `RANDNLA_PROJECT_DIR`, no `--modify-rc` equivalent |
| `INSTALL_SCRIPT.md` | documented the pre-backend flag list, and still told people the script would move their clone |

## The two things most worth reviewing

### Integer width is read back, not assumed

BLAS++ probes `int32` before `int64`, and `blas_int` only filters which *library names* to try. For MKL that is a real choice — `mkl_intel_lp64` and `mkl_intel_ilp64` are different libraries. For OpenBLAS there is only `-lopenblas`, so **a successful `blas_int=int64` configure proves nothing**: an LP64 build passes the `int32` probe and is accepted. The resolved width therefore comes from BLAS++'s generated `blas/defines.h` after the build. Trusting the request would stamp LP64 installs as ILP64 and have every later run reuse them believing otherwise.

### Verification runs the program, and that is the point

The conftest compiles, links and *runs* against the finished install — through BLAS++ and LAPACK++ rather than raw `dgemm_`, since that is how RandLAPACK reaches them — checking a `gemm` result and a `gesdd` factorization numerically. `gesdd` is chosen because it is the routine Apple's legacy Accelerate computes incorrectly.

Running it rather than only linking matters for a reason specific to integer width. BLAS++ and LAPACK++ *do* guard the `int64_t` downcast — `to_blas_int` (`blaspp/src/blas_internal.hh:16-22`) throws rather than truncates — but that guard keys off `sizeof(blas_int)` **as declared by the header**. If the headers say 64-bit while the library actually loaded is LP64, the guard compiles out and 64-bit values reach routines reading 32 bits. That surfaces not as wrong numbers but as nonsense control values: a misread workspace query becomes an absurd `lwork`, and the run dies in allocation or never finishes. Nothing catches it by inspection.

## A cross-project collision, found while testing

Dependency install directories now carry backend and GPU in their names (`blaspp-mkl-cpu-install`). That is not cosmetic.

RandBLAS's installer uses the same `RandNLA-project` layout and named its BLAS++ install **identically** (`blaspp-<backend>-install`), with a different stamp filename. With a shared `RANDNLA_PROJECT_DIR`, this script would rebuild over RandBLAS's BLAS++ — their stamp never matches ours — and **RandBLAS's next run would reuse an artifact we had replaced underneath it, while its own stamp still described the original.** Distinct names make it impossible; sharing is instead explicit via `BLASPP_INSTALL_DIR`, verified by the conftest.

## Everything else

- **macOS keeps Homebrew OpenBLAS as the default.** Apple's legacy Accelerate has a broken divide-and-conquer `gesdd`, and RandLAPACK calls `gesdd` in `rl_rsvd.hh:146`, `rl_abrik.hh:692`, `rl_revd2.hh:208`, `rl_preconditioners.hh:355` and `rl_util.hh:413`. That is what #157's quarantine is about. `--blas=accelerate` warns, citing #159. The hardcoded `/opt/homebrew` is fixed regardless.
- **Extras and benchmarks stay built by default** (`--no-extras` / `--no-benchmarks`), unlike RandBLAS's examples — they need nothing this script has not already built.
- **The clone is never moved**; a symlink gives the same layout and the path CI invokes still resolves.
- **RandBLAS is untouched** — still a pinned submodule, still authoritative.
- **`install.ps1`** now honours `RANDNLA_PROJECT_DIR` with the same precedence as `install.sh`, gains `-ModifyEnvironment` (User-scope, the only thing that survives a new shell) and `-Prefix`, and its path-length warning now checks the resolved path rather than only an explicitly passed one.
- **Progress rendering** in three tiers, determinate from the build tool's own output, with tier 0 byte-identical to the plain step list — plus a CI assertion that redirected output carries no escape sequence.
- **`INSTALL_SCRIPT.md`** rewritten: current flags, corrected layout diagram, and a new section 6 with a tested-configuration table drawn from the CI lanes, the per-backend integer width, whether LP64 actually limits RandLAPACK, and why macOS is on OpenBLAS.

## Verification

Local Linux (gcc 15.2, oneAPI MKL, NVIDIA GPU present):

| Scenario | Result |
|---|---|
| Fresh MKL build, `--no-gpu` | 9/9 steps, ILP64 confirmed from `blas/defines.h` |
| Re-run in place | all six dependency steps reused, 1s rebuild |
| Full default run (extras + benchmarks) | 13/13 steps |
| `--no-gpu` → `--gpu` | BLAS++ provenance invalidated, rebuilt rather than reused |
| Dependency discovery | all three reused, 3/3 steps |
| Run from a git worktree | clone left in place, worktree still functional |
| Output redirected | no ANSI escapes, no carriage returns |
| **Full test suite** | **313/313 pass** |
| RandBLAS then RandLAPACK, shared `RANDNLA_PROJECT_DIR` | both dependency sets intact |
| RandLAPACK reusing RandBLAS's BLAS++ | reused, only LAPACK++ built, 5/5 steps |

Windows 11, Windows PowerShell 5.1, VS 2022 Build Tools: all three `-ProjectDir` precedence cases resolve as intended, and the User-scope environment write round-trips.

## RandBLAS submodule bump

Also bumps the vendored RandBLAS from `04f2018` to `952251c` (RandBLAS main), and `RandLAPACK_RandBLAS_PIN` with it.

The three commits in that range are **#185** (vcpkg manifest fix), **#186** (CMake hygiene) and **#187** (installer scripts). None of them touch `RandBLAS/` headers — the library code is byte-identical, and everything in the range is build machinery. Two pieces of it matter here:

- RandBLAS's CMake floor moved 3.12 → 3.21. RandLAPACK already declares 3.21, so nothing to change; the submodule now simply enforces what RandLAPACK already required.
- RandBLAS exports `randblas_stage_runtime_dlls()` from its installed package and prints a configuration summary. As a subproject under RandLAPACK, which configures it with `BUILD_TESTS=OFF`, that summary reports tests as deliberately skipped rather than warning.

`CMakeLists.txt` enforces that the pin variable and the submodule move together, and it means it: the cross-check compares the variable against `git ls-tree HEAD RandBLAS`, so a staged-but-uncommitted bump fails configure until both land in one commit. Worth knowing if you ever bump this iteratively — it is not satisfiable before committing.

Verified: clean build against the bumped submodule, and the full suite re-run.

## Notes for reviewers

- **Consolidated from #162 + #163 + #164** at Max's request, matching how the RandBLAS installer set was combined. Those two show as *merged* rather than closed because this branch was fast-forwarded to contain them — they merged into their stacked base, not into `main`. The tree is byte-identical to the state tested and green as three separate PRs.
- Stacked on #161 (CI fixes), which stays separate — it is independent and useful on its own.
- **`-ModifyEnvironment` is not verified end to end.** It runs at the end of a successful install, and I could not reach it: the clone sits on a `\\wsl.localhost` path and Windows `git` refuses it with `dubious ownership`. Precedence and the User-scope write are each verified directly, but not together in one completed run.
- Two upstream gaps are filed rather than worked around silently: BLAS++ never looks for an ILP64 OpenBLAS (#166), and implements only Apple's legacy Accelerate interface (#165).

