### PR TITLE
Include the GPU layer from RandLAPACK.hh, guarded on __CUDACC__ (fixes #77)

### DIFF
--- a/RandLAPACK.hh
+++ b/RandLAPACK.hh
@@ -1,3 +1,10 @@
+// The umbrella header: RandLAPACK's single public entry point, installed to
+// <prefix>/include. RandLAPACK is header only (an INTERFACE CMake target), so there is
+// nothing to link and this is what tests, benchmarks and downstream projects include.
+// Sections below follow the source tree in dependency order. The testing utilities are
+// public on purpose: the benchmark project consumes them like the tests do. HQRRP is
+// not listed; it arrives transitively through rl_cqrrpt.hh and rl_bqrrp.hh.
+
 #ifndef RANDLAPACK_HH
 #define RANDLAPACK_HH
 
@@ -41,11 +48,14 @@
 #include "RandLAPACK/drivers/rl_abrik.hh"
 #include "RandLAPACK/drivers/rl_krill.hh"
 
-// Cuda functions - issues with linking/visibility when present if the below is uncommented.
-// A temporary fix is to add the below directly in the test/benchmark files.
-// Ideally, we would like below to be uncommented so that we could simply include RandLAPACK.hh everywhere.
-//#include "RandLAPACK/drivers/rl_cqrrpt_gpu.hh"
-//#include "RandLAPACK/drivers/rl_cqrrp_gpu.hh"
-//#include "RandLAPACK/gpu_functions/rl_cuda_kernels.cuh"
+// GPU layer. __CUDACC__ is set only while a CUDA compiler is processing this file, so
+// .cu translation units get the GPU drivers and host .cc files build with no CUDA
+// toolkit on the include path. rl_cuda_kernels.cuh must come first: it decides whether
+// the kernels exist, and #pragma once means the first inclusion is the one that counts.
+#if defined(__CUDACC__)
+#include "RandLAPACK/gpu_functions/rl_cuda_kernels.cuh"
+#include "RandLAPACK/drivers/rl_cqrrpt_gpu.hh"
+#include "RandLAPACK/drivers/rl_bqrrp_gpu.hh"
+#endif
 
 #endif

--- a/RandLAPACK/gpu_functions/rl_cuda_kernels.cuh
+++ b/RandLAPACK/gpu_functions/rl_cuda_kernels.cuh
@@ -1,4 +1,16 @@
 #pragma once
+
+// USE_CUDA gates every kernel below, and every launch inside the host wrappers; without
+// it the wrappers still compile but throw. It used to be defined by hand in each .cu
+// consumer, so correctness depended on include order: this header is #pragma once, so
+// the first inclusion decided whether the kernels existed at all, and an inclusion that
+// arrived through RandLAPACK.hh silently produced a kernel free build. Deriving it from
+// __CUDACC__ removes that hazard. Consumers no longer define it; the define is kept so
+// that out of tree code still setting it by hand keeps working.
+#if defined(__CUDACC__) && !defined(USE_CUDA)
+#define USE_CUDA
+#endif
+
 #include "rl_cuda_macros.hh"
 #include <cuda.h>
 #include <cuda_runtime.h>

--- a/benchmark/bench_BQRRP/BQRRP_GPU_benchmark.cu
+++ b/benchmark/bench_BQRRP/BQRRP_GPU_benchmark.cu
@@ -14,7 +14,7 @@
 #include <chrono>
 #include <numeric>
 
-#include "RandLAPACK/drivers/rl_bqrrp_gpu.hh"
+// The GPU drivers and kernels come in with RandLAPACK.hh, under its __CUDACC__ guard.
 
 using GPUSubroutines = RandLAPACK::BQRRPGPUSubroutines;
 using namespace std::chrono;

--- a/test/comps/test_util_gpu.cu
+++ b/test/comps/test_util_gpu.cu
@@ -13,11 +13,7 @@
 #include <random>
 #include <gtest/gtest.h>
 
-// Use cuda kernels.
-#ifndef USE_CUDA
-#define USE_CUDA
-
-#include "RandLAPACK/gpu_functions/rl_cuda_kernels.cuh"
+// The GPU drivers and kernels come in with RandLAPACK.hh, under its __CUDACC__ guard.
 
 using namespace std::chrono;
 
@@ -523,4 +519,3 @@ TEST_F(TestUtil_GPU, test_ger_gpu) {
     
     ger_gpu(alpha, all_data);
 }
-#endif

--- a/test/drivers/test_bqrrp_gpu.cu
+++ b/test/drivers/test_bqrrp_gpu.cu
@@ -12,10 +12,7 @@
 #include <gtest/gtest.h>
 #include <chrono>
 
-// Use cuda kernels.
-#ifndef USE_CUDA
-#define USE_CUDA
-#include "RandLAPACK/drivers/rl_bqrrp_gpu.hh"
+// The GPU drivers and kernels come in with RandLAPACK.hh, under its __CUDACC__ guard.
 
 using GPUSubroutines = RandLAPACK::BQRRPGPUSubroutines;
 
@@ -475,5 +472,4 @@ TEST_F(TestBQRRP, GEQRF_GPU_ATTEMPT_TO_CATCH_INEFFICIENCY_ON_H100) {
     cudaFree(tau_device);
     blas::device_free(d_work_geqrf_opt, lapack_queue);
 }
-#endif
 #endif

--- a/test/drivers/test_cqrrpt_gpu.cu
+++ b/test/drivers/test_cqrrpt_gpu.cu
@@ -11,9 +11,7 @@
 #include <gtest/gtest.h>
 #include <cusolverDn.h>
 
-#ifndef USE_CUDA
-#define USE_CUDA
-#include "RandLAPACK/drivers/rl_cqrrpt_gpu.hh"
+// The GPU drivers and kernels come in with RandLAPACK.hh, under its __CUDACC__ guard.
 
 class TestCQRRPT : public ::testing::Test
 {
@@ -160,4 +158,3 @@ TEST_F(TestCQRRPT, CQRRPT_GPU_full_rank_no_hqrrp) {
     norm_and_copy_computational_helper<double, r123::Philox4x32>(norm_A, all_data);
     test_CQRRPT_general<double, r123::Philox4x32, RandLAPACK::CQRRPT_GPU<double, r123::Philox4x32>>(d_factor, norm_A, all_data, CQRRPT_GPU, state);
 }
-#endif


### PR DESCRIPTION
Closes #77.

`RandLAPACK.hh` shipped with its three GPU includes commented out, under a note blaming
linking and visibility. The real cause is include order, and the symptom is silence.

## Cause

`USE_CUDA` gates every kernel in `rl_cuda_kernels.cuh` and every launch inside that
file's host wrappers. When it is undefined the wrappers still exist, with bodies that
`throw std::runtime_error("No CUDA support available.")`. Nothing in the build system
ever defined it; each consuming `.cu` file set it by hand. Since the header is
`#pragma once`, whichever translation unit reached it first decided whether the kernels
existed. Uncommenting the includes put `RandLAPACK.hh` first, and it does not define
`USE_CUDA`, so the GPU layer compiled away with no error at compile or link time.

Measured on the real `test_bqrrp_gpu.cu`, same compiler and flags:

| build | compiles | CUDA kernels in the object |
|---|---|---|
| `main` as shipped | yes | 156 |
| `main`, includes naively uncommented | yes | **0** |

## Fix

Derive the switch from `__CUDACC__`, which is set exactly when a CUDA compiler is
processing the translation unit:

```cpp
#if defined(__CUDACC__) && !defined(USE_CUDA)
#define USE_CUDA
#endif
```

`RandLAPACK.hh` guards its GPU section on the same condition, so `.cu` files get the GPU
drivers and host `.cc` files build with no CUDA toolkit on the include path. `USE_CUDA`
is defined rather than replaced so out of tree code that still sets it keeps working.

**The test change is required, not cosmetic.** The three GPU tests wrapped their entire
bodies in `#ifndef USE_CUDA` / `#define USE_CUDA`, using a conditional as an on-switch.
Once the umbrella header defines `USE_CUDA` on line 1, that condition is false and each
file becomes empty: a test binary with zero tests, compiling and reporting success. I hit
this while validating the fix, as `undefined reference to 'main'`. Those wrappers are
removed here along with the manual includes they guarded.

## This also repairs the GPU benchmark

`BQRRP_GPU_benchmark.cu` never defined `USE_CUDA`, so it is already hitting this on
`main`: it builds with **zero** CUDA kernels and would throw at the first launch. After
this PR it compiles with 84 device stubs and no throw string.

## Verification

RTX 5070 Ti, CUDA 13.3, against a stock `main` build configured identically:

- GPU test objects carry the same kernel content as `main`: 80 / 0 / 15 device stubs.
  `test_cqrrpt_gpu` is 0 in both, since `rl_cqrrpt_gpu.hh` uses no custom kernels.
- GPU test inventory identical at 16 cases, `diff` clean.
- Full suite 787/788. The one ctest failure, `TestBQRRP.BQRRP_GPU_wide_aspect`, fails
  identically on stock `main` with the same `oneMKL ERROR: Parameter 2 was incorrect on
  entry to DORGQR`. Running the GPU binary in one process surfaces a second failure,
  `BQRRP_GPU_near_zero_input`, also on both. Per test verdicts diff clean, so both are
  pre existing.
- CPU only build (`RequireCUDA=OFF`) configures and builds; a host `.cc` translation unit
  including `RandLAPACK.hh` needs no CUDA headers.

`RandLAPACK.hh` also gains a short file level comment; it had none.

Three unrelated defects found while investigating (a broken installed `rl_config.hh`,
dead `rl_cusolver.hh`, dead `RandLAPACK_cxx_sources`) are handled separately in #170.
