### PR TITLE
Windows: drop the space-in-path staging; macOS: enable Accelerate ILP64

### DIFF
--- a/.github/actions/setup-randlapack-deps-windows/setup.ps1
+++ b/.github/actions/setup-randlapack-deps-windows/setup.ps1
@@ -579,35 +579,6 @@ if ($Backend -eq "custom") {
     $backendId = "custom-$($hashHex.Substring(0, 8))"
 }
 
-function Copy-LibrariesToSpaceFreePath {
-    # BLAS++ splits library paths on spaces before probing them, so any path
-    # containing one fails as "BLAS library not found". Intel's default oneMKL
-    # location has a space, making this the common case rather than a corner
-    # one. Fixed upstream in icl-utk-edu/blaspp#137; removing this workaround
-    # is tracked in #158. Import libraries only name their DLL, still loaded
-    # at run time from $backendBin, so relocating them is safe.
-    param([string[]]$Libraries, [string]$Destination, [string]$Label)
-    if (-not ($Libraries | Where-Object { $_ -match ' ' })) { return $Libraries }
-    New-Item -ItemType Directory -Force -Path $Destination | Out-Null
-    Write-Host ("Staging $Label import libraries into a space-free path " +
-        "($Destination): BLAS++ cannot probe libraries whose path contains a space.")
-    return @($Libraries | ForEach-Object {
-        $leaf = Split-Path $_ -Leaf
-        $target = Join-Path $Destination $leaf
-        Copy-Item -LiteralPath $_.Replace('/', '\') -Destination $target -Force
-        Convert-ToCMakePath $target
-    })
-}
-
-$spaceFreeLibDir = Join-Path $resolvedRoot "backend-libs"
-$backendLibraries = Copy-LibrariesToSpaceFreePath -Libraries $backendLibraries `
-    -Destination $spaceFreeLibDir -Label "BLAS"
-if ($backendLapackLibraries -ne "") {
-    $backendLapackLibraries = (Copy-LibrariesToSpaceFreePath `
-        -Libraries @($backendLapackLibraries -split ';') `
-        -Destination $spaceFreeLibDir -Label "LAPACK") -join ';'
-}
-
 if ($backendBin -ne "") { $env:PATH = "$backendBin;$env:PATH" }
 
 # ------------------------------------------------------------- GoogleTest ----
@@ -658,7 +629,10 @@ $blasppInstall = Join-Path $resolvedRoot "blaspp-$backendId-install"
 # one includes them. Declared once and used for both the clone and the reuse
 # stamp, so the two cannot drift.
 $blasppUrl = "https://github.com/icl-utk-edu/blaspp.git"
-$blasppRef = "2d8d4e937ac46fffab33d4174a4fc7659726dbda"
+# TEMPORARY PIN -- the head of icl-utk-edu/blaspp#137 (space-split fix),
+# fetchable from upstream via its pull ref. Replace with the merge commit
+# the moment #137 lands; this PR stays a draft until then.
+$blasppRef = "c3ef942a0b9c86dc6c66952b58b7151f938747ca"
 $blasppSource = "$blasppUrl@$blasppRef"
 $blasppReusable = (Test-Path $blasppInstall) -and (Get-ChildItem -Path $blasppInstall -Recurse `
     -Filter "blasppConfig.cmake" -ErrorAction SilentlyContinue | Select-Object -First 1) `
@@ -698,7 +672,10 @@ $lapackppInstall = Join-Path $resolvedRoot "lapackpp-$backendId-install"
 # new-Accelerate support (PR #88, 2026-08-27), which also contains the MSVC
 # fix (PR #87); likewise not yet in a release. Declared once, as above.
 $lapackppUrl = "https://github.com/icl-utk-edu/lapackpp.git"
-$lapackppRef = "b9439cf3c26d1655d88e7f510ae8b4f82fbeb687"
+# TEMPORARY PIN -- the head of icl-utk-edu/lapackpp#90 (Accelerate-ILP64
+# aliasing fix for icl-utk-edu/lapackpp#89). Replace with the merge commit
+# the moment #90 lands; this PR stays a draft until then.
+$lapackppRef = "f891adcb8e06afa7744ac046d96d1282bbe5388a"
 $lapackppSource = "$lapackppUrl@$lapackppRef"
 $lapackppReusable = (Test-Path $lapackppInstall) -and (Get-ChildItem -Path $lapackppInstall -Recurse `
     -Filter "lapackppConfig.cmake" -ErrorAction SilentlyContinue | Select-Object -First 1) `

--- a/.github/workflows/install-script.yaml
+++ b/.github/workflows/install-script.yaml
@@ -141,9 +141,9 @@ jobs:
         run: |
           set -euo pipefail
           bash RandLAPACK/install.sh --yes --no-gpu | tee installer.out
-          # LP64 for now: Accelerate ILP64 is blocked on an upstream LAPACK++
-          # compile bug (icl-utk-edu/lapackpp#89; tracked in issue #173).
-          grep -qE '^  Backend  *accelerate, LP64' installer.out
+          # ILP64 through Apple's new interface, proving issue #173 is closed
+          # (needs the LAPACK++ pin at or past icl-utk-edu/lapackpp#89's fix).
+          grep -qE '^  Backend  *accelerate, ILP64' installer.out
 
       - name: test the installed library
         run: |

--- a/INSTALL_SCRIPT.md
+++ b/INSTALL_SCRIPT.md
@@ -344,7 +344,7 @@ well work; it is simply untested.
 | Ubuntu (latest) | gcc | OpenBLAS | LP64 | none | yes |
 | Ubuntu (latest) | gcc | oneMKL | ILP64 | none | yes |
 | Ubuntu (latest) | clang | OpenBLAS | LP64 | none | yes |
-| macOS 14/15 | Apple Clang | Accelerate (new interface) | LP64 (see 6.2) | none | no (see below) |
+| macOS 14/15 | Apple Clang | Accelerate (new interface) | ILP64 | none | no (see below) |
 | Windows | MSVC | oneMKL | ILP64 | none | yes (`/openmp:llvm`) |
 
 The installer lanes additionally cover a fresh install, an idempotent re-run,
@@ -368,7 +368,7 @@ backend can genuinely provide it:
 |---|---|---|
 | `mkl` | ILP64 | `mkl_intel_ilp64` is a separate library, so requesting it actually selects it |
 | `openblas` | LP64, with a warning | there is only `-lopenblas`, so the request selects nothing |
-| `accelerate` | LP64, for now | Apple's new interface does ship ILP64 and BLAS++ can select it (`icl-utk-edu/blaspp#134`), but LAPACK++ does not compile in that configuration yet (`icl-utk-edu/lapackpp#89`); tracked in issue #173 |
+| `accelerate` | ILP64 on macOS >= 13.3 | Apple's new interface ships ILP64 in the framework; BLAS++ selects it (`icl-utk-edu/blaspp#134`) and LAPACK++ compiles against it (`icl-utk-edu/lapackpp#89`). Older macOS falls back to LP64 with a warning |
 | `custom` | whatever you pass | you named the library, so its width is yours to state |
 
 The OpenBLAS row deserves explaining, because it is counter-intuitive. BLAS++

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -38,7 +38,7 @@ Backend selection:
                         when MKLROOT is set, otherwise OpenBLAS)
   --blas-int=WIDTH      ilp64 | lp64. Defaults to ilp64 wherever the backend
                         can actually provide it, falling back to lp64 with a
-                        warning. Accelerate is lp64 for now (issue #173).
+                        warning. Accelerate ILP64 requires macOS 13.3 or newer.
   --blas-libraries=L    Link line for --blas=custom, used for both BLAS and
                         LAPACK, e.g. "/opt/aocl/lib/libflame.so;/opt/aocl/lib/libblis.so"
 
@@ -482,11 +482,17 @@ BLASPP_URL="https://github.com/icl-utk-edu/blaspp.git"
 # The commit that merged new-Apple-Accelerate support (blaspp PR #134,
 # 2026-08-27); also contains the MSVC portability fix (PR #132). Not in a
 # release yet -- the latest tag, v2025.05.28, predates both.
-BLASPP_REF="2d8d4e937ac46fffab33d4174a4fc7659726dbda"
+# TEMPORARY PIN -- the head of icl-utk-edu/blaspp#137 (space-split fix),
+# fetchable from upstream via its pull ref. Replace with the merge commit
+# the moment #137 lands; this PR stays a draft until then.
+BLASPP_REF="c3ef942a0b9c86dc6c66952b58b7151f938747ca"
 LAPACKPP_URL="https://github.com/icl-utk-edu/lapackpp.git"
 # The commit that merged the LAPACK++ half of new-Accelerate support
 # (lapackpp PR #88, 2026-08-27).
-LAPACKPP_REF="b9439cf3c26d1655d88e7f510ae8b4f82fbeb687"
+# TEMPORARY PIN -- the head of icl-utk-edu/lapackpp#90 (Accelerate-ILP64
+# aliasing fix for icl-utk-edu/lapackpp#89). Replace with the merge commit
+# the moment #90 lands; this PR stays a draft until then.
+LAPACKPP_REF="f891adcb8e06afa7744ac046d96d1282bbe5388a"
 RANDOM123_URL="https://github.com/DEShawResearch/Random123.git"
 RANDOM123_REF="v1.14.0"
 
@@ -534,27 +540,18 @@ fi
 # disagreement is NOT guarded and shows up as an absurd workspace size or a run
 # that never finishes. The conftest below is what catches that.
 #
-# Accelerate: Apple's new interface (macOS >= 13.3) does carry ILP64, and the
-# pinned BLAS++ can select it (icl-utk-edu/blaspp#134) -- but LAPACK++ does
-# not COMPILE in that configuration (its lapack_int becomes Apple's `long`
-# while the wrappers assume int64_t; upstream icl-utk-edu/lapackpp#89), and
-# RandLAPACK always needs LAPACK++. Constrained to LP64 until the upstream
-# fix lands; tracked in issue #173.
+# Accelerate: Apple's new interface (macOS >= 13.3) carries ILP64, selected
+# by ACCELERATE_LAPACK_ILP64; the pinned BLAS++ wires blas_int=int64 to it
+# (icl-utk-edu/blaspp#134) and the pinned LAPACK++ compiles against it
+# (icl-utk-edu/lapackpp#89, closing issue #173). On macOS older than 13.3 the
+# int64 probe fails, so "auto" falls back to LP64 with the usual warning and
+# an explicit --blas-int=ilp64 fails the BLAS++ configure rather than
+# silently downgrading.
 WIDTH_ORDER=()
-case "$BLAS_BACKEND" in
-    accelerate)
-        if [[ "$BLAS_INT_CHOICE" == "ilp64" ]]; then
-            die "--blas-int=ilp64 with Accelerate is blocked for now: LAPACK++ does not compile against Accelerate ILP64 (upstream icl-utk-edu/lapackpp#89; tracked in issue #173). Use --blas=openblas or --blas=mkl for ILP64."
-        fi
-        WIDTH_ORDER=(int32)
-        ;;
-    *)
-        case "$BLAS_INT_CHOICE" in
-            ilp64) WIDTH_ORDER=(int64) ;;
-            lp64)  WIDTH_ORDER=(int32) ;;
-            auto)  WIDTH_ORDER=(int64 int32) ;;
-        esac
-        ;;
+case "$BLAS_INT_CHOICE" in
+    ilp64) WIDTH_ORDER=(int64) ;;
+    lp64)  WIDTH_ORDER=(int32) ;;
+    auto)  WIDTH_ORDER=(int64 int32) ;;
 esac
 
 # blaspp's own backend selector; its matcher accepts "apple" or "accelerate".


### PR DESCRIPTION
## Summary

The last two items gated on upstream, combined into one pin-advance PR. Draft until both upstream PRs merge; everything else is final.

Closes #158. Closes #173.

## Changes

- **Pins (currently TEMPORARY, pointing at the upstream PR heads so CI can prove the result today)**:
  - BLAS++ → head of [icl-utk-edu/blaspp#137](https://github.com/icl-utk-edu/blaspp/pull/137) (`c3ef942`): `BLAS_LIBRARIES` entries are no longer split on spaces.
  - LAPACK++ → head of [icl-utk-edu/lapackpp#90](https://github.com/icl-utk-edu/lapackpp/pull/90) (`f891adc`, fixes [lapackpp#89](https://github.com/icl-utk-edu/lapackpp/issues/89)): LAPACK++ compiles against Accelerate ILP64.
- **#158**: `Copy-LibrariesToSpaceFreePath` and its two call sites deleted from the Windows provisioner — a discovered oneMKL at Intel's default spaced location now reaches BLAS++ unstaged. (The doc notes #158 listed were already removed during #156.)
- **#173**: the installer's Accelerate LP64 constraint and the explicit-`ilp64` refusal are lifted; Accelerate rejoins the standard prefer-ILP64 width policy (`auto` → ILP64 on macOS ≥ 13.3, LP64 fallback with a warning on older macOS). The install-macos assertion flips `accelerate, LP64` → `accelerate, ILP64`; INSTALL_SCRIPT.md §6.1/§6.2 updated.

## Ready when (the do-this-immediately list)

- [ ] **icl-utk-edu/blaspp#137 merges** → replace `BLASPP_REF` in `installers/install.sh` and `$blasppRef` in `.github/actions/setup-randlapack-deps-windows/setup.ps1` with the merge commit, delete the TEMPORARY-PIN comments
- [ ] **icl-utk-edu/lapackpp#90 merges** → same for `LAPACKPP_REF` / `$lapackppRef`
- [ ] CI green on the final pins → mark ready for review

RandBLAS mirror of the #137 half: the draft PR on `drop-space-workaround-and-comment-fix`.